### PR TITLE
style: lowercase all project names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,9 @@ zola check          # Validate links
 ## Terminology — get this right
 
 - PulseEngine is a **WebAssembly Component Model engine**, not a "toolchain" or "framework"
-- Synth **transcodes** (not transpiles, not compiles) — it uses program synthesis
-- Kiln is an **interpreter and runtime** (not just a runtime, not AOT)
+- synth **transcodes** (not transpiles, not compiles) — it uses program synthesis
+- kiln is an **interpreter and runtime** (not just a runtime, not AOT)
+- Project names are always lowercase: meld, loom, synth, kiln, sigil, thrum, temper
 - Everything is **work in progress** — do not make production-ready claims
 
 ## Project structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,10 +104,10 @@ Use the `mermaid` shortcode for inline diagrams. Mermaid JS loads only on pages 
 ```markdown
 {% mermaid() %}
 graph LR
-    A[.wasm] --> B[Meld]
-    B --> C[Loom]
-    C --> D[Synth]
-    D --> E[Kiln]
+    A[.wasm] --> B[meld]
+    B --> C[loom]
+    C --> D[synth]
+    D --> E[kiln]
 {% end %}
 ```
 
@@ -143,8 +143,8 @@ Danger with red accent.
 
 | Shortcode | Purpose | Usage |
 |---|---|---|
-| `pipeline()` | Full pipeline SVG (Meld → Loom → Synth → Kiln + Sigil) | `{% pipeline() %}{% end %}` |
-| `project_card(...)` | Glass card for a project | `{{ project_card(name="Meld", desc="...", url="...", icon="🔗", badge="accent") }}` |
+| `pipeline()` | Full pipeline SVG (meld → loom → synth → kiln + sigil) | `{% pipeline() %}{% end %}` |
+| `project_card(...)` | Glass card for a project | `{{ project_card(name="meld", desc="...", url="...", icon="🔗", badge="accent") }}` |
 | `mermaid()` | Mermaid diagram | See above |
 | `note(kind="...")` | Callout box (info/tip/warning/danger) | See above |
 | `figure(src, alt, caption)` | Image with semantic caption | `{{ figure(src="img.png", alt="...", caption="...") }}` |

--- a/content/blog/2026-03-02-hello-world.md
+++ b/content/blog/2026-03-02-hello-world.md
@@ -16,25 +16,25 @@ This site fills that gap.
 
 **This Week in PulseEngine** — periodic roundups of what changed across the org: new releases, merged PRs worth noting, and work-in-progress that is shaping up.
 
-**Technical deep-dives** — longer posts exploring specific topics: how Meld's component fusion works under the hood, what Loom's twelve-pass optimization pipeline actually does to your Wasm, how Synth transcodes to native ARM through program synthesis, how Sigil chains attestations across build stages.
+**Technical deep-dives** — longer posts exploring specific topics: how meld's component fusion works under the hood, what loom's twelve-pass optimization pipeline actually does to your Wasm, how synth transcodes to native ARM through program synthesis, how sigil chains attestations across build stages.
 
-**Design notes** — the "why" behind architectural choices. Why we chose Cranelift's ISLE for Loom instead of writing a custom rewriter. Why Kiln is an interpreter *and* a runtime. Why Synth synthesizes equivalent programs rather than translating instructions.
+**Design notes** — the "why" behind architectural choices. Why we chose Cranelift's ISLE for loom instead of writing a custom rewriter. Why kiln is an interpreter *and* a runtime. Why synth synthesizes equivalent programs rather than translating instructions.
 
 ## The engine at a glance
 
 {% mermaid() %}
 graph LR
-    W(.wasm) --> M(Meld)
-    M --> L(Loom)
-    L --> S(Synth)
-    S --> K(Kiln)
-    SG(Sigil) -.->|attest| M
+    W(.wasm) --> M(meld)
+    M --> L(loom)
+    L --> S(synth)
+    S --> K(kiln)
+    SG(sigil) -.->|attest| M
     SG -.->|sign| L
     SG -.->|verify| S
     SG -.->|seal| K
 {% end %}
 
