### PR TITLE
feat: domain redirects + deploy workflow fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Zola
+        uses: taiki-e/install-action@v2
+        with:
+          tool: zola@0.22.1
+
+      - name: Build
+        run: zola build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Install Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.19.2
+          tool: zola@0.22.1
 
       - name: Build
         run: zola build
 
       - name: Deploy via SSH
-        uses: easingthemes/ssh-deploy@v5
+        uses: easingthemes/ssh-deploy@v5.1.1
         with:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_KEY }}
           REMOTE_HOST: ${{ secrets.DEPLOY_HOST }}

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,11 @@
+RewriteEngine On
+
+# Force HTTPS
+RewriteCond %{HTTPS} off
+RewriteRule ^ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+
+# Redirect all variants to canonical https://pulseengine.eu
+RewriteCond %{HTTP_HOST} ^www\.pulseengine\.eu$ [NC,OR]
+RewriteCond %{HTTP_HOST} ^pulseengine\.de$ [NC,OR]
+RewriteCond %{HTTP_HOST} ^www\.pulseengine\.de$ [NC]
+RewriteRule ^ https://pulseengine.eu%{REQUEST_URI} [L,R=301]


### PR DESCRIPTION
## Summary
- Add `.htaccess` to redirect all domain variants to canonical `https://pulseengine.eu`
  - `www.pulseengine.eu` → `pulseengine.eu`
  - `pulseengine.de` → `pulseengine.eu`
  - `www.pulseengine.de` → `pulseengine.eu`
  - HTTP → HTTPS on all variants
- Fix deploy workflow: pin `ssh-deploy` to `v5.1.1` and `zola` to `0.22.1`

Supersedes #1.

## Test plan
- [ ] CI resolves actions and `zola build` succeeds
- [ ] After deploy, verify redirects with `curl -I http://www.pulseengine.eu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)