### PR TITLE
chore(ci): add concurrency control to all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,17 @@
 name: Deploy
 
+# Release variant — never cancel a deploy mid-flight. A cancelled deploy
+# can leave the Netcup site in a half-deleted state (the script does
+# `find . -delete && tar -xzf`). Group by ref so two parallel pushes to
+# the same branch serialize cleanly without race-deleting each other.
+#
+# Security note: this concurrency block uses only server-controlled
+# context vars (github.ref, github.workflow) — no PR-author-controlled
+# input flows into the group key.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

Per the org-wide [CI Concurrency Hardening brief](https://gist.github.com/...). Adds top-level \`concurrency:\` blocks to all workflow files in \`.github/workflows/\`. Cancels superseded PR runs; never cancels runs on \`main\`, releases, or operational state-mutating workflows.

This is the lowest-risk, highest-leverage move available against the **93-job org-wide queue backlog** observed in the last 24h.

## Classification per file

| File | Variant applied | Notes |
|---|---|---|
| \`ci.yml\` | **default** | \`cancel-in-progress: \${{ github.event_name == 'pull_request' }}\` — cancels superseded PR runs, never main runs (workflow currently only fires on PR but the conditional is future-proofing) |
| \`deploy.yml\` | **release** | \`cancel-in-progress: false\` — the deploy script does \`find . -delete && tar -xzf\` on Netcup; cancelling mid-flight could half-delete prod. Group by \`github.ref\` |
| \`blog-autopublish.yml\` | **unchanged** | Already has the correct fixed-group pattern (\`group: blog-autopublish, cancel-in-progress: false\`). For this workflow that IS correct — it mutates repo state (creates branches, opens PRs), so all runs (cron + workflow_dispatch) must serialize. The brief's "scheduled variant" with \`\${{ github.run_id }}\` would allow concurrent runs and race conditions. Per idempotency rule, leaving as-is. |

## Out of scope (per brief)

No \`runs-on:\` changes, no matrix restructuring, no caching changes, no permissions tightening. All those are tracked separately and depend on this PR landing first.

## Test plan

- [x] \`ruby -r yaml -e\` parses all 3 workflow files
- [x] All blocks at workflow top level, none inside jobs
- [ ] CI passes
- [ ] Push a follow-up no-op commit to this PR — earlier run must show as Cancelled within ~30s, new run queued
- [ ] After merge: post-merge \`main\` deploy must complete normally (not cancelled, since deploy uses \`cancel-in-progress: false\`)

## Security

The \`concurrency:\` blocks use only server-controlled context vars (\`github.workflow\`, \`github.ref\`, \`github.head_ref\`, \`github.event_name\`). No PR-author-controlled input (issue titles, PR bodies, commit messages) flows into the group key — no command-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)