-Kiln interprets and executes components directly. Synth transcodes them to native ARM when you need bare metal. Meld fuses multiple components into one before any of that happens, and Loom optimizes at every level. Sigil attests every transformation — the full chain is verifiable end-to-end.
+kiln interprets and executes components directly. synth transcodes them to native ARM when you need bare metal. meld fuses multiple components into one before any of that happens, and loom optimizes at every level. sigil attests every transformation — the full chain is verifiable end-to-end.
 
 ## Stay in the loop
 

--- a/content/blog/2026-03-02-meld-v0.1.0.md
+++ b/content/blog/2026-03-02-meld-v0.1.0.md
@@ -1,6 +1,6 @@
 +++
-title = "Meld v0.1.0: Static Component Fusion for WebAssembly"
-description = "Meld's first release fuses WebAssembly components into single core modules. We walk through the hello_c example — what wit-component produces, what meld does to it, and what the wasm looks like after."
+title = "meld v0.1.0: static component fusion for WebAssembly"
+description = "meld's first release fuses WebAssembly components into single core modules. We walk through the hello_c example — what wit-component produces, what meld does to it, and what the wasm looks like after."
 date = 2026-03-02T18:00:00+00:00
 [taxonomies]
 tags = ["meld", "deep-dive"]
@@ -8,11 +8,11 @@ tags = ["meld", "deep-dive"]
 
 ## What meld does
 
