### PR TITLE
fix: pin ssh-deploy to v5.1.1 and zola to 0.22.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Install Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.19.2
+          tool: zola@0.22.1
 
       - name: Build
         run: zola build
 
       - name: Deploy via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@v5.1.1
         with:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_KEY }}
           REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}


### PR DESCRIPTION
## Summary
- Pin `easingthemes/ssh-deploy` to `v5.1.1` — the `v5` major tag doesn't exist
- Pin Zola to `0.22.1` to match local dev (needed for Giallo-based syntax highlighting)

## Test plan
- [ ] CI workflow resolves the action successfully
- [ ] `zola build` succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)