### PR TITLE
feat: update projects and homepage for current repo landscape

### DIFF
--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -8,15 +8,27 @@ template = "section.html"
 
 <div class="grid">
 
-{{ project_card(name="meld", desc="Statically fuses multiple WebAssembly components into a single core module. Import resolution, index-space merging, and canonical ABI adapter generation at build time.", url="https://github.com/pulseengine/meld", icon="🔗", badge="accent") }}
+{{ project_card(name="meld", desc="Statically fuses multiple WebAssembly components into a single core module. Import resolution, index-space merging, and canonical ABI adapter generation at build time.", url="https://github.com/pulseengine/meld", icon="🔗", badge="accent", label="Fusion") }}
 
-{{ project_card(name="loom", desc="Twelve-pass WebAssembly optimization pipeline built on Cranelift's ISLE pattern-matching engine. Constant folding, strength reduction, CSE, inlining, dead code elimination.", url="https://github.com/pulseengine/loom", icon="🧵", badge="cyan") }}
+{{ project_card(name="loom", desc="Twelve-pass WebAssembly optimization pipeline built on Cranelift's ISLE pattern-matching engine. Constant folding, strength reduction, CSE, inlining, dead code elimination.", url="https://github.com/pulseengine/loom", icon="🧵", badge="cyan", label="Optimizer") }}
 
-{{ project_card(name="synth", desc="Transcodes WebAssembly to native ARM for embedded Cortex-M targets through program synthesis — exploring equivalent native implementations, not just translating instructions.", url="https://github.com/pulseengine/synth", icon="⚡", badge="green") }}
+{{ project_card(name="synth", desc="Transcodes WebAssembly to native ARM for embedded Cortex-M targets through program synthesis — exploring equivalent native implementations, not just translating instructions.", url="https://github.com/pulseengine/synth", icon="⚡", badge="green", label="Transcoder") }}
 
-{{ project_card(name="kiln", desc="WebAssembly Component Model interpreter and runtime. Full WASI 0.2 support with no_std architecture for embedded, automotive, medical, and aerospace environments.", url="https://github.com/pulseengine/kiln", icon="🔥", badge="amber") }}
+{{ project_card(name="kiln", desc="WebAssembly Component Model interpreter and runtime. Full WASI 0.2 support with no_std architecture for embedded, automotive, medical, and aerospace environments.", url="https://github.com/pulseengine/kiln", icon="🔥", badge="amber", label="Runtime") }}
 
-{{ project_card(name="sigil", desc="Supply chain security — attestation, signing, and verification across every pipeline stage. Sigstore keyless signing, SLSA L4 provenance, TPM 2.0 support.", url="https://github.com/pulseengine/sigil", icon="🔏", badge="purple") }}
+{{ project_card(name="sigil", desc="Supply chain security — attestation, signing, and verification across every pipeline stage. Sigstore keyless signing, SLSA L4 provenance, TPM 2.0 support.", url="https://github.com/pulseengine/sigil", icon="🔏", badge="purple", label="Security") }}
+
+</div>
+
+## Safety-Critical Systems
+
+<div class="grid">
+
+{{ project_card(name="gale", desc="Formally verified Rust port of Zephyr RTOS kernel primitives for ASIL-D. Dual-track verification with Verus and Rocq, 9 verified synchronization primitives.", url="https://github.com/pulseengine/gale", icon="🌬️", badge="green", label="RTOS") }}
+
+{{ project_card(name="spar", desc="AADL v2.2 architecture analysis toolchain — parser, semantic model, 30+ pluggable analyses, and LSP server for safety-critical system design.", url="https://github.com/pulseengine/spar", icon="🏗️", badge="accent", label="Architecture") }}
+
+{{ project_card(name="rivet", desc="Schema-driven SDLC artifact manager for requirements traceability and safety compliance. STPA, ASPICE, and cybersecurity schemas.", url="https://github.com/pulseengine/rivet", icon="📋", badge="amber", label="Traceability") }}
 
 </div>
 
@@ -24,13 +36,15 @@ template = "section.html"
 
 <div class="grid">
 
-{{ project_card(name="rules_wasm_component", desc="Bazel rules for WebAssembly Component Model across Rust, Go, C++, and JavaScript.", url="https://github.com/pulseengine/rules_wasm_component", icon="📦", badge="accent") }}
+{{ project_card(name="rules_wasm_component", desc="Bazel rules for WebAssembly Component Model across Rust, Go, C++, and JavaScript.", url="https://github.com/pulseengine/rules_wasm_component", icon="📦", badge="accent", label="Bazel") }}
 
