### PR TITLE
feat: verification guide and formal verification blog post

### DIFF
--- a/content/blog/2026-03-15-formal-verification-ai-agents.md
+++ b/content/blog/2026-03-15-formal-verification-ai-agents.md
@@ -1,0 +1,143 @@
++++
+title = "Formal verification just became practical — AI agents changed the economics"
+description = "Formal verification was too expensive for most teams. AI agents collapse the effort. Here is what works, what is still open, and how we verify kernel code with Verus, Rocq, and Lean in CI."
+date = 2026-03-15T20:00:00+00:00
+
+[taxonomies]
+tags = ["verification", "deep-dive"]
+authors = ["Ralf Anton Beier"]
++++
+
+{% insight() %}
+Formal verification was a craft practiced at a handful of universities and research labs. The barrier was never the math — it was the effort. AI agents collapse that effort. The same agents that write code can write proof annotations, and the solver checks them in seconds. The question shifts from "can we afford to prove this" to "what remains to be solved."
+{% end %}
+
+## The shift
+
+For decades, formal verification was reserved for projects with extraordinary budgets and timelines. seL4 took a decade of PhD students writing Isabelle/HOL proofs. CompCert took years. The rest of us tested and hoped.
+
+Two things changed in 2025:
+
+First, [Verus](https://github.com/verus-lang/verus) matured into a practical verification tool for Rust — not a research prototype, a tool that two of three best papers at OSDI 2024 were built on. Microsoft and Amazon use it in production. You write specifications as Rust code (`requires`, `ensures`), and an SMT solver (Z3) checks them exhaustively.
+
+Second, AI agents learned to write these specifications. [AutoVerus](https://github.com/microsoft/verus-proof-synthesis) (Microsoft, ICLR 2025) achieves 91.3% success rate generating Verus proofs automatically. [AlphaVerus](https://github.com/cmu-l3/alphaverus) (CMU, ICML 2025) bootstraps verified code by translating from Dafny to Verus with self-improvement. [Lean Copilot](https://github.com/lean-dojo/LeanCopilot) automates 74.2% of proof steps in Lean. [Strat2Rocq](https://arxiv.org/abs/2510.10131) extracts reusable proof lemmas from LLM reasoning, improving CoqHammer's success rate by 13.4%.
+
+Martin Kleppmann [wrote in December 2025](https://martin.kleppmann.com/2025/12/08/ai-formal-verification.html): "AI will make formal verification go mainstream." The POPL 2026 conference in Rennes dedicated an [entire workshop](https://popl26.sigplan.org/home/dafny-2026) to AI-assisted verification. The academic consensus is forming.
+
+I wanted to see if this holds in practice.
+
+## What I actually do
+
+I use formal verification on [gale](https://github.com/pulseengine/gale), a Rust port of Zephyr RTOS kernel primitives targeting ASIL-D automotive safety. AI agents write the code and the proofs. Multiple verification tools check the results. CI validates everything on every commit.
+
+The verification stack, honestly:
+
+**Three independent proof systems:**
+- **Verus** (SMT/Z3) — functional correctness. Every public function has `requires`/`ensures` contracts. The solver checks all inputs exhaustively.
+- **Rocq** (theorem prover, formerly Coq) — independent proof of the same properties using a fundamentally different technique. Zero admitted lemmas.
+- **Lean** — third proof track. Three proof systems means no single tool's soundness bug can propagate undetected.
+
+**Bounded and runtime checking:**
+- **Kani** — bounded model checking. Exhaustive state space exploration within finite bounds.
+- **Miri** — undefined behavior detection.
+- **Proptest** — property-based testing with random operation sequences.
+- **Fuzz testing** — coverage-guided mutation.
+- **Mutation testing** — verifies that tests actually catch bugs.
+- **Differential specs** — POSIX and FreeRTOS reference models validate specification independence.
+- **Sanitizers** — address, thread, and leak sanitizers.
+
+**Integration testing:**
+- 36 Zephyr test suites on multiple emulated boards (Cortex-M3, M4F, M33, Cortex-R5).
+
+All of this runs in CI. All of it traces through [rivet](https://github.com/pulseengine/rivet) from requirement to proof to test to evidence.
+
+This is comprehensive. It is also not complete — there are open questions I have not solved yet.
+
+## The Rust subset problem
+
+The hardest part is not writing proofs. It is writing Rust code that all verification tools accept simultaneously.
+
+Verus accepts a subset of Rust — no trait objects, no closures in proof context, overflow checked by default. The `coq_of_rust` translator for Rocq accepts a different subset — no async, simpler pattern matching, explicit types preferred. Kani accepts most Rust but has its own limitations.
+
+The solution: write the source once with Verus annotations, then use `verus-strip` (a tool in gale) to produce plain Rust without verification syntax. The stripped version feeds into cargo test, Kani, Miri, coq_of_rust, and everything else.
+
+```
+src/sem.rs            ← Verus-annotated source (single source of truth)
+  ├── verus! { }      ← Verus verifies this
+  └── verus-strip ──→ plain/src/sem.rs  ← plain Rust
+                        ├── cargo test
+                        ├── cargo kani
+                        ├── cargo miri
+                        └── coq_of_rust → proofs/*.v
+```
+
+The intersection of what all tools accept is narrower than any single tool, but it covers the patterns you actually need for kernel primitives: structs, enums, match, if/else, Result, Option, checked arithmetic, impl blocks. Getting agents to consistently write to this intersection is an ongoing challenge — they tend to reach for language features that one or another tool rejects.
+
+## What works for proofs
+
+From AutoVerus's research and my experience:
+
+**Start with the invariant.** Every data structure needs an `inv()` spec function that captures what must always be true. Every operation proves it preserves the invariant.
+
+```rust
+pub open spec fn inv(&self) -> bool {
+    self.limit > 0 && self.count <= self.limit
+}
+```
+
+**Let Z3 try first.** Most proof obligations are simpler than they look. Write the spec, run Verus, see if it passes without manual proof steps.
+
+**Add assert breadcrumbs when it does not.** Intermediate assertions guide the solver:
+
+```rust
+assert(self.count < self.limit);       // establish bound
+assert(self.count + 1 <= self.limit);  // then increment is safe
+```
+
+**Classify the error, apply the matching fix.** Verus error types have known repair strategies — `PreCondFail` means the caller's context is insufficient, `InvFailEnd` means the loop body breaks the invariant, `ArithmeticFlow` means a bound is missing. Targeted fixes beat random attempts.
+
+For Rocq: `lia` solves most integer goals. `unfold; auto` handles structural proofs. Strat2Rocq found that 42.5% of proof improvements come from lemmas that let CoqHammer skip induction — if you can state a closed-form intermediate lemma, do it.
+
+## Bazel rules for reproducibility
+
+I maintain Bazel rules for each verification tool so that proofs are hermetic and reproducible:
+
+- [rules_verus](https://github.com/pulseengine/rules_verus) — `verus_test` rule, pre-built Verus binaries with SHA-256 verification
+- [rules_rocq_rust](https://github.com/pulseengine/rules_rocq_rust) — `rocq_library` + `coq_of_rust` integration via hermetic Nix toolchains
+- [rules_lean](https://github.com/pulseengine/rules_lean) — `lean_proof_test` with Mathlib and Aeneas support
+
+A single `bazel test //...` runs all proof tracks. No local tool installation required.
+
+## What is still open
+
+I want to be honest about what this approach does not yet solve.
+
+**MC/DC and structural coverage.** ISO 26262 recommends MC/DC for the highest ASIL levels. MC/DC was designed for C — measure which boolean conditions affect decision outcomes. A [joint paper by the German Aerospace Center and Ferrous Systems](https://arxiv.org/abs/2409.08708) investigated how MC/DC applies to Rust and found that it *is* applicable, but needs modification. Rust's pattern matching compiles to decisions that contain implicit conditions not visible in source code. The `?` operator desugars to hidden match expressions. Refutable patterns need to be treated as decisions with sub-conditions.
+
+The [Safety-Critical Rust Consortium](https://rustfoundation.org/safety-critical-rust-consortium/) — which includes Ferrous Systems, Arm, AdaCore, Toyota, and others — is [working on MC/DC support as a 2026 Rust Project Goal](https://blog.rust-lang.org/2026/01/14/what-does-it-take-to-ship-rust-in-safety-critical/). An earlier compiler implementation was removed due to maintenance concerns. The consortium is approaching it again with shared ownership between industry and the Rust project. This is an active area of work, not a solved problem.
+
+I believe mathematical proofs of functional correctness provide strictly stronger evidence than any coverage metric — a proof covers all inputs, MC/DC covers only tested inputs. But this is a direction I am working toward, not a claim I can make today. The standards community and certification bodies have not yet accepted formal proofs as a replacement for structural coverage. That conversation is starting.
+
+**Tool qualification.** Three independent proof systems (Verus, Rocq, Lean) checking the same properties gives high confidence that no single tool's bug can cause a false positive. This supports a TCL1 (Tool Confidence Level 1) argument — but no assessor has evaluated this specific combination yet. The argument is sound in principle; it has not been tested in a certification audit.
+
+**coq_of_rust maturity.** The Rust → Rocq translation is improving but not complete. Complex Rust patterns sometimes produce Rocq code that is difficult to reason about. The monadic DSL that `coq_of_rust` generates requires proof strategies that are specific to its output format.
+
+**Specification completeness.** Formal proofs are only as good as their specifications. A correct proof of an incomplete spec gives false confidence. Writing complete specifications requires deep domain understanding — AI agents can write *syntactically valid* specs faster than humans, but *semantically complete* specs still need human review.
+
+## The economics, honestly
+
+The old economics: formal verification requires specialized researchers, costs $1M+, takes years. Practical only for projects where failure means loss of life.
+
+The new economics: AI agents write proof annotations. Solvers check them in seconds. CI runs all verification tracks on every commit. The marginal cost of verifying a new function is minutes, not months.
+
+This does not make verification free. Writing good specifications still requires understanding the domain. Getting code into the intersection of all verification tools still takes care. Debugging a failed proof still needs insight. The open questions above are real and require work to resolve.
+
+But the effort dropped by orders of magnitude. The projects that could never afford formal verification — most automotive, most medical devices, most industrial control — now have a practical path. The tools exist. The agents can use them. The open questions are tractable.
+
+The proof is not in a paper. It is in the CI log.
+
+---
+
+*A detailed reference for agents and developers working with these tools is available as the [Verification Guide](/guides/VERIFICATION-GUIDE/) ([download as Markdown](/guides/VERIFICATION-GUIDE.md)). It covers error tables, proof tactics, the Rust subset intersection, and Bazel rules. We update it as we learn what works — if something is wrong or missing, [open an issue](https://github.com/pulseengine/pulseengine.eu/issues).*
+
+*This post is part of [PulseEngine](/) — a formally verified WebAssembly Component Model engine for safety-critical systems.*

--- a/content/guides/VERIFICATION-GUIDE/index.md
+++ b/content/guides/VERIFICATION-GUIDE/index.md
@@ -1,0 +1,436 @@
++++
+title = "Formal Verification Guide for AI Agents"
+description = "Practical reference for Verus, Rocq, Lean, and Kani verification across PulseEngine projects"
+template = "page.html"
++++
+
+
+Reference document for AI agents working on PulseEngine projects that use
+Verus, Rocq, Lean, or Kani for formal verification. Link to this from your
+project's AGENTS.md or CLAUDE.md.
+
+> Based on findings from AutoVerus (Microsoft, ICLR 2025), AlphaVerus (CMU,
+> ICML 2025), Strat2Rocq (2025), Lean Copilot, and the VeriCoding benchmark.
+
+---
+
+## General Principles
+
+1. **Get the spec right before attempting proofs.** A wrong `requires`/`ensures`
+   wastes all downstream effort. Write the spec, review it, then prove it.
+2. **Try the simple thing first.** Most proofs are simpler than they look.
+   Let the solver attempt it before adding manual proof steps.
+3. **Generate multiple candidates.** If a proof attempt fails, try 3-5
+   different strategies before concluding the property is hard. Success
+   rate jumps from ~60% (single shot) to 91% (5 candidates + repair).
+4. **Classify the error, then apply the matching fix.** Don't guess randomly.
+   Each verifier error type has a known repair pattern (see tables below).
+5. **Code must satisfy all verification tracks simultaneously.** In gale,
+   the same source must: compile as plain Rust, pass Verus, translate through
+   coq_of_rust, and be analyzable by Kani. Write to the intersection.
+
+---
+
+## Verus (SMT / Z3)
+
+### Rust Subset Restrictions
+
+Verus accepts a subset of Rust inside `verus! { }` blocks:
+
+- **No trait objects** (`dyn Trait`) in verified code
+- **No closures** in proof context
+- **No async/await** in verified functions
+- **Integer arithmetic** is checked for overflow by default — `a + b` will
+  fail if overflow is possible. Use `checked_add`/`checked_sub` or prove
+  bounds via `requires`
+- **Use `as int`** in spec functions to lift to mathematical integers
+  (unbounded) for reasoning
+- **`Vec`** works but prefer fixed-size or ghost `Seq` for specifications
+- **`HashMap`/`BTreeMap`**: use `Map<K,V>` in spec, concrete type in exec
+- **Generics**: supported, but some trait bounds may not work in proof context
+
+### Writing Specifications
+
+```rust
+// Good: precise, minimal, testable
+pub fn give(&mut self) -> (result: bool)
+    requires old(self).inv(),
+    ensures
+        self.inv(),
+        result == (old(self).count < old(self).limit),
+        result ==> self.count == old(self).count + 1,
+        !result ==> self.count == old(self).count,
+```
+
+- Start with the **invariant** (`inv()`) — what must always be true
+- `requires` states what the caller must guarantee
+- `ensures` states what the function guarantees
+- Use `old(self)` to refer to pre-state in ensures
+- Keep specs **minimal** — don't over-specify implementation details
+
+### Error Types and Repair Strategies
+
+| Error | What It Means | Fix |
+|-------|--------------|-----|
+| `AssertFail` | An assertion can't be proven | Add intermediate `assert()` steps to guide Z3, or use `assert(...) by { lemma_call(); }` |
+| `PreCondFail` | Caller doesn't satisfy `requires` | Either strengthen the caller's proof context or weaken the precondition |
+| `InvFailFront` | Loop invariant doesn't hold on entry | Check that initial values before the loop satisfy the invariant |
+| `InvFailEnd` | Loop invariant doesn't hold after loop body | Usually a missing update or off-by-one; check every variable the invariant mentions |
+| `ArithmeticFlow` | Possible overflow/underflow | Add bounds to `requires`, use `checked_*` arithmetic, or prove bounds with `assert` |
+| `MismatchedType` | Type mismatch in proof context | Add explicit type casts or restructure to match expected types |
+| Solver timeout | Z3 can't decide within time limit | Break into smaller `assert` steps, add triggers, simplify quantifiers |
+
+### Proof Strategies (ordered by simplicity)
+
+1. **Let the solver try** — write spec, run Verus, see if it just works
+2. **Add assert breadcrumbs** — intermediate assertions that guide Z3:
+   ```rust
+   assert(self.count <= self.limit);  // help Z3 see the bound
+   assert(self.count + 1 <= self.limit);  // then the increment is safe
+   ```
+3. **Use `assert(...) by { ... }`** for explicit proof blocks:
+   ```rust
+   assert(result == expected) by {
+       reveal(some_opaque_fn);  // expose definition to solver
+   }
+   ```
+4. **Call lemmas** — factor reusable proof steps into separate `proof fn`:
+   ```rust
+   proof fn lemma_count_bounded(s: &Semaphore)
+       requires s.inv(),
+       ensures s.count <= s.limit,
+   { /* Z3 handles this */ }
+   ```
+5. **Add triggers** for quantified statements:
+   ```rust
+   forall|i: int| 0 <= i < self.len() ==> #[trigger] self.buf[i] != 0
+   ```
+6. **Use `decreases`** for recursive functions — must strictly decrease on a
+   well-founded measure
+
+### Common Patterns
+
+**Invariant preservation** (most common proof obligation):
+```rust
+pub fn operation(&mut self)
+    requires old(self).inv(),
+    ensures self.inv(),
+{
+    // ... modify state ...
+    // Z3 must see that inv() still holds
+}
+```
+
+**Bounded arithmetic** (gale kernel primitives):
+```rust
+requires
+    self.count < self.limit,  // explicitly bound before arithmetic
+ensures
+    self.count == old(self).count + 1,  // safe: bounded by requires
+```
+
+**Option/Result reasoning**:
+```rust
+ensures
+    match result {
+        Ok(v) => v.inv() && v.count == initial,
+        Err(e) => e == EINVAL && (limit == 0 || initial > limit),
+    }
+```
+
+---
+
+## Rocq (Coq Theorem Prover)
+
+### coq_of_rust Compatibility
+
+When writing Rust that must translate through `coq_of_rust`:
+
+- **No async/await**
+- **No complex trait bounds** with associated types
+- **Keep match arms simple** — deeply nested patterns may not translate
+- **Prefer explicit types** over inference where possible
+- **Avoid complex closures** — use named functions
+- The generated `.v` file uses a **monadic DSL** — proofs reason about
+  `M.run`, `M.bind`, `M.return`
+
+### Proof Tactics (ordered by reach-for-first)
+
+| Tactic | When To Use |
+|--------|------------|
+| `lia` | Linear integer arithmetic — handles most numeric proofs |
+| `auto` | Simple logical reasoning, constructor matching |
+| `unfold X; auto` | When the goal mentions a defined function — expand it first |
+| `unfold X; lia` | Numeric goals behind a definition |
+| `intros; destruct` | Case analysis on sum types, booleans |
+| `induction n; simpl; lia` | Inductive proofs on naturals/lists |
+| `omega` | Integer arithmetic (alternative to lia) |
+| `trivial` | Obvious goals (reflexivity, assumption) |
+
+### Proof Structure (from gale's existing proofs)
+
+```coq
+(* 1. Define the invariant *)
+Definition sem_inv (count limit : Z) : Prop :=
+  limit > 0 /\ 0 <= count /\ count <= limit.
+
+(* 2. Prove initialization establishes invariant *)
+Theorem init_establishes_invariant :
+  forall initial_count limit : Z,
+    limit > 0 -> 0 <= initial_count -> initial_count <= limit ->
+    sem_inv initial_count limit.
+Proof. intros. unfold sem_inv. auto. Qed.
+
+(* 3. Prove operations preserve invariant *)
+Theorem give_preserves_invariant :
+  forall count limit : Z,
+    sem_inv count limit -> count < limit ->
+    sem_inv (count + 1) limit.
+Proof. intros count limit [Hlim [Hge Hle]] Hlt. unfold sem_inv. lia. Qed.
+```
+
+### Strategies from Strat2Rocq Research
+
+- **Avoid induction when possible** — 42.5% of proof improvements come from
+  lemmas that let CoqHammer skip induction entirely. If you can state a
+  closed-form lemma, do it.
+- **Don't restate definitions as lemmas** — `Lemma foo : X = X.` is useless.
+  Good lemmas reformulate facts in ways the solver can exploit.
+- **Extract ~2 reusable lemmas per theorem** — look for intermediate facts
+  that appear in multiple proofs.
+- **Reformulate implications** — sometimes `A -> B` is hard but the
+  contrapositive `~B -> ~A` is easy. CoqHammer benefits from both forms.
+
+---
+
+## Lean 4
+
+### Proof Approach
+
+Lean proofs in PulseEngine are a third independent verification track.
+
+- **Use `simp` aggressively** — Lean's simplifier handles many goals
+- **`omega`** for integer arithmetic (like Rocq's `lia`)
+- **`decide`** for decidable propositions
+- **`cases`/`match`** for case analysis
+- **`induction`** when structural recursion is needed
+
+### Lean Copilot Integration
+
+If using Lean Copilot (github.com/lean-dojo/LeanCopilot):
+
+- `suggest_tactics` — shows candidate next steps
+- `search_proof` — finds complete multi-tactic proofs (74.2% success)
+- `select_premises` — retrieves useful lemmas from the library
+- Automates most mechanical proof steps; focus human/agent effort on the
+  remaining 25% that need domain knowledge
+
+---
+
+## Kani (Bounded Model Checking)
+
+### Harness Patterns
+
+```rust
+#[kani::proof]
+fn verify_sem_give_no_overflow() {
+    let count: u32 = kani::any();
+    let limit: u32 = kani::any();
+    kani::assume(limit > 0);
+    kani::assume(count <= limit);
+    kani::assume(count < limit);
+
+    let new_count = count + 1;  // Kani checks: can this overflow?
+    assert!(new_count <= limit);
+}
+```
+
+- **`kani::any()`** — symbolic value, Kani explores all possibilities
+- **`kani::assume()`** — constrain the search space (like requires)
+- **`assert!()`** — what must hold (like ensures)
+- Kani exhaustively checks within the bounded state space
+- Use for: absence of panics, arithmetic safety, FFI equivalence
+
+### FFI Equivalence Checking
+
+```rust
+#[kani::proof]
+fn verify_ffi_sem_give_matches() {
+    let count: u32 = kani::any();
+    let limit: u32 = kani::any();
+    kani::assume(limit > 0 && count <= limit);
+
+    let rust_result = Semaphore::give_logic(count, limit);
+    let ffi_result = gale_sem_count_give(count, limit);
+    assert_eq!(rust_result, ffi_result);
+}
+```
+
+---
+
+## Writing Code for All Tracks Simultaneously
+
+### The Intersection
+
+Code in gale must work across: plain Rust, Verus, coq_of_rust, and Kani.
+The safe intersection:
+
+| Feature | Plain Rust | Verus | coq_of_rust | Kani |
+|---------|-----------|-------|-------------|------|
+| Basic types (u32, bool, etc.) | ✓ | ✓ | ✓ | ✓ |
+| Structs with named fields | ✓ | ✓ | ✓ | ✓ |
+| Enums (simple) | ✓ | ✓ | ✓ | ✓ |
+| `match` (simple arms) | ✓ | ✓ | ✓ | ✓ |
+| `if/else` | ✓ | ✓ | ✓ | ✓ |
+| `Result<T, E>` | ✓ | ✓ | ✓ | ✓ |
+| `Option<T>` | ✓ | ✓ | ✓ | ✓ |
+| Checked arithmetic | ✓ | ✓ | ✓ | ✓ |
+| `impl` blocks | ✓ | ✓ | ✓ | ✓ |
+| Trait objects (`dyn`) | ✓ | ✗ | ✗ | ✓ |
+| Closures | ✓ | ✗ | ✗ | ✓ |
+| async/await | ✓ | ✗ | ✗ | ✗ |
+| Complex generics | ✓ | partial | partial | ✓ |
+| `unsafe` blocks | ✓ | ✗ | ✗ | ✓ |
+
+### Architecture Pattern
+
+```
+src/sem.rs          ← Verus-annotated source (single source of truth)
+  │
+  ├── verus! { }    ← Verus verifies this
+  │
+  └── verus-strip ──→ plain/src/sem.rs  ← plain Rust (auto-generated)
+                        │
+                        ├── cargo test   ← unit tests, proptest
+                        ├── cargo kani   ← bounded model checking
+                        ├── cargo miri   ← UB detection
+                        └── coq_of_rust  ← generates .v for Rocq proofs
+```
+
+The `verus-strip` tool removes all verification annotations, producing
+standard Rust that all other tools can consume.
+
+---
+
+## Bazel Rules
+
+PulseEngine provides Bazel rules for each verification tool, enabling
+hermetic, reproducible verification builds:
+
+- **[rules_verus](https://github.com/pulseengine/rules_verus)** — `verus_library` and `verus_test` rules. Downloads pre-built Verus binaries with SHA-256 verification. Cross-platform (macOS, Linux, Windows).
+- **[rules_rocq_rust](https://github.com/pulseengine/rules_rocq_rust)** — `rocq_library`, `rocq_proof_test`, and `rocq_rust_verified_library` rules. Hermetic Rocq 9.0 toolchain via Nix. Includes `coq_of_rust` integration for Rust → Rocq translation.
+- **[rules_lean](https://github.com/pulseengine/rules_lean)** — `lean_library`, `lean_proof_test`, and `lean_prebuilt_library` rules. Mathlib integration. Aeneas support for LLBC → Lean translation.
+
+### Example BUILD.bazel
+
+```starlark
+load("@rules_verus//verus:defs.bzl", "verus_test")
+load("@rules_rocq_rust//rocq:defs.bzl", "rocq_library", "rocq_proof_test")
+load("@rules_rocq_rust//coq_of_rust:defs.bzl", "rocq_rust_verified_library")
+
+# Track 1: Verus verification (SMT/Z3)
+verus_test(name = "verus_test", srcs = glob(["src/*.rs"]))
+
+# Track 2: Rocq — translate Rust to Rocq, then prove properties
+rocq_rust_verified_library(
+    name = "kernel_translated",
+    rust_sources = glob(["plain/src/*.rs"]),
+)
+
+rocq_library(
+    name = "kernel_proofs",
+    srcs = glob(["proofs/*.v"]),
+    deps = [":kernel_translated"],
+)
+
+rocq_proof_test(
+    name = "rocq_proof_test",
+    deps = [":kernel_proofs"],
+)
+```
+
+---
+
+## References
+
+- [AutoVerus](https://github.com/microsoft/verus-proof-synthesis) (Microsoft) — automated Verus proof generation, 91.3% success rate
+- [AlphaVerus](https://github.com/cmu-l3/alphaverus) (CMU) — self-improving Dafny → Verus translation
+- [Strat2Rocq](https://arxiv.org/abs/2510.10131) — lemma extraction from LLMs for CoqHammer, +13.4% improvement
+- [Lean Copilot](https://github.com/lean-dojo/LeanCopilot) — 74.2% proof step automation in Lean
+- [VeriCoding Benchmark](https://github.com/Beneficial-AI-Foundation/vericoding-benchmark) — 2,334 Verus tasks for testing proof generation
+- [Verus documentation](https://verus-lang.github.io/verus/)
+- [Rocq/Coq reference](https://rocq-prover.org/)
+- [Blog post: Formal verification just became practical](/blog/formal-verification-ai-agents/)
+
+---
+
+## Integrating Into Your Project
+
+### Step 1: Add to AGENTS.md (or CLAUDE.md)
+
+Add this section to your project's `AGENTS.md` or `CLAUDE.md` so that any AI agent working on the project knows about the verification guide:
+
+```markdown
+## Formal Verification
+
+This project uses formal verification. Before writing or modifying
+verified code, read the Verification Guide:
+
+  https://pulseengine.eu/guides/VERIFICATION-GUIDE.md
+
+Key rules:
+- Code must compile in the intersection of Verus, coq_of_rust, and Kani
+  (see the compatibility table in the guide)
+- Follow the error classification table when a proof fails — don't guess
+- Use `verus-strip` to produce plain Rust for non-Verus tools
+- Run `bazel test //...` or the equivalent cargo commands to verify all tracks
+
+If you encounter a verification pattern that does not match the guide —
+a proof strategy that fails, an error type not listed, or a Rust feature
+that should work but doesn't — open an issue:
+
+  https://github.com/pulseengine/pulseengine.eu/issues
+
+Tag it `verification-guide` and describe what you tried, what failed,
+and what you expected. This helps us improve the guide for everyone.
+```
+
+### Step 2: Reference from rivet artifacts (optional)
+
+If your project uses rivet for traceability, you can link verification
+artifacts to the guide:
+
+```yaml
+- id: FV-GUIDE-001
+  type: design-decision
+  title: Verification guide reference
+  description: >
+    Formal verification follows the PulseEngine Verification Guide.
+    Proof strategies, error handling, and Rust subset rules are
+    documented at pulseengine.eu/guides/VERIFICATION-GUIDE/
+  status: approved
+```
+
+### Step 3: Keep it current
+
+When you find something that works better than what the guide says,
+or something that no longer works, update the guide. It lives at:
+
+- Website (rendered): [pulseengine.eu/guides/VERIFICATION-GUIDE/](/guides/VERIFICATION-GUIDE/)
+- Source: `content/guides/VERIFICATION-GUIDE/index.md` in the pulseengine.eu repo
+- Downloadable: [/guides/VERIFICATION-GUIDE.md](/guides/VERIFICATION-GUIDE.md)
+
+---
+
+## Feedback and Updates
+
+This guide evolves as we learn what works. If you encounter:
+
+- Proof strategies that fail or produce false confidence
+- Verus/Rocq/Lean error patterns not documented here
+- Rust subset restrictions we missed
+- Better approaches than what we describe
+
+Open an issue at [github.com/pulseengine/pulseengine.eu](https://github.com/pulseengine/pulseengine.eu/issues) with the tag `verification-guide`. Whether you are a human or an AI agent, the feedback is valuable.
+
+*Last updated: March 2026*

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -1,0 +1,36 @@
++++
+title = "Guides"
+description = "Practical references for working with PulseEngine tools — designed for both humans and AI agents"
+template = "section.html"
++++
+
+## Verification Guide
+
+A practical reference for AI agents and developers working with Verus, Rocq, Lean, and Kani across PulseEngine projects.
+
+Covers the Rust subset intersection (what all verification tools accept simultaneously), error classification and repair strategies, proof tactics, Bazel rules for reproducible verification, and the `verus-strip` architecture for multi-track verification.
+
+Based on findings from AutoVerus (Microsoft), AlphaVerus (CMU), Strat2Rocq, and Lean Copilot.
+
+[Read the guide](/guides/VERIFICATION-GUIDE/) · [Download as Markdown](/guides/VERIFICATION-GUIDE.md)
+
+---
+
+### For AI agents
+
+Add this to your project's `AGENTS.md` or `CLAUDE.md`:
+
+```markdown
+## Formal Verification
+
+This project uses formal verification. Before writing or modifying
+verified code, read the Verification Guide:
+
+  https://pulseengine.eu/guides/VERIFICATION-GUIDE.md
+
+If you encounter a verification pattern that does not match the guide,
+open an issue at https://github.com/pulseengine/pulseengine.eu/issues
+with the tag `verification-guide`.
+```
+
+The guide includes a full integration section with copy-paste instructions and an optional rivet artifact template.

--- a/static/guides/VERIFICATION-GUIDE.md
+++ b/static/guides/VERIFICATION-GUIDE.md
@@ -1,0 +1,358 @@
+# Formal Verification Guide for AI Agents
+
+Reference document for AI agents working on PulseEngine projects that use
+Verus, Rocq, Lean, or Kani for formal verification. Link to this from your
+project's AGENTS.md or CLAUDE.md.
+
+> Based on findings from AutoVerus (Microsoft, ICLR 2025), AlphaVerus (CMU,
+> ICML 2025), Strat2Rocq (2025), Lean Copilot, and the VeriCoding benchmark.
+
+---
+
+## General Principles
+
+1. **Get the spec right before attempting proofs.** A wrong `requires`/`ensures`
+   wastes all downstream effort. Write the spec, review it, then prove it.
+2. **Try the simple thing first.** Most proofs are simpler than they look.
+   Let the solver attempt it before adding manual proof steps.
+3. **Generate multiple candidates.** If a proof attempt fails, try 3-5
+   different strategies before concluding the property is hard. Success
+   rate jumps from ~60% (single shot) to 91% (5 candidates + repair).
+4. **Classify the error, then apply the matching fix.** Don't guess randomly.
+   Each verifier error type has a known repair pattern (see tables below).
+5. **Code must satisfy all verification tracks simultaneously.** In gale,
+   the same source must: compile as plain Rust, pass Verus, translate through
+   coq_of_rust, and be analyzable by Kani. Write to the intersection.
+
+---
+
+## Verus (SMT / Z3)
+
+### Rust Subset Restrictions
+
+Verus accepts a subset of Rust inside `verus! { }` blocks:
+
+- **No trait objects** (`dyn Trait`) in verified code
+- **No closures** in proof context
+- **No async/await** in verified functions
+- **Integer arithmetic** is checked for overflow by default — `a + b` will
+  fail if overflow is possible. Use `checked_add`/`checked_sub` or prove
+  bounds via `requires`
+- **Use `as int`** in spec functions to lift to mathematical integers
+  (unbounded) for reasoning
+- **`Vec`** works but prefer fixed-size or ghost `Seq` for specifications
+- **`HashMap`/`BTreeMap`**: use `Map<K,V>` in spec, concrete type in exec
+- **Generics**: supported, but some trait bounds may not work in proof context
+
+### Writing Specifications
+
+```rust
+// Good: precise, minimal, testable
+pub fn give(&mut self) -> (result: bool)
+    requires old(self).inv(),
+    ensures
+        self.inv(),
+        result == (old(self).count < old(self).limit),
+        result ==> self.count == old(self).count + 1,
+        !result ==> self.count == old(self).count,
+```
+
+- Start with the **invariant** (`inv()`) — what must always be true
+- `requires` states what the caller must guarantee
+- `ensures` states what the function guarantees
+- Use `old(self)` to refer to pre-state in ensures
+- Keep specs **minimal** — don't over-specify implementation details
+
+### Error Types and Repair Strategies
+
+| Error | What It Means | Fix |
+|-------|--------------|-----|
+| `AssertFail` | An assertion can't be proven | Add intermediate `assert()` steps to guide Z3, or use `assert(...) by { lemma_call(); }` |
+| `PreCondFail` | Caller doesn't satisfy `requires` | Either strengthen the caller's proof context or weaken the precondition |
+| `InvFailFront` | Loop invariant doesn't hold on entry | Check that initial values before the loop satisfy the invariant |
+| `InvFailEnd` | Loop invariant doesn't hold after loop body | Usually a missing update or off-by-one; check every variable the invariant mentions |
+| `ArithmeticFlow` | Possible overflow/underflow | Add bounds to `requires`, use `checked_*` arithmetic, or prove bounds with `assert` |
+| `MismatchedType` | Type mismatch in proof context | Add explicit type casts or restructure to match expected types |
+| Solver timeout | Z3 can't decide within time limit | Break into smaller `assert` steps, add triggers, simplify quantifiers |
+
+### Proof Strategies (ordered by simplicity)
+
+1. **Let the solver try** — write spec, run Verus, see if it just works
+2. **Add assert breadcrumbs** — intermediate assertions that guide Z3:
+   ```rust
+   assert(self.count <= self.limit);  // help Z3 see the bound
+   assert(self.count + 1 <= self.limit);  // then the increment is safe
+   ```
+3. **Use `assert(...) by { ... }`** for explicit proof blocks:
+   ```rust
+   assert(result == expected) by {
+       reveal(some_opaque_fn);  // expose definition to solver
+   }
+   ```
+4. **Call lemmas** — factor reusable proof steps into separate `proof fn`:
+   ```rust
+   proof fn lemma_count_bounded(s: &Semaphore)
+       requires s.inv(),
+       ensures s.count <= s.limit,
+   { /* Z3 handles this */ }
+   ```
+5. **Add triggers** for quantified statements:
+   ```rust
+   forall|i: int| 0 <= i < self.len() ==> #[trigger] self.buf[i] != 0
+   ```
+6. **Use `decreases`** for recursive functions — must strictly decrease on a
+   well-founded measure
+
+### Common Patterns
+
+**Invariant preservation** (most common proof obligation):
+```rust
+pub fn operation(&mut self)
+    requires old(self).inv(),
+    ensures self.inv(),
+{
+    // ... modify state ...
+    // Z3 must see that inv() still holds
+}
+```
+
+**Bounded arithmetic** (gale kernel primitives):
+```rust
+requires
+    self.count < self.limit,  // explicitly bound before arithmetic
+ensures
+    self.count == old(self).count + 1,  // safe: bounded by requires
+```
+
+**Option/Result reasoning**:
+```rust
+ensures
+    match result {
+        Ok(v) => v.inv() && v.count == initial,
+        Err(e) => e == EINVAL && (limit == 0 || initial > limit),
+    }
+```
+
+---
+
+## Rocq (Coq Theorem Prover)
+
+### coq_of_rust Compatibility
+
+When writing Rust that must translate through `coq_of_rust`:
+
+- **No async/await**
+- **No complex trait bounds** with associated types
+- **Keep match arms simple** — deeply nested patterns may not translate
+- **Prefer explicit types** over inference where possible
+- **Avoid complex closures** — use named functions
+- The generated `.v` file uses a **monadic DSL** — proofs reason about
+  `M.run`, `M.bind`, `M.return`
+
+### Proof Tactics (ordered by reach-for-first)
+
+| Tactic | When To Use |
+|--------|------------|
+| `lia` | Linear integer arithmetic — handles most numeric proofs |
+| `auto` | Simple logical reasoning, constructor matching |
+| `unfold X; auto` | When the goal mentions a defined function — expand it first |
+| `unfold X; lia` | Numeric goals behind a definition |
+| `intros; destruct` | Case analysis on sum types, booleans |
+| `induction n; simpl; lia` | Inductive proofs on naturals/lists |
+| `omega` | Integer arithmetic (alternative to lia) |
+| `trivial` | Obvious goals (reflexivity, assumption) |
+
+### Proof Structure (from gale's existing proofs)
+
+```coq
+(* 1. Define the invariant *)
+Definition sem_inv (count limit : Z) : Prop :=
+  limit > 0 /\ 0 <= count /\ count <= limit.
+
+(* 2. Prove initialization establishes invariant *)
+Theorem init_establishes_invariant :
+  forall initial_count limit : Z,
+    limit > 0 -> 0 <= initial_count -> initial_count <= limit ->
+    sem_inv initial_count limit.
+Proof. intros. unfold sem_inv. auto. Qed.
+
+(* 3. Prove operations preserve invariant *)
+Theorem give_preserves_invariant :
+  forall count limit : Z,
+    sem_inv count limit -> count < limit ->
+    sem_inv (count + 1) limit.
+Proof. intros count limit [Hlim [Hge Hle]] Hlt. unfold sem_inv. lia. Qed.
+```
+
+### Strategies from Strat2Rocq Research
+
+- **Avoid induction when possible** — 42.5% of proof improvements come from
+  lemmas that let CoqHammer skip induction entirely. If you can state a
+  closed-form lemma, do it.
+- **Don't restate definitions as lemmas** — `Lemma foo : X = X.` is useless.
+  Good lemmas reformulate facts in ways the solver can exploit.
+- **Extract ~2 reusable lemmas per theorem** — look for intermediate facts
+  that appear in multiple proofs.
+- **Reformulate implications** — sometimes `A -> B` is hard but the
+  contrapositive `~B -> ~A` is easy. CoqHammer benefits from both forms.
+
+---
+
+## Lean 4
+
+### Proof Approach
+
+Lean proofs in PulseEngine are a third independent verification track.
+
+- **Use `simp` aggressively** — Lean's simplifier handles many goals
+- **`omega`** for integer arithmetic (like Rocq's `lia`)
+- **`decide`** for decidable propositions
+- **`cases`/`match`** for case analysis
+- **`induction`** when structural recursion is needed
+
+### Lean Copilot Integration
+
+If using Lean Copilot (github.com/lean-dojo/LeanCopilot):
+
+- `suggest_tactics` — shows candidate next steps
+- `search_proof` — finds complete multi-tactic proofs (74.2% success)
+- `select_premises` — retrieves useful lemmas from the library
+- Automates most mechanical proof steps; focus human/agent effort on the
+  remaining 25% that need domain knowledge
+
+---
+
+## Kani (Bounded Model Checking)
+
+### Harness Patterns
+
+```rust
+#[kani::proof]
+fn verify_sem_give_no_overflow() {
+    let count: u32 = kani::any();
+    let limit: u32 = kani::any();
+    kani::assume(limit > 0);
+    kani::assume(count <= limit);
+    kani::assume(count < limit);
+
+    let new_count = count + 1;  // Kani checks: can this overflow?
+    assert!(new_count <= limit);
+}
+```
+
+- **`kani::any()`** — symbolic value, Kani explores all possibilities
+- **`kani::assume()`** — constrain the search space (like requires)
+- **`assert!()`** — what must hold (like ensures)
+- Kani exhaustively checks within the bounded state space
+- Use for: absence of panics, arithmetic safety, FFI equivalence
+
+### FFI Equivalence Checking
+
+```rust
+#[kani::proof]
+fn verify_ffi_sem_give_matches() {
+    let count: u32 = kani::any();
+    let limit: u32 = kani::any();
+    kani::assume(limit > 0 && count <= limit);
+
+    let rust_result = Semaphore::give_logic(count, limit);
+    let ffi_result = gale_sem_count_give(count, limit);
+    assert_eq!(rust_result, ffi_result);
+}
+```
+
+---
+
+## Writing Code for All Tracks Simultaneously
+
+### The Intersection
+
+Code in gale must work across: plain Rust, Verus, coq_of_rust, and Kani.
+The safe intersection:
+
+| Feature | Plain Rust | Verus | coq_of_rust | Kani |
+|---------|-----------|-------|-------------|------|
+| Basic types (u32, bool, etc.) | ✓ | ✓ | ✓ | ✓ |
+| Structs with named fields | ✓ | ✓ | ✓ | ✓ |
+| Enums (simple) | ✓ | ✓ | ✓ | ✓ |
+| `match` (simple arms) | ✓ | ✓ | ✓ | ✓ |
+| `if/else` | ✓ | ✓ | ✓ | ✓ |
+| `Result<T, E>` | ✓ | ✓ | ✓ | ✓ |
+| `Option<T>` | ✓ | ✓ | ✓ | ✓ |
+| Checked arithmetic | ✓ | ✓ | ✓ | ✓ |
+| `impl` blocks | ✓ | ✓ | ✓ | ✓ |
+| Trait objects (`dyn`) | ✓ | ✗ | ✗ | ✓ |
+| Closures | ✓ | ✗ | ✗ | ✓ |
+| async/await | ✓ | ✗ | ✗ | ✗ |
+| Complex generics | ✓ | partial | partial | ✓ |
+| `unsafe` blocks | ✓ | ✗ | ✗ | ✓ |
+
+### Architecture Pattern
+
+```
+src/sem.rs          ← Verus-annotated source (single source of truth)
+  │
+  ├── verus! { }    ← Verus verifies this
+  │
+  └── verus-strip ──→ plain/src/sem.rs  ← plain Rust (auto-generated)
+                        │
+                        ├── cargo test   ← unit tests, proptest
+                        ├── cargo kani   ← bounded model checking
+                        ├── cargo miri   ← UB detection
+                        └── coq_of_rust  ← generates .v for Rocq proofs
+```
+
+The `verus-strip` tool removes all verification annotations, producing
+standard Rust that all other tools can consume.
+
+---
+
+## Bazel Rules
+
+PulseEngine provides Bazel rules for each verification tool, enabling
+hermetic, reproducible verification builds:
+
+- **[rules_verus](https://github.com/pulseengine/rules_verus)** — `verus_library` and `verus_test` rules. Downloads pre-built Verus binaries with SHA-256 verification. Cross-platform (macOS, Linux, Windows).
+- **[rules_rocq_rust](https://github.com/pulseengine/rules_rocq_rust)** — `rocq_library`, `rocq_proof_test`, and `rocq_rust_verified_library` rules. Hermetic Rocq 9.0 toolchain via Nix. Includes `coq_of_rust` integration for Rust → Rocq translation.
+- **[rules_lean](https://github.com/pulseengine/rules_lean)** — `lean_library`, `lean_proof_test`, and `lean_prebuilt_library` rules. Mathlib integration. Aeneas support for LLBC → Lean translation.
+
+### Example BUILD.bazel
+
+```starlark
+load("@rules_verus//verus:defs.bzl", "verus_test")
+load("@rules_rocq_rust//rocq:defs.bzl", "rocq_library", "rocq_proof_test")
+load("@rules_rocq_rust//coq_of_rust:defs.bzl", "rocq_rust_verified_library")
+
+# Track 1: Verus verification (SMT/Z3)
+verus_test(name = "verus_test", srcs = glob(["src/*.rs"]))
+
+# Track 2: Rocq — translate Rust to Rocq, then prove properties
+rocq_rust_verified_library(
+    name = "kernel_translated",
+    rust_sources = glob(["plain/src/*.rs"]),
+)
+
+rocq_library(
+    name = "kernel_proofs",
+    srcs = glob(["proofs/*.v"]),
+    deps = [":kernel_translated"],
+)
+
+rocq_proof_test(
+    name = "rocq_proof_test",
+    deps = [":kernel_proofs"],
+)
+```
+
+---
+
+## References
+
+- AutoVerus (Microsoft): github.com/microsoft/verus-proof-synthesis
+- AlphaVerus (CMU): github.com/cmu-l3/alphaverus
+- Strat2Rocq: arxiv.org/abs/2510.10131
+- Lean Copilot: github.com/lean-dojo/LeanCopilot
+- VeriCoding Benchmark (2,334 Verus tasks): github.com/Beneficial-AI-Foundation/vericoding-benchmark
+- Verus documentation: verus-lang.github.io/verus
+- Rocq/Coq reference: rocq-prover.org
+- Blog post: pulseengine.eu/blog/formal-verification-ai-agents/


### PR DESCRIPTION
## Summary
- **Blog post**: "Formal verification just became practical — AI agents changed the economics"
  - References AutoVerus, AlphaVerus, Lean Copilot, Strat2Rocq research
  - References Safety-Critical Rust Consortium MC/DC work
  - Honest "what is still open" section (MC/DC, tool qualification, coq_of_rust, spec completeness)
  - Frames as direction, not claims
- **Verification Guide** at `/guides/VERIFICATION-GUIDE/`
  - Error classification and repair strategies for Verus
  - Rocq proof tactics
  - Rust subset intersection table (what all tools accept)
  - Bazel rules examples
  - Agent integration instructions (AGENTS.md snippet)
  - Downloadable as Markdown at `/guides/VERIFICATION-GUIDE.md`
- **`verification-guide` label** created on this repo for feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)