### PR TITLE
fix: rewrite rivet blog post — AI agent angle, half the length

### DIFF
--- a/content/blog/2026-03-15-rivet-v0.1.0.md
+++ b/content/blog/2026-03-15-rivet-v0.1.0.md
@@ -1,6 +1,6 @@
 +++
-title = "rivet v0.1.0: traceability for safety-critical systems"
-description = "rivet keeps requirements, architecture, and safety analysis as YAML in git — then validates everything. We explain why we built it, how we use it, and what ships in v0.1.0."
+title = "rivet: because AI agents don't remember why"
+description = "AI agents can implement a feature in minutes. They cannot tell an auditor which requirement it satisfies. rivet keeps that chain intact — requirements to tests to evidence, as YAML in git, validated on every commit."
 date = 2026-03-15
 [taxonomies]
 tags = ["rivet", "deep-dive"]
@@ -8,148 +8,66 @@ authors = ["Ralf Anton Beier"]
 +++
 
 {% insight() %}
-Safety standards require traceability — a documented chain from requirement to test to deployed artifact. Most teams track this in spreadsheets, external databases, or heavyweight ALM tools that live outside the repository. rivet keeps the entire traceability model as YAML files in git, validated on every commit. The artifacts travel with the code they describe.
+The faster you can produce code, the more important it becomes to prove *why* that code exists. rivet keeps the chain from requirement to test to evidence as YAML in git — machine-readable, agent-writable, validated in CI. When an auditor asks "show me the requirement for this function", the answer is a command, not a meeting.
 {% end %}
 
-## Why we need rivet
+## The problem
 
-PulseEngine builds a formally verified WebAssembly pipeline for safety-critical systems. That means we are targeting environments governed by ISO 26262 (automotive), DO-178C (aerospace), and IEC 62304 (medical devices). These standards share a common demand: **every requirement must trace to a design, every design to a test, and every test result must be recorded and auditable**.
+An AI agent can implement a feature, write the tests, and open a pull request in under ten minutes. What it does not do — what no agent does today — is maintain the traceability chain that safety standards demand. ISO 26262 does not care how fast you shipped. It asks: which requirement does this satisfy? Where is the test? Where is the evidence that the test passed on the version you released?
 
-We looked at the available tools. Enterprise ALM systems like Polarion and DOORS work, but they live outside the repository, require server infrastructure, and introduce a parallel source of truth that drifts from the code. Spreadsheets work until they do not — and they break the moment two people edit them at the same time. None of these options let you validate traceability in CI the way you validate code.
+These questions are not optional in automotive, aerospace, or medical devices. They are the difference between a product that ships and one that does not.
 
-We needed something different: traceability artifacts as text files, version-controlled alongside the source code, validated automatically. So we built rivet.
+Most teams track traceability in systems that live outside the codebase — databases, spreadsheets, proprietary ALM tools. That worked when humans wrote every artifact by hand. It breaks when agents produce code faster than anyone can update a separate tracking system. The traceability model drifts from the code within hours.
 
-## What rivet does
+## rivet's answer
 
