### PR TITLE
content(overdoing): name witness as the cell-filler + add 11th matrix column

### DIFF
--- a/content/blog/2026-04-22-overdoing-the-verification-chain.md
+++ b/content/blog/2026-04-22-overdoing-the-verification-chain.md
@@ -148,6 +148,7 @@ A one-line gloss for each technique in the matrix below — skip if these read l
 - **tokio-rs/loom** — permutation-checks every possible thread interleaving in a bounded concurrent program.
 - **Sanitizer · Miri** — runtime instrumentation that detects undefined behaviour, memory errors, and data races (ASAN, TSAN, LSAN, UBSAN, Miri).
 - **Mutation testing** — inject small plausible bugs into the source and check whether the test suite catches them; empirical test-suite adequacy.
+- **Structural coverage (Wasm IR)** — branch / MC/DC coverage measured on the post-compile WebAssembly module rather than at source. Closes the §FM.6.7(f) / MC/DC-shaped cell that source-level lcov has long pretended to satisfy across DO-178C, ISO 26262, IEC 61508. Shipping as [witness](https://github.com/pulseengine/witness); the credit-template work for the other four standards is the next post's hook.
 - **Traceability** — requirement ↔ design ↔ code ↔ test ↔ proof chain, validated on every commit (rivet).
 
 At a glance, all seven domains against the core chain techniques:
@@ -166,6 +167,7 @@ At a glance, all seven domains against the core chain techniques:
       <th title="tokio-rs/loom — every thread interleaving">tokio-rs<br>loom</th>
       <th title="Miri + ASAN/TSAN/LSAN/UBSAN — runtime anomaly detection">Sanitizer<br>&nbsp;· Miri</th>
       <th title="cargo-mutants — test-suite adequacy">Mutation<br>testing</th>
+      <th title="witness — branch / MC/DC coverage on post-compile Wasm">Struct.<br>coverage</th>
       <th title="rivet — requirements-to-evidence linking">Trace-<br>ability</th>
     </tr>
   </thead>
@@ -181,6 +183,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-strong" title="strong — bounded model checking for concurrency (DO-333)">●</td>
       <td class="fit-strong" title="strong — runtime robustness evidence">●</td>
       <td class="fit-strong" title="strong — test-suite adequacy addresses the MC/DC-for-Rust gap">●</td>
+      <td class="fit-strong" title="strong — closes the §FM.6.7(f) / MC/DC-on-object cell witness measures at Wasm IR">●</td>
       <td class="fit-strong" title="strong — rivet artefacts support the full trace chain">●</td>
     </tr>
     <tr>
@@ -194,6 +197,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-partial" title="partial — Table 10 integration context">◐</td>
       <td class="fit-strong" title="Table 7 analysis techniques">●</td>
       <td class="fit-partial" title="Table 13 referenced as test-quality metric">◐</td>
+      <td class="fit-strong" title="strong — Part 6 Table 12 structural coverage at module integration level">●</td>
       <td class="fit-strong">●</td>
     </tr>
     <tr>
@@ -207,6 +211,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-strong" title="Annex B concurrency model checking">●</td>
       <td class="fit-strong" title="Annex B defensive programming / dynamic analysis">●</td>
       <td class="fit-strong" title="Annex C.5.12 mutation testing — explicit">●</td>
+      <td class="fit-strong" title="strong — Annex C structural test coverage at object-code-equivalent level">●</td>
       <td class="fit-strong">●</td>
     </tr>
     <tr>
@@ -220,6 +225,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-strong" title="Table A.17 model checking for concurrency">●</td>
       <td class="fit-strong" title="Table A.5 defensive programming">●</td>
       <td class="fit-strong" title="Table A.17 test coverage adequacy">●</td>
+      <td class="fit-na" title="not yet mapped — credit-template work is the next post's hook"></td>
       <td class="fit-strong">●</td>
     </tr>
     <tr>
@@ -233,6 +239,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-partial" title="concurrency testing accepted">◐</td>
       <td class="fit-strong" title="UB detection valued for unsafe code">●</td>
       <td class="fit-strong" title="FDA CSA accepts mutation as adequacy evidence">●</td>
+      <td class="fit-na" title="not yet mapped — credit-template work is the next post's hook"></td>
       <td class="fit-strong" title="§9 + FDA DHF requires full traceability">●</td>
     </tr>
     <tr>
@@ -246,6 +253,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-partial">◐</td>
       <td class="fit-strong">●</td>
       <td class="fit-partial" title="accepted but no established template">◐</td>
+      <td class="fit-na" title="not yet mapped — credit-template work is the next post's hook"></td>
       <td class="fit-partial">◐</td>
     </tr>
     <tr>
@@ -259,6 +267,7 @@ At a glance, all seven domains against the core chain techniques:
       <td class="fit-partial">◐</td>
       <td class="fit-partial">◐</td>
       <td class="fit-partial">◐</td>
+      <td class="fit-na" title="not yet mapped — credit-template work is the next post's hook"></td>
       <td class="fit-partial">◐</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Summary

Per advisor's recommendation: ship the *Overdoing the verification chain* post this week with **witness** named in it, before doing anything else on either the post or the tool. The post is the carrier wave; witness is what people click through to once they understand why the cell was empty.

The post stays scheduled for auto-publish on **2026-04-29** (Wednesday) — this PR just lands the content edit before the cron fires.

## Three concrete changes

1. **Gloss bullet** for *"Structural coverage (Wasm IR)"* naming witness with a one-line link to [github.com/pulseengine/witness](https://github.com/pulseengine/witness), framed as the cell-filler for the §FM.6.7(f) / MC/DC-shaped slot that source-level lcov has long pretended to satisfy across DO-178C, ISO 26262, IEC 61508.
2. **11th column** added to the credit matrix between *Mutation testing* and *Trace-ability* — *"Struct. coverage"*.
3. **Cells filled honestly:**
   - DO-178C, ISO 26262, IEC 61508 → strong fit (●) with per-cell rationale tooltips
   - EN 50128, IEC 62304, ECSS-Q-ST-80C, IEC 60880 → deliberately empty (\`fit-na\`) with \`title="not yet mapped — credit-template work is the next post's hook"\`

## Why deliberately-empty rather than \`fit-gap\` or \`fit-partial\`

Per advisor: *"that's honest and it's the next post's hook."* An empty cell signals different uncertainty than \`fit-gap\` (which means "we don't have the technique"). Here we have the technique; we just haven't done the credit-template mapping for those four standards yet.

## Test plan

- [x] zola build --drafts clean (27 pages)
- [x] Matrix renders with 11 columns; structural-coverage column has ● in three rows and visually-empty cells in four
- [x] Witness link target verified live (\`gh repo view pulseengine/witness\` returns public repo)
- [ ] CI passes
- [ ] After merge: post stays scheduled for 2026-04-29 (cron will pick up the content edit on next run, ship the new version when it auto-publishes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)