### PR TITLE
docs: draft workflow and zero-cost abstraction blog post

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ See `CONTRIBUTING.md` for the full guide including frontmatter, shortcodes, imag
 
 Quick reference:
 - Frontmatter needs `title`, `description`, `date`, and `[taxonomies] tags`
+- Use `draft = true` to keep a post out of production builds; `zola serve --drafts` to preview locally
 - Use `{% mermaid() %}...{% end %}` for diagrams
 - Use `{% note(kind="tip|warning|danger") %}...{% end %}` for callouts
 - Co-locate images next to `index.md` in a post directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,7 @@ Zola copies co-located assets to the output automatically.
 title = "Post Title"
 description = "One-line summary — shown on listing cards and in <meta> tags."
 date = 2026-03-05
+draft = true
 [taxonomies]
 tags = ["deep-dive", "meld"]
 +++
@@ -50,6 +51,15 @@ tags = ["deep-dive", "meld"]
 - `date` controls sort order on the blog listing
 - `description` is required — it appears on the blog index cards
 - `tags` render as accent badges and generate tag pages at `/tags/<name>/`
+- `draft = true` excludes the post from production builds — remove it when ready to publish
+
+### Draft workflow
+
+Posts start as drafts and get published when ready:
+
+1. Write with `draft = true` in frontmatter
+2. Preview locally: `zola serve --drafts`
+3. Publish: remove `draft = true`, commit, push — deploy is automatic
 
 ### What you get automatically
 