-rivet is a schema-driven SDLC artifact manager. You define your artifact types, link types, and traceability rules in YAML schemas. Then you write your requirements, architecture decisions, test specifications, and safety analysis as YAML files in the same repository. rivet validates the whole model:
-
-- Every required link exists (a requirement has a test, a hazard has a mitigation)
-- No broken references
-- No orphaned artifacts
-- Coverage percentages per traceability rule
-- Schema-defined field constraints and lifecycle states
-
-The key idea: **schemas are composable**. rivet ships with built-in schemas for common safety workflows — you pick the ones you need and they merge together:
-
-| Schema | Domain | Artifact types |
-|--------|--------|----------------|
-| `common` | Shared | Base link types: satisfies, verifies, derives-from, mitigates |
-| `dev` | General | Requirements, decisions, features |
-| `stpa` | Safety analysis | Losses, hazards, control actions, UCAs, scenarios, constraints |
-| `aspice` | Automotive SPICE | 14 types spanning the V-model |
-| `cybersecurity` | Automotive | TARA, attack paths, security requirements |
-| `aadl` | Architecture | Integration with spar for AADL models |
-| `score` | Certification | Safety case metamodel, evidence items |
-
-A project picks the schemas it needs in `rivet.yaml`:
+Keep the artifacts next to the code. Requirements, design decisions, safety analysis, test specifications — all as YAML files in the same git repository. rivet validates the links between them on every commit:
 
 ```yaml
-schemas:
-  - schemas/common.yaml
-  - schemas/dev.yaml
-  - schemas/stpa.yaml
-```
-
-Then writes artifacts:
-
-```yaml
-# artifacts/requirements.yaml
 - id: REQ-001
   type: requirement
   title: Component fusion preserves semantics
-  description: >
-    meld's output must be observationally equivalent to the
-    input components when executed on any conforming runtime.
   status: approved
   links:
     - target: TST-001
       type: verifies
 ```
 
-And validates:
-
 ```bash
 $ rivet validate
-Loaded 3 schemas, 42 artifacts
-  Requirements: 12 (all linked)
-  Decisions: 6
-  Features: 24
   Coverage: 100% (12/12 requirements traced to tests)
   Errors: 0
-  Warnings: 0
 ```
 
-## How we use it
+If an agent adds a feature without linking it to a requirement, CI fails. If a requirement exists without a test, rivet reports the gap. The traceability model is validated the same way the code is — automatically, on every push.
 
-rivet dogfoods itself. The rivet repository tracks its own development lifecycle — requirements, design decisions, features, and verification status — as artifacts validated by rivet:
+This matters for agents specifically: an agent can run `rivet add`, `rivet link`, and `rivet validate` as part of its workflow. The traceability chain becomes something agents maintain, not something humans reconstruct after the fact.
 
-```
-rivet/
-  rivet.yaml             # project config
-  schemas/               # dev + stpa schemas
-  artifacts/
-    requirements.yaml    # 12 requirements
-    decisions.yaml       # 6 design decisions
-    features.yaml        # 71 features (68 approved, 3 draft)
-    architecture.yaml    # architecture artifacts
-    verification.yaml    # verification links
-  safety/stpa/           # STPA analysis
-```
+## What we use it for
 
-Every commit runs `rivet validate` in CI. Every pull request includes a traceability check. The compliance report — the HTML dashboard showing coverage, matrices, and verification status — is generated as a release artifact and published to [pulseengine.eu/reports](/reports/).
+We build a formally verified WebAssembly pipeline for safety-critical systems. That means every component in PulseEngine needs to carry its own traceability. rivet manages this — and it starts by managing itself:
 
-This is not just a demonstration. gale, our formally verified port of Zephyr RTOS kernel primitives, already uses rivet for ASPICE traceability across 268 artifacts with 97% coverage. As more PulseEngine components reach release maturity, each will carry its own rivet-managed artifact set.
+- **rivet** tracks its own 344 artifacts, 71 features, 100% traceability coverage
+- **gale** (our Zephyr RTOS kernel port) tracks 268 ASPICE artifacts at 97% coverage
+- Each release publishes a compliance report to [pulseengine.eu/reports](/reports/)
 
-## What ships in v0.1.0
+rivet ships with schemas for STPA, Automotive SPICE, cybersecurity (TARA), and a lightweight dev schema. Pick what you need, combine them, validate.
 
-22 CLI commands. 402 tests. 344 dogfood artifacts. The highlights:
+## v0.1.0
 
-**Core validation engine** — schema loading, artifact parsing, link graph construction (via petgraph), traceability rule evaluation, coverage computation. The validation is incremental via salsa — on a warm cache, re-validation after a single artifact change takes milliseconds.
+22 CLI commands. `rivet validate` checks links, coverage, and schema rules. `rivet serve` runs an interactive dashboard. `rivet export --format html` produces a self-contained static report. `rivet impact REQ-001` shows everything downstream of a change. `rivet add` and `rivet link` let agents maintain artifacts from the command line.
 
