### PR TITLE
feat: copy-to-clipboard, figure captions, build info in footer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,14 @@ jobs:
         with:
           tool: zola@0.22.1
 
+      - name: Inject build info
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          COMMIT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+          BUILD_HTML="&middot; <a href=\"${COMMIT_URL}\">${SHORT_SHA}</a> · <a href=\"${RUN_URL}\">deploy #${GITHUB_RUN_NUMBER}</a>"
+          sed -i "s|<!-- BUILD_INFO -->|${BUILD_HTML}|" templates/base.html
+
       - name: Build
         run: zola build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,13 @@ Colors are aligned with the thrum unified dashboard (`/Users/r/git/temper/thrum/
 
 Fonts: Atkinson Hyperlegible Next (sans) + Mono, loaded from Google Fonts.
 
+## Git workflow
+
+- `main` is protected — always use PRs, never push directly
+- CI runs `zola build` on PRs; deploy runs on push to `main` (tar + scp to Netcup)
+- Commit messages: Conventional Commits (`feat:`, `fix:`, `docs:`, etc.)
+- After merge, deploy takes ~20s — check with `gh run list --workflow=deploy.yml`
+
 ## Zola version notes
 
 - Zola 0.22 uses `[markdown.highlighting]` (not `highlight_code`/`highlight_theme`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ tags = ["deep-dive", "meld"]
 |---|---|
 | Table of contents | Generated from `##` and `###` headings — appears as a glass card above the post |
 | Syntax highlighting | Fenced code blocks with language tag (`` ```rust ``). Theme: `material-theme-ocean` |
+| Copy to clipboard | Code blocks get a "Copy" button on hover (top-right corner) |
 | Reading time | Automatic via Zola |
 | Tags | Badge links to tag listing pages |
 | Article width | 720px max, centered |
@@ -79,12 +80,22 @@ Place in `static/img/` and reference as:
 ![Diagram](/img/shared-diagram.png)
 ```
 
-**Image captions:** Place italic text immediately after an image:
+**Image captions** — two options:
+
+Markdown style (italic text after image):
 
 ```markdown
 ![Architecture overview](architecture.png)
 *Figure 1: The component fusion pipeline*
 ```
+
+Shortcode style (recommended for important figures):
+
+```markdown
+{{ figure(src="architecture.png", alt="Architecture overview", caption="Figure 1: The component fusion pipeline") }}
+```
+
+The shortcode renders a semantic `<figure>/<figcaption>` with centered caption styling.
 
 ### Mermaid diagrams
 
@@ -136,6 +147,7 @@ Danger with red accent.
 | `project_card(...)` | Glass card for a project | `{{ project_card(name="Meld", desc="...", url="...", icon="🔗", badge="accent") }}` |
 | `mermaid()` | Mermaid diagram | See above |
 | `note(kind="...")` | Callout box (info/tip/warning/danger) | See above |
+| `figure(src, alt, caption)` | Image with semantic caption | `{{ figure(src="img.png", alt="...", caption="...") }}` |
 
 ### Content styling reference
 
@@ -225,12 +237,59 @@ Wrap up and point to related resources.
 - **Sans:** Atkinson Hyperlegible Next (Google Fonts)
 - **Mono:** Atkinson Hyperlegible Mono (Google Fonts)
 
+## Git workflow
+
+### Branch protection
+
+`main` is protected — all changes go through pull requests with a passing CI build.
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add dark mode toggle
+fix: correct pipeline SVG viewBox on mobile
+docs: update blog authoring guide
+```
+
+Common prefixes: `feat`, `fix`, `docs`, `style`, `refactor`, `chore`
+
+### CI / CD pipeline
+
+| Trigger | Workflow | What it does |
+|---|---|---|
+| PR to `main` | **CI** (`.github/workflows/ci.yml`) | `zola build` — validates the site compiles |
+| Push to `main` | **Deploy** (`.github/workflows/deploy.yml`) | `zola build` → tar + scp to Netcup |
+
+After merging a PR, the deploy runs automatically (~20s). Check status:
+
+```sh
+gh run list --workflow=deploy.yml --limit=3   # recent deploys
+gh run view <run-id> --log-failed             # debug failures
+```
+
+### Typical flow
+
+```sh
+git checkout -b feat/my-change
+# make changes
+zola build                        # verify locally
+git add <files>
+git commit -m "feat: description"
+git push -u origin feat/my-change
+gh pr create --title "feat: description"
+# CI runs → merge → auto-deploy
+```
+
 ## Deployment
 
 Push to `main` triggers GitHub Actions:
 
 1. `zola build`
-2. SSH deploy to Netcup
+2. `tar` + `scp` + `ssh` extract to Netcup (rsync not available on shared hosting)
+
+Target: `pulseengine.eu` on Netcup Webhosting 1000 NUE.
 
 Secrets required: `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_KEY`, `DEPLOY_PATH`
 

--- a/content/blog/2026-03-02-meld-v0.1.0.md
+++ b/content/blog/2026-03-02-meld-v0.1.0.md
@@ -1,0 +1,283 @@
++++
+title = "Meld v0.1.0: Static Component Fusion for WebAssembly"
+description = "Meld's first release fuses WebAssembly components into single core modules. We walk through the hello_c example — what wit-component produces, what meld does to it, and what the wasm looks like after."
+date = 2026-03-02T18:00:00+00:00
+[taxonomies]
+tags = ["meld", "deep-dive"]
++++
+
+## What meld does
+
+Meld v0.1.0 is out — our static fusion tool for WebAssembly components.
+
+A [Component Model](https://github.com/WebAssembly/component-model) component is not a flat wasm module. It is a tree of core modules, type definitions, and [Canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md) operations — `canon lift`, `canon lower`, `canon resource.drop` — that bridge between the component's typed [WIT](https://component-model.bytecodealliance.org/design/wit.html) interface and the i32/i64 world of core wasm. [`wit-component`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) produces this structure, and it works well for composition, but a runtime still has to instantiate and link multiple core modules on every load.
+
+Meld resolves that at build time. It takes a component, flattens the internal imports, remaps every function/memory/table index into a single space, generates [FACT-style adapters](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canonical-definitions) where calls cross memory boundaries, and emits one core module. One instantiation, direct calls, no linking overhead.
+
+We will walk through the `hello_c` CLI component from [wasm-component-examples](https://github.com/pulseengine/wasm-component-examples) — what `wit-component` produces, what meld does to it, and what the wasm looks like after.
+
+## Get the tools
+
+[v0.1.0 release](https://github.com/pulseengine/meld/releases/tag/v0.1.0) binaries for Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon):
+
+```bash
+# macOS Apple Silicon
+curl -LO https://github.com/pulseengine/meld/releases/download/v0.1.0/meld-aarch64-apple-darwin
+chmod +x meld-aarch64-apple-darwin && mv meld-aarch64-apple-darwin meld
+
+# Example components
+curl -LO https://github.com/pulseengine/wasm-component-examples/releases/download/v0.2.0/wasm-components-0.2.0.tar.gz
+tar xzf wasm-components-0.2.0.tar.gz
+```
+
+We will look at `hello_c_cli.wasm` — a [WASI](https://wasi.dev) CLI component built from C with `wit-component` 0.241.2. It prints "Hello wasm component world from C!" and exports `wasi:cli/run@0.2.6`.
+
+## Before fusion: what wit-component produces
+
+`wasm-tools print hello_c_cli.wasm` — 8,331 lines of WAT, 304 KB. Four core modules, 23 core instances, 23 canonical ABI operations. All to run `printf`.
+
+### Module `$main` — the C program
+
+hello.c compiled by clang (wasi-sdk v29). 28 functions — the greeting plus full musl libc (`printf`, `dlmalloc`, `memcpy`, math). 19 WASI imports, all at `@0.2.0` — the version wasi-sdk generated bindings against:
+
+```wasm
+(core module $main (;0;)
+  (import "wasi:io/error@0.2.0" "[resource-drop]error" (func ...))
+  (import "wasi:io/poll@0.2.0" "[resource-drop]pollable" (func ...))
+  (import "wasi:io/streams@0.2.0" "[method]output-stream.check-write" (func ...))
+  (import "wasi:cli/stdout@0.2.0" "get-stdout" (func ...))
+  (import "wasi:cli/exit@0.2.0" "exit" (func ...))
+  ;; ... 19 imports total, all @0.2.0
+
+  (table (;0;) 11 11 funcref)
+  (memory (;0;) 2)
+  (data (i32.const 1024) "Hello wasm component world from C!\00")
+
+  (export "memory" (memory 0))
+  (export "_start" (func $_start))
+  (export "cabi_realloc" (func $cabi_realloc))
+  ;; 28 defined functions
+)
+```
+
+The host provides `@0.2.6` — someone has to bridge that version gap.
+
+### Module `$wit-component:adapter:wasi_snapshot_preview1` — the bridge
+
+A Rust-compiled adapter, 16 functions. Bridges WASI preview1 libc calls to preview2 component imports. Imports `_start` and `cabi_realloc` from the main module, imports a few `@0.2.6` WASI functions directly, and exports the actual `run` entry point:
+
+```wasm
+(core module $wit-component:adapter:wasi_snapshot_preview1 (;1;)
+  (import "env" "memory" (memory 0))
+  (import "__main_module__" "_start" (func ...))
+  (import "__main_module__" "cabi_realloc" (func ...))
+  (import "wasi:cli/stderr@0.2.6" "get-stderr" (func ...))
+  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush" (func ...))
+
+  (export "wasi:cli/run@0.2.6#run" (func ...))
+  (export "cabi_import_realloc" (func ...))
+  ;; 16 functions: run wrapper, stack allocator, fd_write shim, ...
+)
+```
+
+### Module `$wit-component-shim-module` — the indirect table
+
+The [indirect table pattern](https://github.com/nicksenger/nicksenger.github.io/issues/1). 8 stub functions that dispatch through a `funcref` table via `call_indirect`. Breaks the circular dependency — `canon lower` needs `cabi_realloc`, but the module that defines `cabi_realloc` cannot be instantiated until its imports are lowered:
+
+```wasm
+(core module $wit-component-shim-module (;2;)
+  (table (;0;) 8 8 funcref)
+  (export "$imports" (table 0))
+  (export "0" (func 0))
+  ;; ... 8 stubs
+
+  (func (;0;) (type 0) (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.const 0
+    call_indirect (type 0))
+  ;; same pattern for all 8
+)
+```
+
+### Module `$wit-component-fixup` — fills the table
+
+Imports the 8 `canon lower`'d functions and the table, fills all slots with an active element segment:
+
+```wasm
+(core module $wit-component-fixup (;3;)
+  (import "" "0" (func (;0;) ...))
+  ;; ... 8 function imports
+  (import "" "$imports" (table (;0;) 8 8 funcref))
+  (elem (i32.const 0) func 0 1 2 3 4 5 6 7)
+)
+```
+
+### The instantiation chain
+
+With all four modules defined, `wit-component` orchestrates 23 core instances:
+
+```wasm
+;; 1. Shim — provides memory + empty funcref table
+(core instance (;0;) (instantiate $wit-component-shim-module))
+
+;; 2. Canon lower + resource.drop — 15 lower, 8 drop
+(core func (;2;)  (canon lower (func $"[method]pollable.block")))
+(core func (;11;) (canon lower (func $exit)))
+(core func (;13;) (canon lower (func $get-stdout)))
+;; ...
+
+;; 3. Per-interface instances from lowered functions
+(core instance $wasi:io/streams@0.2.0 (;3;)
+  (export "[resource-drop]output-stream" ...)
+  (export "[method]output-stream.check-write" ...)
+  (export "[method]output-stream.write" ...)
+)
+
+;; 4. Instantiate $main with all 13 WASI instances
+(core instance $main (;14;) (instantiate $main
+  (with "wasi:io/streams@0.2.0" (instance $wasi:io/streams@0.2.0))
+  (with "wasi:cli/stdout@0.2.0" (instance $wasi:cli/stdout@0.2.0))
+  ;; ...
+))
+
+;; 5. Adapter gets main's exports + @0.2.6 WASI
+(core instance (;20;) (instantiate $wit-component:adapter:wasi_snapshot_preview1
+  (with "env" (instance $env))
+  (with "__main_module__" (instance ...))
+  (with "wasi:cli/stderr@0.2.6" ...)
+))
+
+;; 6. Fixup fills the indirect table
+(core instance (;22;) (instantiate $wit-component-fixup
+  (with "" (instance $fixup-args))
+))
+
+;; 7. Lift the run export to the component level
+(func (;15;) (canon lift (core func $wasi:cli/run@0.2.6#run)))
+(export "wasi:cli/run@0.2.6" ...)
+```
+
+{% mermaid() %}
+graph TD
+  SHIM["$wit-component-shim-module<br/><i>8 stubs + funcref table</i>"]
+  MAIN["$main<br/><i>hello.c — 28 funcs, 19 imports @0.2.0</i>"]
+  ADAPT["$wasi_snapshot_preview1 adapter<br/><i>16 funcs — bridges preview1 to 0.2.6</i>"]
+  FIXUP["$wit-component-fixup<br/><i>fills table with lowered funcs</i>"]
+
+  CL["15x canon lower<br/>8x resource.drop"]
+
+  SHIM -->|"memory, table, stubs"| MAIN
+  MAIN -->|"_start, cabi_realloc, memory"| ADAPT
+  CL -->|"lowered funcs"| FIXUP
+  SHIM -->|"$imports table"| FIXUP
+  ADAPT -->|"run"| LIFT["canon lift"]
+  LIFT --> E["export wasi:cli/run@0.2.6"]
+{% end %}
+
+Four core modules, 23 instances, 23 canonical ABI operations — correct and compositional, but a lot of machinery a runtime has to set up on every instantiation.
+
+## Fuse it
+
+```bash
+./meld fuse hello_c_cli.wasm -o fused.wasm --stats
+```
+
+With `--component` the output is wrapped back as a valid P2 component — wasmtime can run it directly:
+
+```bash
+./meld fuse hello_c_cli.wasm -o fused_component.wasm --component --stats
+```
+
+## After fusion: one flat module
+
+All four core modules collapsed into one. `wasm-tools print fused.wasm`:
+
+```wasm
+(module
+  ;; 20 WASI imports — host-provided, cannot be resolved further
+  (import "wasi:io/error@0.2.6" "[resource-drop]error" (func (;0;)))
+  (import "wasi:io/poll@0.2.6" "[resource-drop]pollable" (func (;1;)))
+  (import "wasi:io/streams@0.2.6" "[resource-drop]input-stream" (func (;2;)))
+  (import "wasi:io/streams@0.2.6" "[resource-drop]output-stream" (func (;3;)))
+  (import "wasi:cli/exit@0.2.6" "exit" (func (;6;)))
+  (import "wasi:cli/stdout@0.2.6" "get-stdout" (func (;10;)))
+  (import "wasi:io/streams@0.2.6" "[method]output-stream.write" (func (;13;)))
+  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush" (func (;19;)))
+  ;; ... 20 imports total, all @0.2.6
+
+  (table (;0;) 8 8 funcref)    ;; from shim
+  (table (;1;) 11 11 funcref)  ;; from main
+  (memory (;0;) 2)             ;; single merged memory
+  (global (;0;) (mut i32) i32.const 68496)  ;; __stack_pointer
+  ;; ... 4 globals
+
+  ;; 54 functions — main (28) + adapter (16) + stubs (8) + fixup (2)
+  ;; all call indices rewritten to the merged space
+
+  (export "_start" (func 29))
+  (export "wasi:cli/run@0.2.6#run" (func 56))
+  (export "cabi_realloc" (func 34))
+  (export "cabi_import_realloc" (func 59))
+  (export "memory" (memory 0))
+  (export "$imports" (table 0))
+  ;; ... 14 exports
+)
+```
+
+{% mermaid() %}
+graph TD
+  IMP["20 WASI imports @0.2.6<br/><i>resource.drop, exit, get-stdout,<br/>output-stream.write, ...</i>"]
+  MOD["fused.wasm<br/><i>54 functions, 1 memory, 2 tables, 4 globals</i>"]
+  EXP["14 exports<br/><i>_start, run, cabi_realloc, memory, ...</i>"]
+
+  IMP --> MOD --> EXP
+{% end %}
+
+The `@0.2.0` / `@0.2.6` version mismatch is gone — resolved into a single set of `@0.2.6` host imports. The indirect table, the shim stubs, the fixup element segments, the 23 instantiation steps — all collapsed into one flat module.
+
+| | Original component | Fused core module | Fused component |
+|---|---|---|---|
+| Core modules | 4 | 1 | 3 (stubs + fused + fixup) |
+| Core instances | 23 | 1 | 18 |
+| `canon lower` / `resource.drop` | 15 + 8 | 0 | 0 (re-wrapped) |
+| Functions | 28 + 16 + 8 (separate) | 54 (merged) | 54 (merged) |
+| Size | 304,336 bytes | 17,994 bytes | 22,189 bytes |
+
+{% mermaid() %}
+graph LR
+  C["hello_c_cli.wasm<br/><i>4 core modules, 23 instances</i><br/><i>304 KB</i>"]
+  C -->|"meld fuse"| F["fused.wasm<br/><i>1 core module</i><br/><i>18 KB</i>"]
+  C -->|"meld fuse --component"| FC["fused_component.wasm<br/><i>P2 component, 3 modules</i><br/><i>22 KB</i>"]
+{% end %}
+
+{% note(kind="tip") %}
+The size drop from 304 KB to 18 KB is mostly stripping debug info and custom sections — `.debug_str` alone is ~14 KB of musl symbol names. The structural win is collapsing 4 modules and 23 instances into 1.
+{% end %}
+
+## Run it
+
+With `--component`, the output is still a valid WASI component:
+
+```bash
+wasmtime run fused_component.wasm
+# Hello wasm component world from C!
+```
+
+```bash
+wasm-tools validate fused_component.wasm
+wasm-tools component wit fused_component.wasm    # same WIT interface
+wasm-tools print fused_component.wasm | head -30  # peek inside
+```
+
+Same `wasi:cli/run@0.2.6` export, same WASI imports. Runtimes see no difference.
+
+## What is next
+
+Meld handles P1-style intra-component fusion today and wraps output back as P2 components via `--component`. We are working toward:
+
+- **Cross-component fusion** — fusing separate components that talk to each other
+- **String transcoding adapters** — UTF-8/UTF-16/Latin-1 conversion during cross-memory calls
+- **[Loom](https://github.com/pulseengine/loom) integration** — whole-program optimization on the fused output
+
+Code at [pulseengine/meld](https://github.com/pulseengine/meld). Example components at [pulseengine/wasm-component-examples](https://github.com/pulseengine/wasm-component-examples).

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -60,12 +60,44 @@ pre {
   padding: 1rem;
   overflow-x: auto;
   margin-bottom: 1.5rem;
+  position: relative;
 
   code {
     background: none;
     border: none;
     padding: 0;
     font-size: 0.875rem;
+  }
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: $surface-raised;
+  border: 1px solid $border;
+  border-radius: 6px;
+  color: $text-faint;
+  font-family: $font-mono;
+  font-size: 0.7rem;
+  padding: 0.25em 0.5em;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s, border-color 0.2s, color 0.2s;
+
+  pre:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    border-color: $accent;
+    color: $accent;
+  }
+
+  &.copied {
+    opacity: 1;
+    border-color: $green;
+    color: $green;
   }
 }
 

--- a/sass/_blog.scss
+++ b/sass/_blog.scss
@@ -113,8 +113,7 @@
     background: $surface;
   }
 
-  // Image with caption: use <figure> or ![alt](src "title")
-  // Zola renders title attr as title, we style alt as caption via CSS
+  // Markdown caption: *italic* immediately after image
   img + em,
   p > img + br + em {
     display: block;
@@ -123,6 +122,22 @@
     color: $text-faint;
     margin-top: -1rem;
     margin-bottom: 1.5rem;
+  }
+
+  // Shortcode figure with caption
+  .figure {
+    margin: 1.5rem 0;
+
+    img {
+      margin-bottom: 0;
+    }
+
+    figcaption {
+      text-align: center;
+      font-size: 0.8rem;
+      color: $text-faint;
+      margin-top: 0.5rem;
+    }
   }
 
   // Callout notes

--- a/sass/_glass.scss
+++ b/sass/_glass.scss
@@ -256,3 +256,17 @@
   color: $text-faint;
   font-size: 0.8rem;
 }
+
+.build-ref {
+  font-family: $font-mono;
+  font-size: 0.7rem;
+
+  a {
+    color: $text-faint;
+    border-bottom: none;
+
+    &:hover {
+      color: $accent;
+    }
+  }
+}

--- a/static/codecopy.js
+++ b/static/codecopy.js
@@ -1,0 +1,25 @@
+// Copy-to-clipboard for code blocks
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre:not(.mermaid)').forEach(pre => {
+    const btn = document.createElement('button');
+    btn.className = 'copy-btn';
+    btn.textContent = 'Copy';
+    btn.setAttribute('aria-label', 'Copy code to clipboard');
+
+    btn.addEventListener('click', () => {
+      const code = pre.querySelector('code');
+      const text = (code || pre).textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = 'Copy';
+          btn.classList.remove('copied');
+        }, 2000);
+      });
+    });
+
+    pre.style.position = 'relative';
+    pre.appendChild(btn);
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,6 +42,7 @@
   <footer class="site-footer">
     <div class="container">
       &copy; {{ now() | date(format="%Y") }} PulseEngine &middot; Built with <a href="https://www.getzola.org">Zola</a>
+      <span class="build-ref"><!-- BUILD_INFO --></span>
     </div>
   </footer>
   <script src="{{ get_url(path='mandelbrot.js') }}" defer></script>

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -51,6 +51,7 @@
   </article>
 </div>
 
+<script src="{{ get_url(path='codecopy.js') }}" defer></script>
 {% if page.content is containing("mermaid") %}
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';

--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,0 +1,6 @@
+<figure class="figure">
+  <img src="{{ src }}" alt="{{ alt | default(value='') }}" loading="lazy">
+  {% if caption %}
+  <figcaption>{{ caption }}</figcaption>
+  {% endif %}
+</figure>


### PR DESCRIPTION
## Summary
- **Copy button** on code blocks — appears on hover, "Copied!" feedback, blog pages only
- **Figure shortcode** — `{{ figure(src, alt, caption) }}` for semantic `<figure>/<figcaption>`
- **Build info in footer** — commit SHA + deploy run link injected during CI
- **Git workflow docs** — CONTRIBUTING.md and CLAUDE.md updated with CI/CD pipeline, branch protection, commit conventions
- **Draft blog post** — Meld v0.1.0 deep-dive

## Test plan
- [ ] CI build passes
- [ ] Deploy succeeds after merge
- [ ] Footer shows commit hash + deploy link on production
- [ ] Code blocks show copy button on hover
- [ ] `figure` shortcode renders caption correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)