-{{ project_card(name="rules_rocq_rust", desc="Bazel rules for Rocq theorem proving and Rust formal verification with hermetic Nix toolchains.", url="https://github.com/pulseengine/rules_rocq_rust", icon="📐", badge="green") }}
+{{ project_card(name="rules_rocq_rust", desc="Bazel rules for Rocq theorem proving and Rust formal verification with hermetic Nix toolchains.", url="https://github.com/pulseengine/rules_rocq_rust", icon="📐", badge="green", label="Verification") }}
 
-{{ project_card(name="rules_verus", desc="Bazel rules for Verus Rust verification.", url="https://github.com/pulseengine/rules_verus", icon="✅", badge="green") }}
+{{ project_card(name="rules_verus", desc="Bazel rules for Verus Rust verification.", url="https://github.com/pulseengine/rules_verus", icon="✅", badge="green", label="Verification") }}
 
-{{ project_card(name="rules_moonbit", desc="Bazel rules for MoonBit with hermetic toolchain support.", url="https://github.com/pulseengine/rules_moonbit", icon="🌙", badge="cyan") }}
+{{ project_card(name="rules_moonbit", desc="Bazel rules for MoonBit with hermetic toolchain support.", url="https://github.com/pulseengine/rules_moonbit", icon="🌙", badge="cyan", label="Bazel") }}
+
+{{ project_card(name="rules_lean", desc="Bazel rules for Lean 4 with Mathlib and Aeneas integration for formal verification.", url="https://github.com/pulseengine/rules_lean", icon="📏", badge="green", label="Verification") }}
 
 </div>
 
@@ -38,9 +52,11 @@ template = "section.html"
 
 <div class="grid">
 
-{{ project_card(name="mcp", desc="Rust framework for building Model Context Protocol servers and clients, published to crates.io.", url="https://github.com/pulseengine/mcp", icon="🤖", badge="purple") }}
+{{ project_card(name="mcp", desc="Rust framework for building Model Context Protocol servers and clients, published to crates.io.", url="https://github.com/pulseengine/mcp", icon="🤖", badge="purple", label="Framework") }}
 
-{{ project_card(name="wasi-mcp", desc="Proposed WASI API for Model Context Protocol, targeting WASI 0.3 standardization.", url="https://github.com/pulseengine/wasi-mcp", icon="🌐", badge="purple") }}
+{{ project_card(name="template-mcp-server", desc="Scaffolding template for creating MCP servers in Rust with cross-platform npm distribution.", url="https://github.com/pulseengine/template-mcp-server", icon="🧩", badge="purple", label="Template") }}
+
+{{ project_card(name="timedate-mcp", desc="MCP server for time, date, and timezone operations with full IANA timezone support.", url="https://github.com/pulseengine/timedate-mcp", icon="🕐", badge="purple", label="Server") }}
 
 </div>
 
@@ -48,12 +64,12 @@ template = "section.html"
 
 <div class="grid">
 
-{{ project_card(name="thrum", desc="Gate-based pipeline orchestrator for autonomous AI-driven development.", url="https://github.com/pulseengine/thrum", icon="🎵", badge="amber") }}
+{{ project_card(name="temper", desc="GitHub App that hardens repositories to organizational standards.", url="https://github.com/pulseengine/temper", icon="🛡️", badge="red", label="Governance") }}
 
-{{ project_card(name="temper", desc="GitHub App that hardens repositories to organizational standards.", url="https://github.com/pulseengine/temper", icon="🛡️", badge="red") }}
+{{ project_card(name="wasm-component-examples", desc="Working examples for Component Model development in C, C++, Go, and Rust.", url="https://github.com/pulseengine/wasm-component-examples", icon="📝", badge="accent", label="Examples") }}
 
-{{ project_card(name="wasm-component-examples", desc="Working examples for Component Model development in C, C++, Go, and Rust.", url="https://github.com/pulseengine/wasm-component-examples", icon="📝", badge="accent") }}
+{{ project_card(name="bazel-file-ops-component", desc="WebAssembly-based cross-platform file operations for Bazel builds. Dual TinyGo and Rust implementations.", url="https://github.com/pulseengine/bazel-file-ops-component", icon="📂", badge="cyan", label="Build") }}
 
-{{ project_card(name="moonbit_checksum_updater", desc="Native MoonBit checksum management with GitHub API integration.", url="https://github.com/pulseengine/moonbit_checksum_updater", icon="🔢", badge="cyan") }}
+{{ project_card(name="moonbit_checksum_updater", desc="Native MoonBit checksum management with GitHub API integration.", url="https://github.com/pulseengine/moonbit_checksum_updater", icon="🔢", badge="cyan", label="Build") }}
 
 </div>