-**STPA workflow** — first-class support for Systems-Theoretic Process Analysis. Losses, hazards, control actions, unsafe control actions (UCAs), loss scenarios, and controller constraints — with completeness rules that check the full STPA analysis chain.
-
-**Interactive dashboard** — `rivet serve` runs an HTMX-powered dashboard with artifact browsing, traceability matrices, coverage reports, interactive graphs, verification tracking, document rendering, and source code viewing. No JavaScript framework — the entire UI is server-rendered HTML with HTMX for navigation.
-
-**HTML export** — `rivet export --format html` generates a self-contained static version of the dashboard. All CSS embedded, all links relative, works offline. A `config.js` script tag enables runtime customization (homepage link, version switcher) when the export is hosted on a website.
-
-**Artifact mutation** — `rivet add`, `rivet modify`, `rivet remove`, `rivet link`, `rivet unlink`. Edit artifacts from the command line without touching YAML by hand. Useful for scripting and CI.
-
-**Impact analysis** — `rivet impact REQ-001` traces forward through the link graph to show every artifact affected by a change to a given requirement.
-
-**Cross-repository linking** — artifacts in one repository can reference artifacts in another. rivet resolves these at validation time, enabling shared components to maintain traceability across project boundaries.
-
-**Formal verification** — rivet includes Kani bounded model checking proofs, Verus specifications, and Rocq theorems for core data structures. This is the beginning of rivet verifying itself.
-
-## What comes next
-
-rivet v0.1.0 is a foundation. The roadmap includes:
-
-- **ReqIF import/export** — interchange with Polarion, DOORS, and other ALM tools that speak ReqIF XML. Teams migrating from existing tools can import their artifacts into rivet and keep working in git.
-- **OSLC sync** — bidirectional synchronization with OSLC-compatible tools for organizations that need to maintain both a git-native and a traditional ALM view.
-- **WASM adapter runtime** — pluggable format adapters as WebAssembly components, so custom import/export formats do not require rebuilding rivet.
-- **Baseline management** — named sets of artifact versions that represent a release, enabling delta comparisons between baselines.
-
-## Try it
+402 tests. Cross-repository linking. Incremental validation. Kani proofs and Verus specs on core data structures.
 
 ```bash
-# Clone and build
 git clone https://github.com/pulseengine/rivet
-cd rivet
-cargo build --release
-
-# Validate rivet's own artifacts
+cd rivet && cargo build --release
 ./target/release/rivet validate
-
-# Launch the dashboard
-./target/release/rivet serve
-# Open http://localhost:3000
-
-# Export a static compliance report
-./target/release/rivet export --format html --output compliance/
+./target/release/rivet serve  # http://localhost:3000
 ```
 
-The [rivet repository](https://github.com/pulseengine/rivet) is the best working example — it tracks its own development using the same schemas and workflows that downstream projects will use.
+The [repository](https://github.com/pulseengine/rivet) is the best example — it tracks its own development with the same schemas downstream projects will use.
 
 ---
 
-*rivet is part of [PulseEngine](/) — a formally verified WebAssembly Component Model engine for safety-critical systems. Meld fuses. Loom weaves. Synth transpiles. Kiln fires. Sigil seals. Rivet binds.*
+*Meld fuses. Loom weaves. Synth transpiles. Kiln fires. Sigil seals. Rivet binds.*


### PR DESCRIPTION
## Summary
Rewrites the rivet v0.1.0 blog post from a feature dump into a compelling argument:

**Hook**: AI agents produce code fast — but they don't maintain the traceability chain safety standards demand. rivet makes that chain machine-readable and agent-writable.

**Cut**: 155 lines → 75 lines. Removed schema table, directory tree listing, verbose feature descriptions, and roadmap section.

**Kept**: The core "why", one YAML example, one CLI example, what we use it for (dogfooding + gale), and a tight v0.1.0 summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)