-Meld v0.1.0 is out — our static fusion tool for WebAssembly components.
+meld v0.1.0 is out — our static fusion tool for WebAssembly components.
 
 A [Component Model](https://github.com/WebAssembly/component-model) component is not a flat wasm module. It is a tree of core modules, type definitions, and [Canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md) operations — `canon lift`, `canon lower`, `canon resource.drop` — that bridge between the component's typed [WIT](https://component-model.bytecodealliance.org/design/wit.html) interface and the i32/i64 world of core wasm. [`wit-component`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) produces this structure, and it works well for composition, but a runtime still has to instantiate and link multiple core modules on every load.
 
-Meld resolves that at build time. It takes a component, flattens the internal imports, remaps every function/memory/table index into a single space, generates [FACT-style adapters](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canonical-definitions) where calls cross memory boundaries, and emits one core module. One instantiation, direct calls, no linking overhead.
+meld resolves that at build time. It takes a component, flattens the internal imports, remaps every function/memory/table index into a single space, generates [FACT-style adapters](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canonical-definitions) where calls cross memory boundaries, and emits one core module. One instantiation, direct calls, no linking overhead.
 
 We will walk through the `hello_c` CLI component from [wasm-component-examples](https://github.com/pulseengine/wasm-component-examples) — what `wit-component` produces, what meld does to it, and what the wasm looks like after.
 
@@ -274,10 +274,10 @@ Same `wasi:cli/run@0.2.6` export, same WASI imports. Runtimes see no difference.
 
 ## What is next
 
-Meld handles P1-style intra-component fusion today and wraps output back as P2 components via `--component`. We are working toward:
+meld handles P1-style intra-component fusion today and wraps output back as P2 components via `--component`. We are working toward:
 
 - **Cross-component fusion** — fusing separate components that talk to each other
 - **String transcoding adapters** — UTF-8/UTF-16/Latin-1 conversion during cross-memory calls
-- **[Loom](https://github.com/pulseengine/loom) integration** — whole-program optimization on the fused output
+- **[loom](https://github.com/pulseengine/loom) integration** — whole-program optimization on the fused output
 
 Code at [pulseengine/meld](https://github.com/pulseengine/meld). Example components at [pulseengine/wasm-component-examples](https://github.com/pulseengine/wasm-component-examples).

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -8,15 +8,15 @@ template = "section.html"
 
 <div class="grid">
 
-{{ project_card(name="Meld", desc="Statically fuses multiple WebAssembly components into a single core module. Import resolution, index-space merging, and canonical ABI adapter generation at build time.", url="https://github.com/pulseengine/meld", icon="🔗", badge="accent") }}
+{{ project_card(name="meld", desc="Statically fuses multiple WebAssembly components into a single core module. Import resolution, index-space merging, and canonical ABI adapter generation at build time.", url="https://github.com/pulseengine/meld", icon="🔗", badge="accent") }}
 
-{{ project_card(name="Loom", desc="Twelve-pass WebAssembly optimization pipeline built on Cranelift's ISLE pattern-matching engine. Constant folding, strength reduction, CSE, inlining, dead code elimination.", url="https://github.com/pulseengine/loom", icon="🧵", badge="cyan") }}
+{{ project_card(name="loom", desc="Twelve-pass WebAssembly optimization pipeline built on Cranelift's ISLE pattern-matching engine. Constant folding, strength reduction, CSE, inlining, dead code elimination.", url="https://github.com/pulseengine/loom", icon="🧵", badge="cyan") }}
 
-{{ project_card(name="Synth", desc="Transcodes WebAssembly to native ARM for embedded Cortex-M targets through program synthesis — exploring equivalent native implementations, not just translating instructions.", url="https://github.com/pulseengine/synth", icon="⚡", badge="green") }}
+{{ project_card(name="synth", desc="Transcodes WebAssembly to native ARM for embedded Cortex-M targets through program synthesis — exploring equivalent native implementations, not just translating instructions.", url="https://github.com/pulseengine/synth", icon="⚡", badge="green") }}
 
-{{ project_card(name="Kiln", desc="WebAssembly Component Model interpreter and runtime. Full WASI 0.2 support with no_std architecture for embedded, automotive, medical, and aerospace environments.", url="https://github.com/pulseengine/kiln", icon="🔥", badge="amber") }}
+{{ project_card(name="kiln", desc="WebAssembly Component Model interpreter and runtime. Full WASI 0.2 support with no_std architecture for embedded, automotive, medical, and aerospace environments.", url="https://github.com/pulseengine/kiln", icon="🔥", badge="amber") }}
 
-{{ project_card(name="Sigil", desc="Supply chain security — attestation, signing, and verification across every pipeline stage. Sigstore keyless signing, SLSA L4 provenance, TPM 2.0 support.", url="https://github.com/pulseengine/sigil", icon="🔏", badge="purple") }}
+{{ project_card(name="sigil", desc="Supply chain security — attestation, signing, and verification across every pipeline stage. Sigstore keyless signing, SLSA L4 provenance, TPM 2.0 support.", url="https://github.com/pulseengine/sigil", icon="🔏", badge="purple") }}
 
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
         <p>
           Every transformation — fusion, optimization, transcoding, execution —
           is designed to carry <strong>mechanized proofs</strong>. Rocq, Kani, Z3, Verus.
-          Sigil binds it together with cryptographic attestation:
+          sigil binds it together with cryptographic attestation:
           signed, verifiable evidence that your component went through exactly the
           pipeline you specified.
         </p>
@@ -73,26 +73,26 @@
     <h2 class="section-heading">The Pipeline</h2>
     <p class="pipeline-intro">
       A <code>.wasm</code> component enters on the left. Each stage transforms it — fuse, optimize,
-      transcode, fire — and Sigil attests every step. Click any stage to see its source.
+      transcode, fire — and sigil attests every step. Click any stage to see its source.
     </p>
     <div class="pipeline-wrap">
       {% include "shortcodes/pipeline.html" %}
     </div>
     <div class="pipeline-detail">
       <div class="pipeline-detail__item">
-        <strong>Meld</strong> fuses multiple components into a single module — runtime linking eliminated.
+        <strong>meld</strong> fuses multiple components into a single module — runtime linking eliminated.
       </div>
       <div class="pipeline-detail__item">
-        <strong>Loom</strong> runs twelve optimization passes via Cranelift's ISLE engine.
+        <strong>loom</strong> runs twelve optimization passes via Cranelift's ISLE engine.
       </div>
       <div class="pipeline-detail__item">
-        <strong>Synth</strong> transcodes Wasm to native ARM through program synthesis — not translation, synthesis.
+        <strong>synth</strong> transcodes Wasm to native ARM through program synthesis — not translation, synthesis.
       </div>
       <div class="pipeline-detail__item">
-        <strong>Kiln</strong> interprets and executes components — full Component Model, WASI 0.2, <code>no_std</code>.
+        <strong>kiln</strong> interprets and executes components — full Component Model, WASI 0.2, <code>no_std</code>.
       </div>
       <div class="pipeline-detail__item">
-        <strong>Sigil</strong> signs and attests every transformation — end-to-end verifiable.
+        <strong>sigil</strong> signs and attests every transformation — end-to-end verifiable.
       </div>
     </div>
   </section>

--- a/templates/shortcodes/pipeline.html
+++ b/templates/shortcodes/pipeline.html
@@ -11,7 +11,7 @@
     .pe-input { fill: #8b90a0; font-family: 'Atkinson Hyperlegible Mono', monospace; font-size: 12px; }
   </style>
 
-  <!-- Sigil spanning label and dashed line -->
+  <!-- sigil spanning label and dashed line -->
   <a href="https://github.com/pulseengine/sigil" target="_blank">
     <text class="pe-sigil-label" x="490" y="16" text-anchor="middle" style="cursor:pointer">sigil · attest · sign · verify</text>
   </a>
@@ -22,43 +22,43 @@
   <line class="pe-arrow-line" x1="108" y1="67" x2="148" y2="67" />
   <polygon class="pe-arrow-head" points="148,63 158,67 148,71" />
 
-  <!-- Meld -->
+  <!-- meld -->
   <a href="https://github.com/pulseengine/meld" target="_blank">
     <rect class="pe-box" x="158" y="42" width="125" height="50" rx="8" style="cursor:pointer" />
-    <text class="pe-name" x="220" y="64" text-anchor="middle">Meld</text>
+    <text class="pe-name" x="220" y="64" text-anchor="middle">meld</text>
     <text class="pe-role" x="220" y="80" text-anchor="middle">fuse</text>
   </a>
 
-  <!-- Arrow Meld → Loom -->
+  <!-- Arrow meld → loom -->
   <line class="pe-arrow-line" x1="283" y1="67" x2="328" y2="67" />
   <polygon class="pe-arrow-head" points="328,63 338,67 328,71" />
 
-  <!-- Loom -->
+  <!-- loom -->
   <a href="https://github.com/pulseengine/loom" target="_blank">
     <rect class="pe-box" x="338" y="42" width="125" height="50" rx="8" style="cursor:pointer" />
-    <text class="pe-name" x="400" y="64" text-anchor="middle">Loom</text>
+    <text class="pe-name" x="400" y="64" text-anchor="middle">loom</text>
     <text class="pe-role" x="400" y="80" text-anchor="middle">optimize</text>
   </a>
 
-  <!-- Arrow Loom → Synth -->
+  <!-- Arrow loom → synth -->
   <line class="pe-arrow-line" x1="463" y1="67" x2="508" y2="67" />
   <polygon class="pe-arrow-head" points="508,63 518,67 508,71" />
 
-  <!-- Synth -->
+  <!-- synth -->
   <a href="https://github.com/pulseengine/synth" target="_blank">
     <rect class="pe-box" x="518" y="42" width="125" height="50" rx="8" style="cursor:pointer" />
-    <text class="pe-name" x="580" y="64" text-anchor="middle">Synth</text>
+    <text class="pe-name" x="580" y="64" text-anchor="middle">synth</text>
     <text class="pe-role" x="580" y="80" text-anchor="middle">transcode</text>
   </a>
 
-  <!-- Arrow Synth → Kiln -->
+  <!-- Arrow synth → kiln -->
   <line class="pe-arrow-line" x1="643" y1="67" x2="688" y2="67" />
   <polygon class="pe-arrow-head" points="688,63 698,67 688,71" />
 
-  <!-- Kiln -->
+  <!-- kiln -->
   <a href="https://github.com/pulseengine/kiln" target="_blank">
     <rect class="pe-box" x="698" y="42" width="125" height="50" rx="8" style="cursor:pointer" />
-    <text class="pe-name" x="760" y="64" text-anchor="middle">Kiln</text>
+    <text class="pe-name" x="760" y="64" text-anchor="middle">kiln</text>
     <text class="pe-role" x="760" y="80" text-anchor="middle">fire</text>
   </a>
 </svg>


### PR DESCRIPTION
## Summary
- Lowercase meld, loom, synth, kiln, sigil everywhere — content, templates, pipeline SVG, docs
- Adds naming convention rule to CLAUDE.md so agents keep it consistent

## Files changed
- `content/projects/_index.md` — project card names
- `content/blog/2026-03-02-hello-world.md` — prose + mermaid diagram
- `content/blog/2026-03-02-meld-v0.1.0.md` — title, description, prose
- `templates/index.html` — landing page pipeline descriptions
- `templates/shortcodes/pipeline.html` — SVG labels + comments
- `CLAUDE.md` / `CONTRIBUTING.md` — docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)