--- a/content/blog/2026-03-03-zero-cost-component-model.md
+++ b/content/blog/2026-03-03-zero-cost-component-model.md
@@ -1,0 +1,117 @@
++++
+title = "the Component Model as a zero-cost abstraction for safety-critical systems"
+description = "the WebAssembly Component Model gives you composition, portability, and isolation at development time. meld, loom, and synth erase that overhead before it reaches the target. what remains is a flat, optimized artifact — with the full pipeline attested by sigil."
+date = 2026-03-03
+draft = true
+[taxonomies]
+tags = ["deep-dive", "architecture"]
++++
+
+## the problem
+
+the WebAssembly Component Model solves a real problem: portable, language-neutral composition with strong isolation guarantees. you can build a component in Rust, another in C, compose them through typed interfaces, and the result is a self-describing binary that any compliant runtime can execute.
+
+but when you talk to folks building systems for automotive, aerospace, or medical devices, the reaction is consistent: the model is interesting, the runtime story doesn't fit.
+
+three concerns keep coming up:
+
+**the Component Model is structurally complex.** a simple hello-world component built with `wit-component` produces 4 core modules, 23 core instances, and 23 canonical ABI operations. shim modules, indirect function tables, fixup modules — all correct and compositional, but all overhead that a runtime must resolve on every instantiation.
+
+**wasmtime is too large.** wasmtime is a general-purpose runtime with JIT compilation via Cranelift. its binary size and resource requirements put it outside the envelope for Cortex-M class targets. and even smaller runtimes like WAMR, wasm3, or [DLR's wasm-interpreter](https://github.com/DLR-FT/wasm-interpreter) — none of them support the Component Model. they consume core modules only.
+
+**the ecosystem moves too fast.** safety-critical industries need frozen, qualified baselines. they need versions they can certify against and maintain for a decade. an always-bleeding-edge runtime with weekly releases is a non-starter for ISO 26262 or DO-178C qualification.
+
+## who else is working on this
+
+we're not alone in seeing WebAssembly's potential for embedded and safety-critical systems:
+
+- **[DLR (German Aerospace Center)](https://github.com/DLR-FT/wasm-interpreter)** built a minimal `no_std` Wasm interpreter in Rust for avionics. they ran it on an ARINC 653 hypervisor and published ["WebAssembly in Avionics: Decoupling Software from Hardware"](https://elib.dlr.de/201323/). their interpreter handles core Wasm only — no Component Model. crucially, their paper notes that JIT and AOT compilation at *runtime* generate executable object code — "a behavior which is not foreseen by current regulations." this is exactly why build-time transcoding matters.
+
+- **[Infineon](https://github.com/Infineon/aurix_webassembly_aot)** built an AOT compiler translating Wasm to native TriCore for AURIX — their ASIL-D automotive MCU. core Wasm only, no Component Model. synth is designed with pluggable backends — ARM Cortex-M first, but architectures like TriCore are exactly the kind of target a backend could support.
+
+- **[wasmi](https://github.com/wasmi-labs/wasmi)** is an efficient Wasm interpreter for embedded, used in Substrate/Polkadot. `no_std` compatible, actively maintained, but again — core Wasm modules, no Component Model support.
+
+the pattern is clear: everyone who targets embedded stops at core Wasm. the Component Model is treated as a development-time convenience that must be stripped before deployment. the question is whether that stripping can be done systematically, verifiably, and without losing the benefits.
+
+## the pipeline approach
+
+this is where PulseEngine's pipeline comes in. instead of asking the runtime to handle component structure, we resolve it at build time:
+
+{% mermaid() %}
+graph LR
+    W(.wasm component) --> M(meld)
+    M --> L(loom)
+    L --> S(synth)
+    S --> K(kiln / target)
+    SG(sigil) -.->|attest| M
+    SG -.->|attest| L
+    SG -.->|attest| S
+{% end %}
+
+**meld** fuses the component structure. multiple core modules become one. internal imports become direct calls. the shim modules, indirect tables, and canonical ABI trampolines disappear. what exits meld is a flat core module with only the host imports that actually need runtime resolution.
+
+**loom** optimizes the fused module. this is where the approach becomes stronger than traditional LTO: after meld has erased component boundaries, loom sees the *entire program*. it can optimize across what were cross-component call boundaries — inlining, constant folding, dead code elimination across boundaries that a linker would never see. the component abstraction gave you isolation during development; meld erased it; loom exploits the result.
+
+**synth** transcodes to native code. the flat, optimized Wasm module becomes an ELF binary or firmware image for the target — no Wasm runtime needed on the device. synth is built around pluggable backends: ARM Cortex-M first, with the architecture designed so that additional targets (TriCore, RISC-V, or others) are separate backend implementations. the transcoding happens at build time, producing inspectable native code — not runtime-generated object code that current avionics and automotive regulations don't foresee.
+
+**sigil** attests every step. each transformation is signed. the final artifact carries cryptographic evidence that it went through exactly the pipeline specified — from source component to deployed binary.
+
+## what "zero cost" means (and what it doesn't)
+
+calling this a "zero-cost abstraction" invites scrutiny, and it should. let's be precise about what can and cannot be resolved at build time.
+
+### what the pipeline eliminates
+
+- **component structure** — module nesting, instantiation chains, type checking, import/export wiring: all resolved by meld
+- **canonical ABI trampolines** — `canon lift` / `canon lower` pairs where one component calls another: fused into direct calls
+- **indirect dispatch** — shim tables and fixup modules: collapsed into the merged function space
+- **cross-component optimization barriers** — loom can optimize across what were component boundaries because they no longer exist
+
+### what it cannot eliminate
+
+- **resource handle tables** — if your components use `resource` types, the handle table (allocation, free list, lifecycle tracking) is runtime state. resource lifetimes depend on program execution, not program structure.
+- **string transcoding** — when components disagree on encoding (UTF-8 vs UTF-16), transcoding is irreducible runtime work. if you constrain all components to the same encoding, this cost vanishes — a reasonable constraint for embedded.
+- **async and streams** — the Component Model's async design introduces cooperative scheduling, backpressure, and task queues. these are inherently dynamic. for embedded systems that are overwhelmingly synchronous, this rarely applies.
+
+the honest framing: the Component Model's *structural* overhead is zero-cost — it's fully eliminated at build time. the *behavioral* overhead (resources, transcoding, async) persists proportionally to the features used. for the embedded use case — synchronous, same-encoding, minimal resource types — the residual cost approaches zero.
+
+### the precedent
+
+this pattern isn't new. Rust's generics are monomorphized — the abstraction is erased at compile time, zero runtime dispatch. C++ templates work the same way. GraalVM compiles Spring's entire dependency injection framework into direct calls. the Component Model follows the same principle: rich composition at development time, flat artifact at deployment time.
+
+the difference is that the Component Model operates at the *module boundary*, not the function or type boundary. fusing modules across memory spaces has implications (Luke Wagner raised [isolation concerns](https://github.com/WebAssembly/component-model/issues/386) about shared-everything linking). for safety-critical systems, where the target is a single-purpose firmware image, this tradeoff is well-understood and acceptable.
+
+## what this means for qualification
+
+in AUTOSAR Classic, integrating a pre-validated software component (SWC) into a new ECU still requires system-level integration testing, impact analysis, and validation that all original artifacts remain applicable (ISO 26262-8, Clause 12). the SWC code may be portable, but the RTE is regenerated, the BSW changes, and the timing environment is different. every integration is partly a re-validation.
+
+a verified build pipeline changes the equation. if meld's fusion is proven to preserve semantics (like CompCert proves compilation correctness), and sigil attests that the specific pipeline was applied, then:
+
+- the component is validated once against its WIT interface
+- the pipeline transformation is qualified once (tool qualification, not per-project)
+- integration testing focuses on the system context, not the component internals
+- sigil provides the audit trail linking deployed artifact to source component and pipeline version
+
+this doesn't eliminate system validation — nothing does, and nothing should. but it reduces the per-integration cost to what actually changed: the system context. the component's internal correctness is carried forward by the verified pipeline, not re-demonstrated.
+
+{% note(kind="warning") %}
+this is the goal, not the current state. meld is at v0.1.0. formal verification of the pipeline is future work. no Wasm runtime or toolchain has undergone DO-178C or ISO 26262 qualification today. we are building toward this, not claiming it.
+{% end %}
+
+## the development model advantage
+
+beyond the technical pipeline, the Component Model offers something AUTOSAR Classic never had: a genuine development-time abstraction that decouples component authoring from target integration.
+
+you write a component against a WIT interface. you test it, validate it, publish it. downstream projects consume it through composition — not by copying source, not by configuring an RTE, not by re-running the full AUTOSAR methodology. meld fuses it into their system. loom optimizes across the boundary. synth delivers it to their target. sigil proves nothing was lost.
+
+the component is a qualified building block. the pipeline is a qualified transformation. what remains is integration testing — which is what system validation should always have been about.
+
+## what's next
+
+- meld v0.1.0 handles intra-component fusion. cross-component fusion is next.
+- loom's optimization passes need to be validated against the fused output from meld.
+- synth is early — ARM Cortex-M backend first, pluggable architecture for additional targets.
+- sigil needs to [sign native artifacts](https://github.com/pulseengine/sigil/issues/47) (ELF, MCUboot images), not just Wasm custom sections.
+- formal verification of the pipeline is the long game. Verus for Rust, Rocq for the mathematical foundations.
+
+if you're working in this space — embedded Wasm, safety-critical systems, Component Model tooling — we'd like to hear from you. everything is at [github.com/pulseengine](https://github.com/pulseengine).


### PR DESCRIPTION
## Summary
- Documents the draft blog post workflow in CONTRIBUTING.md and CLAUDE.md (`draft = true` → `zola serve --drafts` → remove draft to publish)
- Adds draft blog post: "the Component Model as a zero-cost abstraction for safety-critical systems"
  - Landscape analysis: DLR avionics interpreter, Infineon AURIX AOT, wasmi
  - Pipeline walkthrough: meld → loom → synth → kiln + sigil
  - Honest assessment of what "zero cost" covers (structural overhead) and what it doesn't (resource handles, transcoding, async)
  - synth pluggable backend architecture (ARM Cortex-M first, extensible to TriCore, RISC-V)
  - Qualification implications for ISO 26262 / DO-178C
  - WIP caveat — we're building toward this, not claiming it

The blog post has `draft = true` — it won't appear in production builds.

## Test plan
- [x] `zola build` passes (2 pages, draft excluded)
- [x] `zola build --drafts` passes (3 pages, draft included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)