### PR TITLE
fix: ensure autopublish labels exist before using them

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -59,6 +59,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # `gh label create --force` upserts (creates or updates), so this
+          # step is idempotent and immune to a label being deleted manually.
+          gh label create autopublish         --color 6c8cff --description "Auto-publish PR opened by the daily cron" --force
+          gh label create autopublish-status  --color 22d3ee --description "Pinned status issue for the auto-publish cron" --force
+          gh label create autopublish-failure --color f87171 --description "Auto-publish workflow failed on this run" --force
+
       - name: Scan drafts
         id: scan
         run: |


### PR DESCRIPTION
## Summary

The first run of the new auto-publish workflow ([run #24937929649](https://github.com/pulseengine/pulseengine.eu/actions/runs/24937929649)) failed at the *Post / update status comment* step:

\`\`\`
could not add label: 'autopublish-status' not found
\`\`\`

`gh issue create --label X` errors out if X doesn't exist. The cascade meant the failure-issue step also failed (\`autopublish-failure\` label missing), so a failed run leaves no visible artifact.

## Fix

Add an idempotent "Ensure labels exist" step using \`gh label create --force\` (which upserts) before any step that uses the labels. Three labels:

- \`autopublish\` (blue) — applied to per-post publish PRs
- \`autopublish-status\` (cyan) — pinned status issue
- \`autopublish-failure\` (red) — opened when a run fails

Self-healing: if any label is deleted manually, the next cron run recreates it.

## Test plan

- [x] YAML parses
- [ ] CI green
- [ ] After merge, re-fire \`workflow_dispatch\` — should succeed end-to-end this time, creating the pinned status issue with the no-op report

🤖 Generated with [Claude Code](https://claude.com/claude-code)