### PR TITLE
feat: add spar to compliance reports manifest

### DIFF
--- a/reports.toml
+++ b/reports.toml
@@ -11,6 +11,11 @@ repo = "pulseengine/rivet"
 asset_pattern = "{name}-v{version}-compliance-report.tar.gz"
 exclude = ["*-rc*", "*-alpha*"]
 
+[projects.spar]
+repo = "pulseengine/spar"
+asset_pattern = "{name}-v{version}-compliance-report.tar.gz"
+exclude = ["*-rc*", "*-alpha*"]
+
 [projects.gale]
 repo = "pulseengine/gale"
 asset_pattern = "{name}-v{version}-compliance-report.tar.gz"


### PR DESCRIPTION
## Summary
Add spar to `reports.toml` so its compliance report (from v0.1.0 release) gets picked up by fetch-reports.

## Test plan
- [x] `spar-v0.1.0-compliance-report.tar.gz` exists in the v0.1.0 release
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)