### PR TITLE
feat: compact version display on reports page, add sigil

### DIFF
--- a/reports.toml
+++ b/reports.toml
@@ -16,6 +16,11 @@ repo = "pulseengine/spar"
 asset_pattern = "{name}-v{version}-compliance-report.tar.gz"
 exclude = ["*-rc*", "*-alpha*"]
 
+[projects.sigil]
+repo = "pulseengine/sigil"
+asset_pattern = "{name}-v{version}-compliance-report.tar.gz"
+exclude = ["*-rc*", "*-alpha*"]
+
 [projects.gale]
 repo = "pulseengine/gale"
 asset_pattern = "{name}-v{version}-compliance-report.tar.gz"

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -26,13 +26,20 @@
             &middot;
             {{ project.versions | length }} version{{ project.versions | length | pluralize }}
           </div>
-          <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem;">
-            {% for version in project.versions | reverse %}
+          <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; align-items: center;">
+            {% for version in project.display_versions %}
               <a href="{{ get_url(path='reports/' ~ name ~ '/' ~ version ~ '/compliance/') }}"
-                 class="badge {% if version == project.latest %}badge--accent{% else %}badge--cyan{% endif %}">
+                 class="badge {% if version == project.latest %}badge--accent{% else %}badge--cyan{% endif %}"
+                 style="text-decoration: none;">
                 v{{ version }}
               </a>
             {% endfor %}
+            {% if project.versions | length > project.display_versions | length %}
+              <a href="{{ get_url(path='reports/' ~ name ~ '/latest/compliance/') }}"
+                 style="font-size: 0.8rem; color: #8b90a0;">
+                all {{ project.versions | length }} versions
+              </a>
+            {% endif %}
           </div>
         </div>
       {% endfor %}

--- a/tools/fetch-reports/src/main.rs
+++ b/tools/fetch-reports/src/main.rs
@@ -55,7 +55,11 @@ struct IndexJson {
 #[derive(Debug, Serialize)]
 struct ProjectIndex {
     latest: String,
+    /// All versions, sorted descending by semver.
     versions: Vec<String>,
+    /// Latest patch per minor version (e.g., 0.1.2, 0.2.5, 0.3.0, 1.0.0).
+    /// Used by the reports page to show a compact version list.
+    display_versions: Vec<String>,
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -509,12 +513,28 @@ fn main() {
             }
         }
 
+        // Compute display versions: latest patch per minor version.
+        // Versions are already sorted descending, so first seen per (major, minor) wins.
+        let display_versions = {
+            let mut seen: Vec<(u64, u64)> = Vec::new();
+            let mut display: Vec<String> = Vec::new();
+            for v in &successful_versions {
+                let key = (v.major, v.minor);
+                if !seen.contains(&key) {
+                    seen.push(key);
+                    display.push(v.to_string());
+                }
+            }
+            display
+        };
+
         // Record in index.
         index.projects.insert(
             project_name.clone(),
             ProjectIndex {
                 latest: latest_version.to_string(),
                 versions: successful_versions.iter().map(|v| v.to_string()).collect(),
+                display_versions,
             },
         );
     }


### PR DESCRIPTION
## Summary
- Reports page shows latest patch per minor version (0.1.2, 0.2.5, 0.3.0) instead of every patch release
- "all N versions" link when patches are hidden, pointing to the compliance report's own version switcher
- Add sigil to reports.toml
- fetch-reports computes `display_versions` in index.json

## Example
spar with versions 0.1.0, 0.2.0, 0.2.1, 0.2.2, 0.3.0 would show: **v0.3.0 v0.2.2 v0.1.0** + "all 5 versions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)