### PR TITLE
fix: version switcher 404 in compliance reports

### DIFF
--- a/tools/fetch-reports/src/main.rs
+++ b/tools/fetch-reports/src/main.rs
@@ -348,11 +348,12 @@ fn write_config_js(
     for (i, v) in all_versions.iter().enumerate() {
         let comma = if i + 1 < all_versions.len() + 1 { "," } else { "" }; // +1 for latest
         version_entries.push_str(&format!(
-            "    {{ label: \"v{v}\", path: \"../{v}/compliance/\" }}{comma}\n"
+            "    {{ label: \"v{v}\", path: \"../../{v}/compliance/\" }}{comma}\n"
         ));
     }
     // Add "latest" entry (always last, no trailing comma).
-    version_entries.push_str("    { label: \"latest\", path: \"../latest/compliance/\" }\n");
+    // Paths go up twice: out of compliance/, out of <version>/, into <target>/.
+    version_entries.push_str("    { label: \"latest\", path: \"../../latest/compliance/\" }\n");
 
     let content = format!(
         "var RIVET_EXPORT = {{\n  \


### PR DESCRIPTION
## Summary
Fix relative paths in generated `config.js` — version switcher was navigating to `../latest/compliance/` which resolves incorrectly from inside `compliance/`. Changed to `../../latest/compliance/`.

## Root cause
`config.js` lives at `spar/0.1.0/compliance/config.js`. Relative path `../latest/compliance/` goes up to `spar/0.1.0/` then into `latest/compliance/` → `spar/0.1.0/latest/compliance/` (404). Correct path is `../../latest/compliance/` which goes up to `spar/` then into `latest/compliance/`.

## Test plan
- [x] Build passes
- [ ] Version switcher navigates correctly after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)