--- a/sass/_glass.scss
+++ b/sass/_glass.scss
@@ -137,7 +137,7 @@
 }
 
 .intro-block {
-  h3 {
+  h3, &__heading {
     font-size: 1.15rem;
     margin-bottom: 0.75rem;
     color: $text;

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@
   <section class="page-section intro-section">
     <div class="intro-columns">
       <div class="intro-block glass-card">
-        <h3>What is PulseEngine?</h3>
+        <h2 class="intro-block__heading">What is PulseEngine?</h2>
         <p>
           A complete WebAssembly Component Model engine built in Rust. Interpret
           components directly, fuse multiple components into one, optimize them,
@@ -41,7 +41,7 @@
         </p>
       </div>
       <div class="intro-block glass-card">
-        <h3>Where to find things</h3>
+        <h2 class="intro-block__heading">Where to find things</h2>
         <ul class="link-list">
           <li>
             <a href="https://github.com/pulseengine" rel="noopener">GitHub org</a>
@@ -101,7 +101,7 @@
   <section class="page-section">
     <h2 class="section-heading">Beyond the Pipeline</h2>
     <p style="margin-bottom: 1.5rem;">
-      The core pipeline is backed by build rules, verification tooling, AI infrastructure, and developer tools.
+      The core pipeline is backed by safety-critical systems tooling, build rules, verification infrastructure, and AI tools.
       <a href="{{ get_url(path='@/projects/_index.md') }}">See all projects &rarr;</a>
     </p>
     <div class="grid">
@@ -120,20 +120,20 @@
         <div class="glass-card__desc">Rust framework for building Model Context Protocol servers and clients</div>
         <span class="badge badge--purple">AI</span>
       </a>
-      <a href="https://github.com/pulseengine/thrum" class="glass-card glass-card--link" rel="noopener">
-        <div class="glass-card__title">thrum</div>
-        <div class="glass-card__desc">Gate-based pipeline orchestrator for autonomous AI-driven development</div>
-        <span class="badge badge--amber">Tools</span>
+      <a href="https://github.com/pulseengine/gale" class="glass-card glass-card--link" rel="noopener">
+        <div class="glass-card__title">gale</div>
+        <div class="glass-card__desc">Formally verified Rust port of Zephyr RTOS kernel primitives for ASIL-D</div>
+        <span class="badge badge--green">Safety-Critical</span>
       </a>
-      <a href="https://github.com/pulseengine/temper" class="glass-card glass-card--link" rel="noopener">
-        <div class="glass-card__title">temper</div>
-        <div class="glass-card__desc">GitHub App that hardens repositories to organizational standards</div>
-        <span class="badge badge--red">Tools</span>
+      <a href="https://github.com/pulseengine/spar" class="glass-card glass-card--link" rel="noopener">
+        <div class="glass-card__title">spar</div>
+        <div class="glass-card__desc">AADL v2.2 architecture analysis toolchain with 30+ pluggable analyses</div>
+        <span class="badge badge--accent">Safety-Critical</span>
       </a>
-      <a href="https://github.com/pulseengine/wasi-mcp" class="glass-card glass-card--link" rel="noopener">
-        <div class="glass-card__title">wasi-mcp</div>
-        <div class="glass-card__desc">Proposed WASI API for Model Context Protocol, targeting WASI 0.3</div>
-        <span class="badge badge--purple">AI</span>
+      <a href="https://github.com/pulseengine/rivet" class="glass-card glass-card--link" rel="noopener">
+        <div class="glass-card__title">rivet</div>
+        <div class="glass-card__desc">Schema-driven SDLC artifact manager for requirements traceability</div>
+        <span class="badge badge--amber">Safety-Critical</span>
       </a>
     </div>
   </section>

--- a/templates/shortcodes/project_card.html
+++ b/templates/shortcodes/project_card.html
@@ -2,5 +2,5 @@
   {% if icon %}<div class="project-card__icon">{{ icon }}</div>{% endif %}
   <div class="glass-card__title">{{ name }}</div>
   <div class="glass-card__desc">{{ desc }}</div>
-  {% if badge %}<span class="badge badge--{{ badge }}">{{ badge | title }}</span>{% endif %}
+  {% if badge %}<span class="badge badge--{{ badge }}">{% if label %}{{ label }}{% else %}{{ badge | title }}{% endif %}</span>{% endif %}
 </a>


### PR DESCRIPTION
## Summary
- Add new **Safety-Critical Systems** section with gale, spar, rivet
- Add `rules_lean`, `template-mcp-server`, `timedate-mcp`, `bazel-file-ops-component`
- Remove archived `thrum` and `wasi-mcp` references
- Fix badge labels to show semantic names (Fusion, Optimizer, etc.) instead of raw color names
- Fix heading hierarchy skip (h1 -> h3) for accessibility compliance
- Update "Beyond the Pipeline" homepage section with safety-critical projects

## Test plan
- [ ] `zola build` passes without errors
- [ ] Homepage renders correctly with proper heading hierarchy
- [ ] Projects page shows all 21 repos with semantic badge labels
- [ ] No console errors in browser
- [ ] All links resolve to non-archived repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)