### PR TITLE
content(projects): add witness as the 4th Verify tool

### DIFF
--- a/templates/projects.html
+++ b/templates/projects.html
@@ -91,6 +91,10 @@
               <span class="face-tool__name">Lean 4</span>
               <span class="face-tool__desc">scheduling theory</span>
             </a>
+            <a href="https://github.com/pulseengine/witness" class="face-tool" rel="noopener">
+              <span class="face-tool__name">witness</span>
+              <span class="face-tool__desc">MC/DC on Wasm IR</span>
+            </a>
           </div>
           <div class="face-divider"></div>
           <div class="face-edge">
@@ -215,13 +219,14 @@
       </div>
 
       <div class="cube-detail__panel" data-detail="verify" style="display:none">
-        <h3 style="color:#4ade80">Verify — three independent proof paths across everything</h3>
-        <p><strong>Verus</strong> proves Rust code via SMT/Z3 — preconditions, postconditions, invariants on every public function. <strong>Rocq</strong> machine-checks abstract invariants that hold regardless of implementation. <strong>Lean 4</strong> proves scheduling theory — priority inheritance, deadline guarantees, starvation freedom.</p>
-        <p>These are not limited to one tool. Every component in the ecosystem — meld, loom, synth, kiln, gale, relay, wohl — carries formal verification. Three independent paths run in CI on every commit.</p>
+        <h3 style="color:#4ade80">Verify — three proof paths and the empirical coverage cell</h3>
+        <p><strong>Verus</strong> proves Rust code via SMT/Z3 — preconditions, postconditions, invariants on every public function. <strong>Rocq</strong> machine-checks abstract invariants that hold regardless of implementation. <strong>Lean 4</strong> proves scheduling theory — priority inheritance, deadline guarantees, starvation freedom. <strong>witness</strong> measures branch / MC/DC coverage at the post-compile WebAssembly level — the empirical counterpart that closes the §FM.6.7(f) / structural-coverage cell DO-178C, ISO 26262 Part 6 Table 12, and IEC 61508 Annex C expect.</p>
+        <p>These are not limited to one tool. Every component in the ecosystem — meld, loom, synth, kiln, gale, relay, wohl — carries formal verification. Four independent verification paths run in CI on every commit: three proof, one coverage.</p>
         <div class="cube-detail__links">
           <a href="https://github.com/pulseengine/rules_verus" rel="noopener">rules_verus</a>
           <a href="https://github.com/pulseengine/rules_rocq_rust" rel="noopener">rules_rocq_rust</a>
           <a href="https://github.com/pulseengine/rules_lean" rel="noopener">rules_lean</a>
+          <a href="https://github.com/pulseengine/witness" rel="noopener">witness</a>
           <a href="https://github.com/pulseengine/gale" rel="noopener">gale</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Witness wasn't on the projects cube. Adding it on the **Verify** face alongside Verus / Rocq / Lean 4 — the empirical structural-coverage counterpart to the three proof tools.

## Two changes

### Face tile (visible on cube rotation)

\`\`\`
witness    MC/DC on Wasm IR
\`\`\`

Slots in as the 4th tool on the Verify face. Same styling as the other three.

### Detail panel (when Verify face is opened)

- Heading: *"Verify — three independent proof paths across everything"* → *"Verify — three proof paths and the empirical coverage cell"*
- Description gains a sentence introducing witness as the §FM.6.7(f) / structural-coverage cell-filler for DO-178C, ISO 26262 Part 6 Table 12, and IEC 61508 Annex C
- Link list adds witness
- *"Three independent paths run in CI on every commit"* → *"Four independent verification paths run in CI on every commit: three proof, one coverage"*

## Why on Verify (not Build)

The advisor's framing positions witness as the empirical complement to proof. Build is for transformations (meld, loom, synth, sigil); Verify is for assurance techniques. Witness measures coverage — that's an assurance/observation activity, not a transformation, so Verify is the right face.

## Test plan

- [x] zola build clean (23 pages)
- [x] Both witness refs rendered in projects/index.html (face tile + detail panel)
- [x] github.com/pulseengine/witness verified live (public repo)
- [ ] CI passes
- [ ] After merge: /projects/ shows 4 tools on the Verify face; clicking the face shows updated description with witness mentioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)