### PR TITLE
fix: rewrite meld v0.1.0 post for accuracy, add per-post git info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Zola
         uses: taiki-e/install-action@v2
         with:
           tool: zola@0.22.1
+
+      - name: Inject git info into blog posts
+        run: python3 scripts/inject-git-info.py
 
       - name: Inject build info
         run: |

--- a/content/blog/2026-03-02-meld-v0.1.0.md
+++ b/content/blog/2026-03-02-meld-v0.1.0.md
@@ -1,27 +1,26 @@
 +++
 title = "meld v0.1.0: static component fusion for WebAssembly"
-description = "meld's first release fuses WebAssembly components into single core modules. We walk through the hello_c example — what wit-component produces, what meld does to it, and what the wasm looks like after."
+description = "meld's first release fuses WebAssembly components into single core modules. We walk through a C hello-world component, show what wit-component produces, and collapse it with meld."
 date = 2026-03-02T18:00:00+00:00
 [taxonomies]
 tags = ["meld", "deep-dive"]
 authors = ["Ralf Anton Beier"]
+
 +++
 
 {% insight() %}
-Today, every embedded Wasm runtime requires flat core modules — none support the Component Model. meld bridges that gap at build time: develop with rich, typed composition, deploy as a single optimized module. This eliminates the tradeoff between developer productivity and deployment constraints.
+Today, every embedded Wasm runtime requires flat core modules — none support the Component Model natively. meld bridges that gap at build time: develop with rich, typed composition, deploy as a single optimized module. This eliminates the tradeoff between developer productivity and deployment constraints.
 {% end %}
 
 ## What meld does
 
 meld v0.1.0 is out — our static fusion tool for WebAssembly components.
 
