### PR TITLE
ci: migrate 3 of 3 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   publish:
     name: Scan, publish, report
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     timeout-minutes: 15
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Migrates all three CI workflows on `pulseengine.eu` from
GitHub-hosted runners to the pulseengine self-hosted smithy fleet.
The repo is a Zola-built static site plus a small Rust tool
(`tools/fetch-reports`) plus a Python-driven daily blog autopublish
cron — none of which need sudo, apt-get, containers, or any
toolchain that smithy is missing.

## Coverage

| Workflow | Job | Class | Notes |
|---|---|---|---|
| `ci.yml` | `build` | `light` | Zola PR build only — 4 G is plenty |
| `deploy.yml` | `deploy` | `rust-cpu` | Builds `tools/fetch-reports` (Rust) and Zola, then ssh/scp to deploy host |
| `blog-autopublish.yml` | `publish` | `light` | Python + jq + git + gh CLI; no compile |

## Stays on hosted

| Job | Reason |
|---|---|
| (none) | All three jobs migrate cleanly |

## Workarounds applied

None. Zola is installed via `taiki-e/install-action` which drops
the binary into a user-writable directory (no sudo). The deploy
job's ssh/scp/keyscan flow writes only to `~/.ssh` and works
unchanged on the smithy runner user.

## Test plan

- [ ] `ci.yml` `build` runs on a `light` runner on the next PR
- [ ] `deploy.yml` `deploy` runs on a `rust-cpu` runner on next push to `main` and produces a working deploy
- [ ] `blog-autopublish.yml` `publish` runs on a `light` runner at next 06:00 UTC schedule (or via manual `workflow_dispatch`)
- [ ] No regression in build outputs or deployed site

## Rollback

Revert this commit. All three `runs-on:` lines flip back to
`ubuntu-latest` and CI returns to GitHub-hosted compute.

## References

- Migration playbook: https://github.com/pulseengine/smithy/blob/main/docs/migration-playbook.md
- Pilot PR: https://github.com/pulseengine/spar/pull/201