### PR TITLE
fix: lowercase guide path, Mathlib section, seL4 reference

### DIFF
--- a/content/blog/2026-03-15-formal-verification-ai-agents.md
+++ b/content/blog/2026-03-15-formal-verification-ai-agents.md
@@ -14,7 +14,7 @@ Formal verification was a craft practiced at a handful of universities and resea
 
 ## The shift
 
-For decades, formal verification was reserved for projects with extraordinary budgets and timelines. seL4 took a decade of PhD students writing Isabelle/HOL proofs. CompCert took years. The rest of us tested and hoped.
+For decades, formal verification was reserved for projects with extraordinary budgets and timelines. [seL4](https://dl.acm.org/doi/10.1145/1629575.1629596) took a decade of PhD students writing ~200,000 lines of Isabelle/HOL proofs for ~10,000 lines of C kernel code (SOSP 2009). CompCert took years. The rest of us tested and hoped.
 
 Two things changed in 2025:
 
@@ -138,6 +138,6 @@ The proof is not in a paper. It is in the CI log.
 
 ---
 
-*A detailed reference for agents and developers working with these tools is available as the [Verification Guide](/guides/VERIFICATION-GUIDE/) ([download as Markdown](/guides/VERIFICATION-GUIDE.md)). It covers error tables, proof tactics, the Rust subset intersection, and Bazel rules. We update it as we learn what works — if something is wrong or missing, [open an issue](https://github.com/pulseengine/pulseengine.eu/issues).*
+*A detailed reference for agents and developers working with these tools is available as the [Verification Guide](/guides/verification-guide/) ([download as Markdown](/guides/VERIFICATION-GUIDE.md)). It covers error tables, proof tactics, the Rust subset intersection, and Bazel rules. We update it as we learn what works — if something is wrong or missing, [open an issue](https://github.com/pulseengine/pulseengine.eu/issues).*
 
 *This post is part of [PulseEngine](/) — a formally verified WebAssembly Component Model engine for safety-critical systems.*

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -12,7 +12,7 @@ Covers the Rust subset intersection (what all verification tools accept simultan
 
 Based on findings from AutoVerus (Microsoft), AlphaVerus (CMU), Strat2Rocq, and Lean Copilot.
 
-[Read the guide](/guides/VERIFICATION-GUIDE/) · [Download as Markdown](/guides/VERIFICATION-GUIDE.md)
+[Read the guide](/guides/verification-guide/) · [Download as Markdown](/guides/VERIFICATION-GUIDE.md)
 
 ---
 

--- a/content/guides/verification-guide/index.md
+++ b/content/guides/verification-guide/index.md
@@ -215,13 +215,28 @@ Lean proofs in PulseEngine are a third independent verification track.
 - **`cases`/`match`** for case analysis
 - **`induction`** when structural recursion is needed
 
+### Mathlib
+
+Lean's power comes partly from [Mathlib](https://github.com/leanprover-community/mathlib4) —
+over 1 million lines of formalized mathematics. For kernel verification,
+relevant Mathlib modules include:
+
+- `Mathlib.Data.Nat.Basic` — natural number arithmetic
+- `Mathlib.Data.Int.Basic` — integer arithmetic and order
+- `Mathlib.Data.Fin` — bounded naturals (useful for array indices)
+- `Mathlib.Order.BoundedOrder` — bounded lattice structures
+- `Mathlib.Tactic` — automation tactics
+
+PulseEngine's [rules_lean](https://github.com/pulseengine/rules_lean)
+provides Bazel rules with Mathlib integration via `lean_prebuilt_library`.
+
 ### Lean Copilot Integration
 
-If using Lean Copilot (github.com/lean-dojo/LeanCopilot):
+If using [Lean Copilot](https://github.com/lean-dojo/LeanCopilot):
 
 - `suggest_tactics` — shows candidate next steps
 - `search_proof` — finds complete multi-tactic proofs (74.2% success)
-- `select_premises` — retrieves useful lemmas from the library
+- `select_premises` — retrieves useful lemmas from Mathlib and project libraries
 - Automates most mechanical proof steps; focus human/agent effort on the
   remaining 25% that need domain knowledge
 
@@ -407,7 +422,7 @@ artifacts to the guide:
   description: >
     Formal verification follows the PulseEngine Verification Guide.
     Proof strategies, error handling, and Rust subset rules are
-    documented at pulseengine.eu/guides/VERIFICATION-GUIDE/
+    documented at pulseengine.eu/guides/verification-guide/
   status: approved
 ```
 
@@ -416,8 +431,8 @@ artifacts to the guide:
 When you find something that works better than what the guide says,
 or something that no longer works, update the guide. It lives at:
 
-- Website (rendered): [pulseengine.eu/guides/VERIFICATION-GUIDE/](/guides/VERIFICATION-GUIDE/)
-- Source: `content/guides/VERIFICATION-GUIDE/index.md` in the pulseengine.eu repo
+- Website (rendered): [pulseengine.eu/guides/verification-guide/](/guides/verification-guide/)
+- Source: `content/guides/verification-guide/index.md` in the pulseengine.eu repo
 - Downloadable: [/guides/VERIFICATION-GUIDE.md](/guides/VERIFICATION-GUIDE.md)
 
 ---
@@ -433,4 +448,4 @@ This guide evolves as we learn what works. If you encounter:
 
 Open an issue at [github.com/pulseengine/pulseengine.eu](https://github.com/pulseengine/pulseengine.eu/issues) with the tag `verification-guide`. Whether you are a human or an AI agent, the feedback is valuable.
 
-*Last updated: March 2026*
+*Last updated: March 22, 2026*


### PR DESCRIPTION
Fixes 404 on /guides/VERIFICATION-GUIDE/ (case-sensitive hosting). Adds Mathlib section and seL4 SOSP 2009 link.