### PR TITLE
fix(blog-autopublish): use App-minted token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -46,9 +46,23 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       REPO: ${{ github.repository }}
     steps:
+      # Mint a token from the PulseEngine Actions Helper App so this job
+      # can `gh pr create` despite the org policy that disables PR-creation
+      # for the default GITHUB_TOKEN. The App's installation grants
+      # contents: write + pull-requests: write + metadata: read on this
+      # repo only — strictly narrower than what GITHUB_TOKEN would have
+      # had with the org permission flipped.
+      - name: Mint App token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ACTIONS_BOT_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app_token.outputs.token }}
 
       - uses: actions/setup-python@v5
         with:
@@ -61,7 +75,7 @@ jobs:
 
       - name: Ensure labels exist
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           # `gh label create --force` upserts (creates or updates), so this
           # step is idempotent and immune to a label being deleted manually.
@@ -91,7 +105,7 @@ jobs:
         id: publish
         if: steps.scan.outputs.ready_count != '0'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
           published='[]'
@@ -146,7 +160,7 @@ jobs:
       - name: Post / update status comment
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           set -euo pipefail
 
@@ -179,7 +193,7 @@ jobs:
       - name: Open failure issue
         if: failure()
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           today=$(date -u +%Y-%m-%d)
           gh issue create \


### PR DESCRIPTION
## Summary

Org policy *"Allow GitHub Actions to create and approve pull requests"* is disabled, which silently kills \`gh pr create\` calls authed with \`GITHUB_TOKEN\`. The cron has been failing for two days running ([#43](../issues/43), [#45](../issues/45)) with:

> \`GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)\`

Three scheduled posts (\`overdoing-the-verification-chain\`, \`variant-pruning-rust-mcdc\`, \`cross-language-lto-three-quiet-barriers\`) are stuck as drafts.

## Fix

Mint a token from the PulseEngine Actions Helper App (\`actions/create-github-app-token@v1\`) using the \`ACTIONS_BOT_APP_ID\` and \`ACTIONS_BOT_PRIVATE_KEY\` repository secrets. App-authenticated calls bypass the org restriction; the App's installation is scoped to **Contents R/W + Pull requests R/W + Metadata R on this repo only** — strictly narrower than the default token would have had.

## Five surgical changes

1. New \`Mint App token\` step before checkout
2. \`actions/checkout@v4\` takes the App token (so the credential helper uses it for \`git push\` later)
3–6. Four \`env: GH_TOKEN\` swaps:
   - Ensure labels exist
   - Publish ready posts
   - Post / update status comment
   - Open failure issue

The existing \`permissions:\` block stays as-is for clarity / defense in depth — even though we no longer use the default \`GITHUB_TOKEN\` in this job.

## Test plan

- [x] YAML parses
- [x] All 5 \`secrets.GITHUB_TOKEN\` references replaced; 0 remain in this file
- [ ] CI passes
- [ ] After merge: \`gh workflow run blog-autopublish.yml\` to flush the 3 stuck posts in one run
- [ ] Verify status issue #36 updates with \`This run: published 3\`

## Token security

App-minted tokens expire in 1 hour. Workflow timeout is 15 min, so no rotation logic needed. Token never persists beyond the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)