-A [Component Model](https://github.com/WebAssembly/component-model) component is not a flat wasm module. It is a tree of core modules, type definitions, and [Canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md) operations — `canon lift`, `canon lower`, `canon resource.drop` — that bridge between the component's typed [WIT](https://component-model.bytecodealliance.org/design/wit.html) interface and the i32/i64 world of core wasm. [`wit-component`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) produces this structure, and it works well for composition, but a runtime still has to instantiate and link multiple core modules on every load.
+A [Component Model](https://github.com/WebAssembly/component-model) component is not a flat wasm module. It is a tree of core modules, type definitions, and [Canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md) operations (`canon lift`, `canon lower`, `canon resource.drop`) that bridge between the component's typed [WIT](https://component-model.bytecodealliance.org/design/wit.html) interface and the i32/i64 world of core wasm. This structure works well for composition, but a runtime has to instantiate and link multiple core modules on every load.
 
-meld resolves that at build time. It takes a component, flattens the internal imports, remaps every function/memory/table index into a single space, generates [FACT-style adapters](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#canonical-definitions) where calls cross memory boundaries, and emits one core module. One instantiation, direct calls, no linking overhead.
+meld resolves that at build time. It takes a component, flattens the internal module tree, remaps every function/memory/table index into a single space, and emits one core module. One instantiation, direct calls, no linking overhead.
 
-We will walk through the `hello_c` CLI component from [wasm-component-examples](https://github.com/pulseengine/wasm-component-examples) — what `wit-component` produces, what meld does to it, and what the wasm looks like after.
-
-## Get the tools
+## Try it
 
 [v0.1.0 release](https://github.com/pulseengine/meld/releases/tag/v0.1.0) binaries for Linux (x86_64, aarch64) and macOS (x86_64, Apple Silicon):
 
@@ -35,253 +34,89 @@ curl -LO https://github.com/pulseengine/wasm-component-examples/releases/downloa
 tar xzf wasm-components-0.2.0.tar.gz
 ```
 
-We will look at `hello_c_cli.wasm` — a [WASI](https://wasi.dev) CLI component built from C with `wit-component` 0.241.2. It prints "Hello wasm component world from C!" and exports `wasi:cli/run@0.2.6`.
+We will use `hello_c_cli.wasm` — a [WASI](https://wasi.dev) CLI component built from C with wasi-sdk v29 and `wit-component` 0.241.2. It prints "Hello wasm component world from C!" and exports `wasi:cli/run@0.2.6`.
 
-## Before fusion: what wit-component produces
-
-`wasm-tools print hello_c_cli.wasm` — 8,331 lines of WAT, 304 KB. Four core modules, 23 core instances, 23 canonical ABI operations. All to run `printf`.
-
-### Module `$main` — the C program
-
-hello.c compiled by clang (wasi-sdk v29). 28 functions — the greeting plus full musl libc (`printf`, `dlmalloc`, `memcpy`, math). 19 WASI imports, all at `@0.2.0` — the version wasi-sdk generated bindings against:
-
-```wasm
-(core module $main (;0;)
-  (import "wasi:io/error@0.2.0" "[resource-drop]error" (func ...))
-  (import "wasi:io/poll@0.2.0" "[resource-drop]pollable" (func ...))
-  (import "wasi:io/streams@0.2.0" "[method]output-stream.check-write" (func ...))
-  (import "wasi:cli/stdout@0.2.0" "get-stdout" (func ...))
-  (import "wasi:cli/exit@0.2.0" "exit" (func ...))
-  ;; ... 19 imports total, all @0.2.0
-
-  (table (;0;) 11 11 funcref)
-  (memory (;0;) 2)
-  (data (i32.const 1024) "Hello wasm component world from C!\00")
-
-  (export "memory" (memory 0))
-  (export "_start" (func $_start))
-  (export "cabi_realloc" (func $cabi_realloc))
-  ;; 28 defined functions
-)
-```
-
-The host provides `@0.2.6` — someone has to bridge that version gap.
-
-### Module `$wit-component:adapter:wasi_snapshot_preview1` — the bridge
-
-A Rust-compiled adapter, 16 functions. Bridges WASI preview1 libc calls to preview2 component imports. Imports `_start` and `cabi_realloc` from the main module, imports a few `@0.2.6` WASI functions directly, and exports the actual `run` entry point:
-
-```wasm
-(core module $wit-component:adapter:wasi_snapshot_preview1 (;1;)
-  (import "env" "memory" (memory 0))
-  (import "__main_module__" "_start" (func ...))
-  (import "__main_module__" "cabi_realloc" (func ...))
-  (import "wasi:cli/stderr@0.2.6" "get-stderr" (func ...))
-  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush" (func ...))
-
-  (export "wasi:cli/run@0.2.6#run" (func ...))
-  (export "cabi_import_realloc" (func ...))
-  ;; 16 functions: run wrapper, stack allocator, fd_write shim, ...
-)
-```
-
-### Module `$wit-component-shim-module` — the indirect table
-
-The indirect table pattern. 8 stub functions that dispatch through a `funcref` table via `call_indirect`. Breaks the circular dependency — `canon lower` needs `cabi_realloc`, but the module that defines `cabi_realloc` cannot be instantiated until its imports are lowered:
-
-```wasm
-(core module $wit-component-shim-module (;2;)
-  (table (;0;) 8 8 funcref)
-  (export "$imports" (table 0))
-  (export "0" (func 0))
-  ;; ... 8 stubs
-
-  (func (;0;) (type 0) (param i32 i32)
-    local.get 0
-    local.get 1
-    i32.const 0
-    call_indirect (type 0))
-  ;; same pattern for all 8
-)
-```
-
-### Module `$wit-component-fixup` — fills the table
-
-Imports the 8 `canon lower`'d functions and the table, fills all slots with an active element segment:
-
-```wasm
-(core module $wit-component-fixup (;3;)
-  (import "" "0" (func (;0;) ...))
-  ;; ... 8 function imports
-  (import "" "$imports" (table (;0;) 8 8 funcref))
-  (elem (i32.const 0) func 0 1 2 3 4 5 6 7)
-)
-```
-
-### The instantiation chain
-
-With all four modules defined, `wit-component` orchestrates 23 core instances:
-
-```wasm
-;; 1. Shim — provides memory + empty funcref table
-(core instance (;0;) (instantiate $wit-component-shim-module))
-
-;; 2. Canon lower + resource.drop — 15 lower, 8 drop
-(core func (;2;)  (canon lower (func $"[method]pollable.block")))
-(core func (;11;) (canon lower (func $exit)))
-(core func (;13;) (canon lower (func $get-stdout)))
-;; ...
-
-;; 3. Per-interface instances from lowered functions
-(core instance $wasi:io/streams@0.2.0 (;3;)
-  (export "[resource-drop]output-stream" ...)
-  (export "[method]output-stream.check-write" ...)
-  (export "[method]output-stream.write" ...)
-)
-
-;; 4. Instantiate $main with all 13 WASI instances
-(core instance $main (;14;) (instantiate $main
-  (with "wasi:io/streams@0.2.0" (instance $wasi:io/streams@0.2.0))
-  (with "wasi:cli/stdout@0.2.0" (instance $wasi:cli/stdout@0.2.0))
-  ;; ...
-))
-
-;; 5. Adapter gets main's exports + @0.2.6 WASI
-(core instance (;20;) (instantiate $wit-component:adapter:wasi_snapshot_preview1
-  (with "env" (instance $env))
-  (with "__main_module__" (instance ...))
-  (with "wasi:cli/stderr@0.2.6" ...)
-))
-
-;; 6. Fixup fills the indirect table
-(core instance (;22;) (instantiate $wit-component-fixup
-  (with "" (instance $fixup-args))
-))
-
-;; 7. Lift the run export to the component level
-(func (;15;) (canon lift (core func $wasi:cli/run@0.2.6#run)))
-(export "wasi:cli/run@0.2.6" ...)
-```
-
-{% mermaid() %}
-graph TD
-  SHIM["$wit-component-shim-module<br/><i>8 stubs + funcref table</i>"]
-  MAIN["$main<br/><i>hello.c — 28 funcs, 19 imports @0.2.0</i>"]
-  ADAPT["$wasi_snapshot_preview1 adapter<br/><i>16 funcs — bridges preview1 to 0.2.6</i>"]
-  FIXUP["$wit-component-fixup<br/><i>fills table with lowered funcs</i>"]
-
-  CL["15x canon lower<br/>8x resource.drop"]
-
-  SHIM -->|"memory, table, stubs"| MAIN
-  MAIN -->|"_start, cabi_realloc, memory"| ADAPT
-  CL -->|"lowered funcs"| FIXUP
-  SHIM -->|"$imports table"| FIXUP
-  ADAPT -->|"run"| LIFT["canon lift"]
-  LIFT --> E["export wasi:cli/run@0.2.6"]
-{% end %}
-
-Four core modules, 23 instances, 23 canonical ABI operations — correct and compositional, but a lot of machinery a runtime has to set up on every instantiation.
-
-## Fuse it
+Fuse it and run it:
 
 ```bash
+# Fuse into a flat core module
 ./meld fuse hello_c_cli.wasm -o fused.wasm --stats
-```
 
-With `--component` the output is wrapped back as a valid P2 component — wasmtime can run it directly:
-
-```bash
+# Or fuse into a valid P2 component that wasmtime can run directly
 ./meld fuse hello_c_cli.wasm -o fused_component.wasm --component --stats
-```
 
-## After fusion: one flat module
-
-All four core modules collapsed into one. `wasm-tools print fused.wasm`:
-
-```wasm
-(module
-  ;; 20 WASI imports — host-provided, cannot be resolved further
-  (import "wasi:io/error@0.2.6" "[resource-drop]error" (func (;0;)))
-  (import "wasi:io/poll@0.2.6" "[resource-drop]pollable" (func (;1;)))
-  (import "wasi:io/streams@0.2.6" "[resource-drop]input-stream" (func (;2;)))
-  (import "wasi:io/streams@0.2.6" "[resource-drop]output-stream" (func (;3;)))
-  (import "wasi:cli/exit@0.2.6" "exit" (func (;6;)))
-  (import "wasi:cli/stdout@0.2.6" "get-stdout" (func (;10;)))
-  (import "wasi:io/streams@0.2.6" "[method]output-stream.write" (func (;13;)))
-  (import "wasi:io/streams@0.2.6" "[method]output-stream.blocking-write-and-flush" (func (;19;)))
-  ;; ... 20 imports total, all @0.2.6
-
-  (table (;0;) 8 8 funcref)    ;; from shim
-  (table (;1;) 11 11 funcref)  ;; from main
-  (memory (;0;) 2)             ;; single merged memory
-  (global (;0;) (mut i32) i32.const 68496)  ;; __stack_pointer
-  ;; ... 4 globals
-
-  ;; 54 functions — main (28) + adapter (16) + stubs (8) + fixup (2)
-  ;; all call indices rewritten to the merged space
-
-  (export "_start" (func 29))
-  (export "wasi:cli/run@0.2.6#run" (func 56))
-  (export "cabi_realloc" (func 34))
-  (export "cabi_import_realloc" (func 59))
-  (export "memory" (memory 0))
-  (export "$imports" (table 0))
-  ;; ... 14 exports
-)
-```
-
-{% mermaid() %}
-graph TD
-  IMP["20 WASI imports @0.2.6<br/><i>resource.drop, exit, get-stdout,<br/>output-stream.write, ...</i>"]
-  MOD["fused.wasm<br/><i>54 functions, 1 memory, 2 tables, 4 globals</i>"]
-  EXP["14 exports<br/><i>_start, run, cabi_realloc, memory, ...</i>"]
-
-  IMP --> MOD --> EXP
-{% end %}
-
-The `@0.2.0` / `@0.2.6` version mismatch is gone — resolved into a single set of `@0.2.6` host imports. The indirect table, the shim stubs, the fixup element segments, the 23 instantiation steps — all collapsed into one flat module.
-
-| | Original component | Fused core module | Fused component |
-|---|---|---|---|
-| Core modules | 4 | 1 | 3 (stubs + fused + fixup) |
-| Core instances | 23 | 1 | 18 |
-| `canon lower` / `resource.drop` | 15 + 8 | 0 | 0 (re-wrapped) |
-| Functions | 28 + 16 + 8 (separate) | 54 (merged) | 54 (merged) |
-| Size | 304,336 bytes | 17,994 bytes | 22,189 bytes |
-
-{% mermaid() %}
-graph LR
-  C["hello_c_cli.wasm<br/><i>4 core modules, 23 instances</i><br/><i>304 KB</i>"]
-  C -->|"meld fuse"| F["fused.wasm<br/><i>1 core module</i><br/><i>18 KB</i>"]
-  C -->|"meld fuse --component"| FC["fused_component.wasm<br/><i>P2 component, 3 modules</i><br/><i>22 KB</i>"]
-{% end %}
-
-{% note(kind="tip") %}
-The size drop from 304 KB to 18 KB is mostly stripping debug info and custom sections — `.debug_str` alone is ~14 KB of musl symbol names. The structural win is collapsing 4 modules and 23 instances into 1.
-{% end %}
-
-## Run it
-
-With `--component`, the output is still a valid WASI component:
-
-```bash
+# Verify it still works
 wasmtime run fused_component.wasm
 # Hello wasm component world from C!
 ```
 
+Result: 4 core modules and 23 instantiation steps collapsed into 1 flat module.
+
+| | Original component | Fused core module | Fused component |
+|---|---|---|---|
+| Core modules | 4 | 1 | 3 (shim + fused + fixup) |
+| Core instances | 23 | 1 | 18 |
+| `canon lower` / `resource.drop` | 15 + 8 | 0 | 0 (re-wrapped) |
+| Size | 304 KB | 292 KB | 296 KB |
+
+## Why does a C hello need 4 core modules?
+
+This is a fair question, and it trips up anyone encountering Component Model internals for the first time. The answer is: **it is a toolchain artifact, not a Component Model requirement.**
+
+When you compile C with wasi-sdk (targeting `wasm32-wasip2`), clang produces a core wasm module that imports WASI interfaces at `@0.2.0` — the version wasi-sdk's bindings were generated against. But the component needs to export `wasi:cli/run@0.2.6` and talk to a host that provides `@0.2.6` interfaces.
+
+[`wit-component`](https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-component) bridges this version gap by packaging four core modules together:
+
+{% mermaid() %}
+graph TD
+  MAIN["<b>$main</b><br/>hello.c — 28 functions<br/>imports wasi:*@0.2.0"]
+  ADAPT["<b>$wasi_snapshot_preview1</b><br/>Rust adapter — 16 functions<br/>bridges @0.2.0 → @0.2.6, exports run"]
+  SHIM["<b>$shim</b><br/>8 stub functions + funcref table<br/>breaks circular dependency"]
+  FIXUP["<b>$fixup</b><br/>fills table with canon-lowered functions"]
+
+  MAIN -->|"_start, cabi_realloc, memory"| ADAPT
+  SHIM -->|"stubs"| MAIN
+  SHIM -->|"$imports table"| FIXUP
+  ADAPT -->|"run"| LIFT["canon lift → export wasi:cli/run@0.2.6"]
+{% end %}
+
+1. **`$main`** — your C code compiled by clang. Imports WASI functions at `@0.2.0` (the version wasi-sdk binds against).
+2. **`$wasi_snapshot_preview1`** — a Rust-compiled adapter (the name is historical). Wraps `_start` into the `wasi:cli/run@0.2.6` entry point and bridges `@0.2.0` imports to `@0.2.6`.
+3. **`$shim`** — 8 stub functions dispatching through a `funcref` table. Breaks a circular dependency: `canon lower` needs `cabi_realloc`, but the module defining it cannot be instantiated until its imports are lowered.
+4. **`$fixup`** — fills the shim table with the actual lowered functions via an element segment.
+
+The `@0.2.0` vs `@0.2.6` version gap and the `_start` → `run` wrapping are what make the adapter necessary today. We use the wasi-sdk v29 output here because it is what most C toolchains produce today, and the multi-module structure makes the value of fusion especially visible.
+
+## What fusion does to it
+
+meld walks the component tree, resolves all internal instantiation edges, and merges every core module into a single flat module. Concretely:
+
+- **Index remapping** — all function, table, memory, and global indices are rewritten into one merged space
+- **Import resolution** — internal imports between modules become direct calls
+- **Version unification** — the `@0.2.0` / `@0.2.6` split collapses into a single set of `@0.2.6` host imports
+- **Shim elimination** — the indirect-table dance disappears; stubs become direct function references
+
+The fused output imports 20 WASI functions from the host (resources, streams, stdio) and exports the `run` entry point — the same import/export surface a hand-written core module would have:
+
+{% mermaid() %}
+graph LR
+  C["hello_c_cli.wasm<br/><i>4 core modules, 23 instances</i><br/><i>304 KB</i>"]
+  C -->|"meld fuse"| F["fused.wasm<br/><i>1 core module, 54 functions</i><br/><i>292 KB</i>"]
+  C -->|"meld fuse --component"| FC["fused_component.wasm<br/><i>P2 component</i><br/><i>296 KB</i>"]
+{% end %}
+
+With `--component`, meld wraps the fused core module back into a valid P2 component — wasmtime and other Component Model runtimes can run it directly. The WIT interface is preserved: same imports, same exports.
+
 ```bash
 wasm-tools validate fused_component.wasm
-wasm-tools component wit fused_component.wasm    # same WIT interface
-wasm-tools print fused_component.wasm | head -30  # peek inside
+wasm-tools component wit fused_component.wasm  # same WIT interface
 ```
-
-Same `wasi:cli/run@0.2.6` export, same WASI imports. Runtimes see no difference.
 
 ## What is next
 
-meld handles P1-style intra-component fusion today and wraps output back as P2 components via `--component`. We are working toward:
+meld handles intra-component fusion today — merging the core modules inside a single component. We are working toward:
 
-- **Cross-component fusion** — fusing separate components that talk to each other
+- **Cross-component fusion** — fusing separate components that talk to each other through WIT interfaces
 - **String transcoding adapters** — UTF-8/UTF-16/Latin-1 conversion during cross-memory calls
 - **[loom](https://github.com/pulseengine/loom) integration** — whole-program optimization on the fused output
 

--- a/sass/_blog.scss
+++ b/sass/_blog.scss
@@ -72,6 +72,16 @@
   }
 }
 
+.blog-post__commit {
+  font-family: $font-mono;
+  font-size: 0.85em;
+  color: $text-faint;
+
+  &:hover {
+    color: $accent;
+  }
+}
+
 .blog-post__content {
   h2 {
     margin-top: 2.5rem;

--- a/scripts/inject-git-info.py
+++ b/scripts/inject-git-info.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Inject git commit info into blog post frontmatter before zola build."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git_info(path: Path) -> tuple[str, str, int]:
+    """Return (short_hash, full_hash, commit_count) for a file."""
+    result = subprocess.run(
+        ["git", "log", "--format=%H", "--", str(path)],
+        capture_output=True, text=True, check=True,
+    )
+    commits = result.stdout.strip().splitlines()
+    if not commits:
+        return ("", "", 0)
+    return (commits[0][:7], commits[0], len(commits))
+
+
+def inject(path: Path) -> bool:
+    """Inject git info into frontmatter. Returns True if modified."""
+    text = path.read_text()
+    if not text.startswith("+++"):
+        return False
+
+    end = text.index("+++", 3)
+    frontmatter = text[3:end]
+    body = text[end:]
+
+    short_hash, full_hash, count = git_info(path)
+    if count == 0:
+        return False
+
+    # Remove existing git info lines if re-running
+    lines = [
+        line for line in frontmatter.splitlines()
+        if not line.startswith("last_commit")
+        and not line.startswith("commit_count")
+    ]
+
+    # Find or create [extra] section
+    extra_idx = None
+    next_section_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "[extra]":
+            extra_idx = i
+        elif extra_idx is not None and line.strip().startswith("["):
+            next_section_idx = i
+            break
+
+    git_lines = [
+        f'last_commit = "{short_hash}"',
+        f'commit_count = {count}',
+    ]
+
+    if extra_idx is not None:
+        insert_at = next_section_idx if next_section_idx else len(lines)
+        for j, gl in enumerate(git_lines):
+            lines.insert(insert_at + j, gl)
+    else:
+        lines.append("")
+        lines.append("[extra]")
+        lines.extend(git_lines)
+
+    new_frontmatter = "\n".join(lines)
+    if not new_frontmatter.endswith("\n"):
+        new_frontmatter += "\n"
+
+    path.write_text("+++" + new_frontmatter + body)
+    return True
+
+
+def main() -> int:
+    blog_dir = Path("content/blog")
+    if not blog_dir.exists():
+        print("content/blog not found", file=sys.stderr)
+        return 1
+
+    count = 0
+    for md in sorted(blog_dir.glob("*.md")):
+        if md.name == "_index.md":
+            continue
+        if inject(md):
+            count += 1
+            info = git_info(md)
+            print(f"  {md.name}: {info[0]} ({info[2]} revisions)")
+
+    print(f"Injected git info into {count} posts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -30,6 +30,9 @@
           {% endfor %}
         </span>
         {% endif %}
+        {% if page.extra.last_commit %}
+        <span>&middot; <a href="https://github.com/pulseengine/pulseengine.eu/commit/{{ page.extra.last_commit }}" class="blog-post__commit">{{ page.extra.last_commit }}</a>{% if page.extra.commit_count %} ({% if page.extra.commit_count == 1 %}1 revision{% else %}{{ page.extra.commit_count }} revisions{% endif %}){% endif %}</span>
+        {% endif %}
       </div>
     </header>
 


### PR DESCRIPTION
      Rewrite the meld blog post addressing feedback:
      - Remove misleading P1/P2 framing — adapter bridges @0.2.0 to @0.2.6
      - Remove wasm-tools strip workflow — show actual meld output sizes
      - Reduce WAT dumps, lead with try-it-yourself workflow
      - Clarify 4-module structure as toolchain artifact, not CM requirement

      Add per-post git revision info to deploy pipeline:
      - inject-git-info.py injects last_commit and commit_count into frontmatter
      - deploy.yml runs script before zola build (with fetch-depth: 0)
      - blog-page.html displays commit hash linked to GitHub + revision count