### PR TITLE
feat: add pulseengine-claude marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "pulseengine-eu",
+  "version": "0.1.0",
+  "description": "PulseEngine engineering plugins for Claude Code — verification + traceability + attestation methodology, the tool directory, and the procedural skills that compose them.",
+  "owner": {
+    "name": "PulseEngine",
+    "url": "https://pulseengine.eu"
+  },
+  "plugins": [
+    {
+      "name": "pulseengine-claude",
+      "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus four procedural skills (clean-room verification, release execution, oracle-gating, and the full feature loop).",
+      "version": "0.1.0",
+      "source": "./claude-tooling/plugins/pulseengine-claude",
+      "category": "development"
+    }
+  ]
+}

--- a/claude-tooling/README.md
+++ b/claude-tooling/README.md
@@ -1,0 +1,49 @@
+# claude-tooling
+
+Houses the `pulseengine-claude` Claude Code plugin (methodology reference memory + procedural skills for PulseEngine engineering work).
+
+The marketplace manifest itself lives at the **repo root** in `pulseengine.eu/.claude-plugin/marketplace.json` (this is the convention Claude Code's marketplace loader expects — same shape as `anthropics/skills`). It points down into `claude-tooling/plugins/pulseengine-claude/` for the actual plugin contents.
+
+See `plugins/pulseengine-claude/README.md` for plugin details.
+
+## Install (same flow as any other Claude Code marketplace)
+
+In Claude Code, run:
+
+```
+/plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu
+/plugin install pulseengine-claude@pulseengine-eu
+```
+
+Or the CLI equivalent:
+
+```sh
+claude plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu
+claude plugin install pulseengine-claude@pulseengine-eu
+```
+
+## Layout
+
+```
+pulseengine.eu/                          (repo root)
+├── .claude-plugin/
+│   └── marketplace.json                 ← marketplace manifest (must be at repo root)
+└── claude-tooling/
+    └── plugins/
+        └── pulseengine-claude/
+            ├── .claude-plugin/plugin.json
+            ├── skills/
+            │   ├── clean-room-verification/SKILL.md
+            │   ├── release-execution/SKILL.md
+            │   ├── oracle-gate-a-change/SKILL.md
+            │   └── pulseengine-feature-loop/SKILL.md
+            ├── memory/
+            │   ├── pulseengine-philosophy.md
+            │   └── pulseengine-toolchain.md
+            ├── hooks/
+            │   ├── hooks.json
+            │   └── inject-pulseengine-memory.sh
+            └── README.md
+```
+
+The marketplace manifest's `plugins[].source` is `./claude-tooling/plugins/pulseengine-claude` — a relative path from the marketplace root (= repo root, the directory containing `.claude-plugin/`).

--- a/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
+++ b/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "pulseengine-claude",
+  "version": "0.1.0",
+  "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus four procedural skills (clean-room verification, release execution, oracle-gating, and the full feature loop).",
+  "author": {
+    "name": "PulseEngine",
+    "url": "https://pulseengine.eu"
+  }
+}

--- a/claude-tooling/plugins/pulseengine-claude/README.md
+++ b/claude-tooling/plugins/pulseengine-claude/README.md
@@ -1,0 +1,32 @@
+# pulseengine-claude
+
+PulseEngine engineering methodology as installable Claude Code tooling.
+
+## What's inside
+
+- **Reference memory** (`memory/`) — auto-injected at session start via the plugin's SessionStart hook:
+  - `pulseengine-philosophy.md` — verification + traceability + attestation, falsification methodology, defense-in-depth, MBSE-mandatory, variant pruning, the three-patterns synthesis.
+  - `pulseengine-toolchain.md` — directory of the tools (rivet, spar, witness, sigil, meld, loom, synth, smithy, wohl) and what each is for.
+
+- **Skills** (`skills/`) — loaded on trigger only:
+  - `clean-room-verification/` — the smithy ritual: findings → falsifiable claims → cold subagent → confirm/refute/cannot-verify → reconcile.
+  - `release-execution/` — end-to-end release machinery: PRs → reviewers → fixes → merge → CI → tag → GitHub Release + crates.io verify. Includes the per-release falsification statement.
+  - `oracle-gate-a-change/` — per-change procedure: name the mechanical oracle (rivet check / spar pass / witness gap / sigil verify / Kani / Verus / fuzz / nm symbol check), write it first if it doesn't exist, only the diff that flips it counts.
+  - `pulseengine-feature-loop/` — end-to-end compose loop: spar (AADL) → WIT → rivet typed artifacts → code (oracle-gated) → witness MC/DC → sigil attestation → clean-room verify.
+
+## Install
+
+The marketplace manifest sits at the **repo root** of pulseengine.eu (under `.claude-plugin/marketplace.json`) so the install flow mirrors `anthropics/skills` exactly:
+
+```
+/plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu
+/plugin install pulseengine-claude@pulseengine-eu
+```
+
+(Run the first command inside Claude Code, or `claude plugin marketplace add ...` from the shell. Adjust GitHub coordinates to wherever you actually publish the repo.)
+
+## Design
+
+Partition rule: **belief / disposition / vocabulary stays in memory; multi-step procedure becomes a skill**. The memory files describe always-on framing for every session. The skills load only when their trigger fires — proposing a change, cutting a release, auditing findings, doing a feature end-to-end.
+
+The four skills compose: `pulseengine-feature-loop` orchestrates a feature; `oracle-gate-a-change` runs per change inside the loop; `clean-room-verification` is the verify step both feature-loop and oracle-gate point at; `release-execution` ships the result.

--- a/claude-tooling/plugins/pulseengine-claude/hooks/hooks.json
+++ b/claude-tooling/plugins/pulseengine-claude/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "description": "Inject PulseEngine philosophy + toolchain reference memory at session start so the methodology is always in context for any PulseEngine project work.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/inject-pulseengine-memory.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-tooling/plugins/pulseengine-claude/hooks/inject-pulseengine-memory.sh
+++ b/claude-tooling/plugins/pulseengine-claude/hooks/inject-pulseengine-memory.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SessionStart hook shipped with the pulseengine-claude plugin.
+# Injects the bundled philosophy + toolchain reference memory as additional context.
+set -euo pipefail
+
+# CLAUDE_PLUGIN_ROOT is set by the harness to the plugin install root.
+MEM_DIR="${CLAUDE_PLUGIN_ROOT}/memory"
+
+if [ ! -d "$MEM_DIR" ]; then
+  exit 0
+fi
+
+{
+  echo "## PulseEngine methodology (injected by pulseengine-claude plugin)"
+  echo
+  echo "Reference memory that travels with the PulseEngine plugin install."
+  echo "These describe always-on framing: vocabulary, methodology stances,"
+  echo "and the tool directory. The procedural skills that operate on this"
+  echo "framing (clean-room-verification, release-execution, oracle-gate-a-change,"
+  echo "pulseengine-feature-loop) load on trigger — they are not in this file."
+  echo
+  for f in "$MEM_DIR"/*.md; do
+    [ -e "$f" ] || continue
+    name=$(basename "$f")
+    echo "### $name"
+    echo
+    cat "$f"
+    echo
+  done
+} | jq -Rs '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: .
+  }
+}'

--- a/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-philosophy.md
+++ b/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-philosophy.md
@@ -1,0 +1,59 @@
+---
+name: pulseengine-philosophy
+description: "Pulseengine.eu engineering philosophy — verification + traceability + attestation methodology applied across every project"
+metadata:
+  node_type: memory
+  type: reference
+  scope: plugin-bundled
+---
+
+PulseEngine (https://pulseengine.eu) — verification + traceability + attestation tooling for safety-critical software, automotive background. The philosophy below is durable methodology, not branding. See [[pulseengine-toolchain]] for the tool landscape.
+
+**Core mission**: *"AI writes the code. Who proves it's safe?"*
+
+**Three pillars**: verification, traceability, attestation.
+
+## Methodology
+
+**Falsification, not prediction.** From `2026-05-01-cross-language-lto-three-quiet-barriers`:
+- Predict specifically — claims must be falsifiable, not vague.
+- Measure on production geometry, not synthetic benchmarks.
+- Publish the falsification when you were wrong — *"wrong-prediction data is more informative than the predicted number would have been if it landed."*
+- Reframe around what the data supports, not what you set out to prove.
+- Binary evidence directly supports claims (e.g. `nm zephyr.elf | grep gale_` and read zero).
+
+**Defense-in-depth, not minimum-viable verification.** From `2026-04-22-overdoing-the-verification-chain`:
+- In regulated domains, combining techniques (proofs + tests + model checkers + sanitizers + mutation testing + fuzzing) shrinks blind spots faster than tightening any single technique.
+- When you don't know which question an assessor will ask, overdoing is the only honest default.
+- AI-velocity authorship *grows* the verification surface, doesn't shrink it.
+
+**MBSE is mandatory infrastructure for AI-authored safety code.** From `2026-04-23-spec-driven-development-is-half-the-loop`:
+- Model-based systems engineering (AADL via spar, requirements via rivet) used to feel heavyweight; AI-velocity untraceable code inverts that — the model must *drive* the build, not sit alongside.
+- Cost dropped from "half a day per requirement" to "agent-minutes plus human review."
+
+**Variant pruning collapses MC/DC scope.** From `2026-04-24-variant-pruning-rust-mcdc`:
+- MC/DC burden on the shipped artifact is proportional to a single variant, not the combinatorial product of feature flags.
+- Five pruning layers: requirements variants → cargo features → cfg → type system → match arms.
+- Counter to the naive "Rust pattern matching makes MC/DC harder" reading.
+
+**Formal verification cost collapsed under AI.** From `2026-03-15-formal-verification-ai-agents`:
+- The seL4-era cost ("PhD students writing 200k lines of proof for 10k lines of code") is no longer the regime.
+- Agent-written annotations checked by SMT solvers in seconds — AutoVerus 91.3%, AlphaVerus 85%, Lean Copilot 74.2%.
+- *Specification completeness* is now the bottleneck, not proof-writing.
+
+**The synthesis (three patterns colliding).** From `2026-04-25-three-patterns-colliding`:
+- Karpathy-style LLM wiki (compounding knowledge across sessions) + oracle-gated agents (mechanical verification gate) + typed compliance (rivet, auditable result).
+- Each alone fails — wiki drifts into fiction, oracle has no memory, typed traceability is labor-intensive. Together they cancel each other's failure modes.
+
+## How to apply (framing only — the procedures live in skills)
+
+When advising on any PulseEngine project (or movement-tracker, which uses the same methodology):
+- Frame work in PulseEngine vocabulary — *falsification, traceability, attestation, kill criteria*.
+- Every claim needs a kill-criterion. The per-change ritual for this lives in the `oracle-gate-a-change` skill.
+- Every release needs a falsification statement. The per-release ritual lives in the `release-execution` skill.
+- Don't propose techniques without a measurable adoption gate.
+- Don't propose minimum-viable verification when defense-in-depth is on the table.
+
+The procedural how — feature-loop composition, oracle selection per change, release tail, clean-room verification of findings — lives in the four skills shipped with this plugin, not in this memory file. This memory is the always-on framing; the skills load on trigger.
+
+See also: [[pulseengine-toolchain]], the `oracle-gate-a-change` skill, the `pulseengine-feature-loop` skill.

--- a/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-toolchain.md
+++ b/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-toolchain.md
@@ -1,0 +1,38 @@
+---
+name: pulseengine-toolchain
+description: "What each pulseengine-* tool does — rivet, spar, witness, sigil, meld, loom, synth, smithy, wohl, kiln. Directory only; the compose-loop procedure lives in the pulseengine-feature-loop skill."
+metadata:
+  node_type: memory
+  type: reference
+  scope: plugin-bundled
+---
+
+Map of the PulseEngine tools. Each lives in `/Users/r/git/pulseengine/<name>` on Ralf's machine and has its own per-project memory store under `~/.claude/projects/-Users-r-git-pulseengine-<name>/memory/`. Treat this as a directory, not a spec — read the project memory for current state.
+
+## Core stack
+
+**rivet** — typed traceability CLI. YAML artifacts in git, schemas, `rivet validate / check / coverage / impact`, typed link predicates (verifies, implements, traced-by), MCP server so agents maintain traceability as they work. Schema support: STPA, ASPICE, IEC 61508, DO-178C, EN 50128, EU AI Act. Installed at `/Users/r/.cargo/bin/rivet`. From `2026-03-15-rivet-v0.1.0`.
+
+**spar** — AADL v2.3 architecture analysis. 27+ analysis passes including scheduling, latency, ARINC 653 partitioning, EMV2 fault trees, ASIL decomposition solver. Modal filtering on operations modes, piecewise-affine arrival curves for TSN, PMOO/LUDB multiplexing. Feeds rivet's traceability graph. Generates WIT interfaces from AADL (don't hand-write WIT in wohl). MCP server for agent access. From `2026-05-11-spar-v0.9.x-milestone`.
+
+**witness** — Wasm MC/DC coverage. Instruments Wasm, runs tests, emits **truth tables with masking / unique-cause proofs**, not coverage percentages. `witness-viz` shows which condition vectors are missing and suggests test stubs. Philosophy: structured evidence (truth table + gap identification + test suggestion) is the artifact, not a number. From `2026-04-25-witness-wasm-mcdc` + `2026-05-05-witness-the-truth-table-not-the-percentage`.
+
+**sigil** — signed attestation chains. Build-stage pipelines, multi-scheme signatures, key rotation, content-addressed stores, detached verification. Sits at intersection of TrustMee (Aalto, signed Wasm verifier) and Cerisier (Aarhus, Iris-formalized sealing predicates) — but the time-indexed, scheme-aware, detached sister logic to those doesn't yet exist, so sigil contains real open research. From `2026-05-11-attestation-chains-trustmee-to-cerisier`.
+
+**meld** — verification fusion tool. Track-3 passes (consult per-project memory for current scope). v0.1.0 in `2026-03-02-meld-v0.1.0`.
+
+**synth** — WebAssembly Component Model engine that transcodes via program synthesis to ARM/RISC-V with Rocq proofs. Cover targets are i.MX RT1062 / STM32H743 (never name NXP S32G publicly). RV32 parity is a tracked goal. See synth project memory for cadence.
+
+**loom** — companion project with its own Rocq Formal Proofs CI; upstream toolchain breakages occasionally turn that gate red.
+
+**kiln** — interpreter and runtime (not just a runtime, not AOT). Companion to synth.
+
+**smithy** — clean-room verifier *agent* (not a CLI). The pattern: spawn smithy (or equivalent subagent) with only the claims, no prior context, to confirm/refute/cannot-verify findings. The procedure lives in the `clean-room-verification` skill.
+
+**wohl** — application of the stack to a wireless field-sensor product (STM32G0 + door contact, CCSDS payload, sub-GHz radio, Matter Bridge at the hub but never native Matter at sensors).
+
+## How they compose
+
+The procedure for composing these tools end-to-end (spar → WIT → rivet → code → witness → sigil → smithy) lives in the **`pulseengine-feature-loop` skill** shipped with this plugin, not here. This memory is the directory; the skill is the recipe.
+
+See also: [[pulseengine-philosophy]], and the four procedural skills in this plugin.

--- a/claude-tooling/plugins/pulseengine-claude/skills/clean-room-verification/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/clean-room-verification/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: clean-room-verification
+description: This skill should be used whenever findings, audits, code-review results, claims, or analysis output need to be validated before reporting — including "verify this", "double-check this", "audit", "is this actually true", "before I report this", "before we merge this", or whenever an agent's summary needs independent confirmation. ALWAYS use this skill before delivering non-trivial inspection results, before claiming a property holds, and whenever agent-produced hashes, digests, versions, file paths, or flag names appear in a report.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# Clean-room verification
+
+## When this fires
+
+Any time you're about to report findings from an investigation, audit, code review, or analysis — *especially* when those findings include claims about behavior, state, version pins, hashes, file paths, flag names, or "everything is green / done." Also fires when reviewing another agent's deliverable: a summary describes intent, not what landed.
+
+This is the smithy ritual in PulseEngine vocabulary. The point is to catch hallucinations and over-claims before they ship.
+
+## Procedure
+
+1. **Write the findings as discrete falsifiable claims.** Each one should be specific enough that an independent checker can confirm, refute, or say "cannot verify." Examples of good claims:
+   - "Function `foo::bar` in `crates/foo/src/lib.rs` returns `Result<(), Error>` and propagates errors via `?`."
+   - "The image `docker.io/nixos/nix@sha256:abcdef...` is pullable from a fresh client."
+   - "`rivet check` on this branch reports zero unsatisfied predicates."
+   - "All four Kani harnesses in `wohl-ota` pass with `cargo kani`."
+
+   Avoid vague claims like "the refactor is clean" or "tests pass" — those aren't checkable.
+
+2. **Spawn a clean-room verification subagent.** Brief it cold — no inherited framing, no access to the original reasoning, no narrative about why the work was done. Give it only:
+   - The list of falsifiable claims.
+   - Whatever read/exec tools it needs to confirm them (Read, Grep, Bash).
+   - An explicit instruction: "Return one of `confirm`, `refute`, or `cannot-verify` per claim. Do not guess. `cannot-verify` is a valid and preferred answer over a guess."
+
+3. **Treat agent-produced artifacts as unverified claims.** Hashes, digests, version pins, file paths, flag names, symbol names — even when produced by a tool that *should* be authoritative — count as claims until checked against the real artifact. The verifier should pull the image, grep the binary, read the file, run the command.
+
+4. **Reconcile.** Compare the verifier's confirm/refute/cannot-verify against your draft findings:
+   - `refute` → the claim is wrong; rewrite or drop it.
+   - `cannot-verify` → either add the evidence the verifier needs, or downgrade the claim to "this is suspected, not verified."
+   - `confirm` → the claim ships as-is.
+
+5. **Report.** Include the verifier's verdict alongside the claim, so the reader can see what was independently checked vs. what was asserted.
+
+## The rules baked in
+
+- **The verifier may say "cannot verify" rather than guess.** A "cannot verify" with evidence beats a guess with confidence.
+- **An agent's summary describes intent, not what landed.** Check the diff. Check the file. Check the symbol. Check the digest.
+- **"It passed CI" is a statement about the gate's coverage that day, not a timeless guarantee.** Re-verify on the current artifact, not on the historical green check.
+- **Evidence-backed "blocked" beats forced "done."** If verification surfaces a real blocker, report the blocker — that's the honest path the user explicitly prefers.
+
+## Anti-patterns
+
+- Skipping verification because "the agent ran successfully." The agent's exit code is not evidence the claim is true.
+- Re-using the verifier's *own* prior context to verify its findings. The whole point is clean-room.
+- Burying the verifier's verdict in a footnote. Lead with what was independently confirmed; the rest is suspected.
+- Verifying with a soft oracle (asking an LLM to read the spec back). See [`oracle-gate-a-change`] — mechanical oracle preferred.
+
+## Where this is referenced from
+
+`oracle-gate-a-change` and `pulseengine-feature-loop` both point here for their verify step. The pattern is single-source-of-truth here; if you're inlining the procedure elsewhere, you're duplicating a known dependency.

--- a/claude-tooling/plugins/pulseengine-claude/skills/oracle-gate-a-change/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/oracle-gate-a-change/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: oracle-gate-a-change
+description: This skill should be used whenever proposing, designing, landing, or evaluating a consequential change on a PulseEngine project (rivet, spar, witness, sigil, meld, loom, synth, wohl) — including "propose a change", "add a feature", "fix a bug", "is this safe to land", "what verifies this", "what's the gate", "how do we know this is correct", "before merging this", or whenever a code change needs a mechanical check to back it. ALWAYS use this skill before claiming a property holds and before recommending a change be merged.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# Oracle-gate a change
+
+## When this fires
+
+Before any consequential change lands on a PulseEngine project. The gate is **mechanical** — a check that fires or doesn't, not an LLM reading the spec back. The skill picks the right oracle for the kind of claim, writes it first if it doesn't exist, and refuses to call the change "done" until red flips to green.
+
+This is distinct from [`clean-room-verification`], which validates *findings* before reporting. Oracle-gating runs at the *system* layer: it's how an agent's "I changed X" earns the right to be merged.
+
+## Procedure
+
+### 1. Name the kind of claim the change makes
+
+Before anything else: what is this change asserting? Pick the right oracle for the claim type:
+
+| Claim type | Mechanical oracle (PulseEngine toolchain) |
+|---|---|
+| Type / schema / traceability claim | `rivet validate`, `rivet check`, `rivet coverage` |
+| Architecture / scheduling / WIT generation claim | spar analysis pass (one of 27+: EMV2 fault trees, ARINC 653 partitioning, ASIL decomposition, modal-filtered scheduling, piecewise-affine TSN arrival curves) |
+| Branch / decision / MC/DC coverage on a Wasm artifact | `witness` truth-table gap report — **the gap view, not a coverage percentage**. The percentage is the wrong artifact. |
+| Build-stage integrity / attestation | `sigil` verification chain |
+| Memory-safety / UB / overflow / dedup-logic | Kani BMC (used in wohl + synth), Verus (used in wohl/AlertDispatcher) |
+| Property-based / state-explosion search | fuzz harness (cargo-fuzz / synth's gale fuzzer), z3-backed verifier in synth-verify |
+| Symbol-elimination claim (e.g. cross-language LTO) | `nm <artifact.elf> | grep <symbol>` returning zero. From the gale → zephyr LTO work. |
+| Coverage gap | `rivet coverage` against the schema-defined trace topology |
+
+If the claim doesn't fit any of these, the change is making a fuzzy claim that can't be mechanically backed. **Sharpen the claim or escalate** — fuzzy claims should not gate merges.
+
+### 2. If no oracle exists for the claim, write the oracle first
+
+This is the most-skipped step and the highest leverage one. If the change claims a new property and no test / `rivet check` / proof obligation / fuzz harness / `nm` invocation currently fires red-or-green for that property:
+
+- **Write the oracle first.** Add the test that would currently fail. Add the `rivet check` rule. Write the Kani harness. Add the fuzz target.
+- **Land the oracle separately if possible** so its red state is visible before the change that's supposed to flip it green. This makes the gate's behavior observable.
+
+If you cannot write the oracle (the property isn't checkable with current tooling), **surface the gap clearly** in the PR description. Do not paper over it with prose review. Either the property is checkable or the change can't claim it.
+
+### 3. Attach a kill-criterion to the claim
+
+Per PulseEngine methodology, every claim should carry a falsifiable kill-criterion: "this claim would be wrong if X is observed." This is required for the philosophy to compose — without kill-criteria the falsification stance is empty.
+
+Examples:
+- "AlertDispatcher dedup is correct" → kill-criterion: "if Verus flags a duplicate-acceptance path."
+- "Cross-language LTO eliminated gale symbols" → kill-criterion: "if `nm zephyr.elf | grep gale_` returns non-zero."
+- "PR doesn't drop trace coverage" → kill-criterion: "if `rivet coverage` reports a new uncovered predicate."
+
+### 4. Gate the diff
+
+Only the diff that flips the oracle from red to green counts. Specifically:
+- If the oracle was already green before the change: the change must add a new oracle that goes red→green on this diff, or this change isn't actually verified.
+- If the oracle was red: the change should flip it green. If green wasn't reached, the change isn't ready.
+- If the oracle's behavior was unchanged: the change is doing something the oracle doesn't measure. Either expand the oracle or shrink the claim.
+
+### 5. Verify before reporting "done"
+
+Apply [`clean-room-verification`] to the claim "this change passed its oracle." An agent saying "I ran the test and it passed" is itself an unverified claim — actually re-run the oracle in a clean environment and read the output.
+
+## The rules baked in
+
+- **A "done" without a flipped mechanical oracle is unverified.** No exceptions for "small" changes.
+- **Soft oracles (LLM reading the spec back) don't count.** They cannot find what the spec didn't anticipate. From the `mythos-slop-hunt` and `spec-driven-development-is-half-the-loop` blog posts.
+- **Write the oracle first if it's missing.** If the property is worth claiming it's worth checking.
+- **Specification completeness is the bottleneck.** Per `formal-verification-ai-agents`, agent-written proofs are cheap now — the limiting factor is whether the spec covers what the change is actually doing.
+- **Kill-criteria are mandatory.** A claim without a falsifier is not a claim, it's a hope.
+
+## Anti-patterns
+
+- "Review looks good" as the gate. Review is input; oracle is the gate.
+- "Tests pass" without saying *which* test exercises the new property. If you can't name it, it doesn't exist.
+- Skipping the oracle write because "we already have lots of tests." The relevant question is whether *this property* is checked, not whether *anything* is.
+- Treating `rivet validate` green as proof the change is correct. `rivet validate` is one oracle of many; pick the one matching the claim type.
+
+## Where this composes
+
+`pulseengine-feature-loop` runs this skill per change inside the feature loop. `release-execution` expects every PR in the queue to have passed through this gate before merge. Verification of the oracle-passed claim flows to [`clean-room-verification`].

--- a/claude-tooling/plugins/pulseengine-claude/skills/pulseengine-feature-loop/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/pulseengine-feature-loop/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: pulseengine-feature-loop
+description: This skill should be used when doing a feature end-to-end on a PulseEngine project (rivet, spar, witness, sigil, meld, loom, synth, wohl, kiln) — including "implement a feature", "add a new requirement", "extend the architecture", "write a new pass", "ship a feature end-to-end", "do this properly with traceability", "model-driven implementation", or any feature work that should pass through the full AADL → WIT → typed traceability → oracle-gated code → MC/DC → attestation → verify loop. ALWAYS use this skill when the user authorizes feature work on a PulseEngine project and the work touches more than a single file.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# PulseEngine feature loop
+
+## When this fires
+
+End-to-end feature work on a PulseEngine project where the methodology actually composes: spar (AADL architecture) → rivet (typed traceability) → code (agent-written, oracle-gated) → witness (MC/DC on Wasm) → sigil (signed attestation) → smithy (clean-room verify). This is the "MBSE is mandatory infrastructure for AI-authored safety code" claim made concrete.
+
+Use this when the feature touches more than one layer of the stack. Single-file refactors don't need the full loop; reach for [`oracle-gate-a-change`] alone.
+
+## The compose loop (ordered steps, each producing a concrete artifact)
+
+### 1. Start in spar — model the architecture
+
+If the feature changes architecture (new component, new mode, new interaction, new resource sharing):
+- Edit / create the AADL model in spar's `.aadl` files.
+- Run the relevant spar analysis passes:
+  - EMV2 fault trees if it touches safety.
+  - ARINC 653 partitioning if it's an avionics-style isolation question.
+  - ASIL decomposition if it's automotive.
+  - Modal-filtered scheduling + piecewise-affine TSN arrival curves if it touches timing.
+- Confirm the analysis passes are green for the new model.
+- **Artifact:** updated `.aadl` files + spar analysis output.
+
+### 2. Generate WIT from spar
+
+WIT interfaces are *derived from AADL via spar*, never hand-written. From `wohl/spar-generates-wit.md`.
+- Run the spar → WIT generator.
+- The new WIT lands in the consumers (wohl, witness, etc.).
+- **Artifact:** updated `.wit` files. Their diff against main is a function of the AADL change, not a manual edit.
+
+### 3. Write typed requirements / decisions / tests in rivet
+
+For each new property the feature claims:
+- Add a requirement / decision / test artifact in the project's rivet directories.
+- Use the appropriate schema (STPA, ASPICE, IEC 61508, DO-178C, EN 50128, EU AI Act, or custom).
+- Link via rivet's typed predicates: `verifies`, `implements`, `traced-by`.
+- Run `rivet validate` and `rivet check` — both must be green.
+- **Artifact:** new YAML in `requirements/`, `decisions/`, `tests/`. `rivet coverage` should show the trace topology now covering the new property.
+
+### 4. Write the code, oracle-gated per change
+
+Per [`oracle-gate-a-change`]:
+- Identify the mechanical oracle for each property the code claims (rivet check / Kani / Verus / fuzz / witness gap / sigil verify / `nm` symbol check).
+- Write missing oracles first.
+- Land code that flips the oracle from red to green.
+- Each PR passes through `oracle-gate-a-change`.
+- **Artifact:** code diff + a now-green oracle traceable to the rivet requirement.
+
+### 5. Witness — MC/DC truth table on the Wasm artifact
+
+If the feature lands a new branch / decision / variant:
+- Run `witness` on the relevant Wasm component.
+- Inspect the **truth table** (not the coverage percentage) — confirm masking / unique-cause vectors exist for each new condition.
+- If gaps appear, witness-viz suggests test stubs — add them, rerun.
+- **Artifact:** truth table file under `witness-out/` (or similar) showing zero unresolved gap rows.
+
+### 6. Sigil — sign the attestation chain
+
+If the feature lands a new build artifact or a new build-stage:
+- Run sigil to sign the relevant outputs.
+- Confirm the verification chain end-to-end: detached verifier accepts the signed artifact.
+- **Artifact:** signed component manifest, verifiable detached.
+
+### 7. Clean-room verify the whole loop
+
+Per [`clean-room-verification`]:
+- Write the feature's claims as discrete falsifiable claims.
+- Spawn smithy (or equivalent subagent) cold — no inherited framing.
+- Reconcile.
+
+### 8. Land via release-execution
+
+When the feature is green end-to-end, ship it via [`release-execution`]. Include the falsification statement for the new behavior in the release notes.
+
+## What "MBSE is mandatory infrastructure" means here
+
+This loop is not optional ritual. It's the cheap version of safety-critical engineering — agent-minutes replace half-a-day-per-requirement, the model drives the build instead of sitting alongside it, and the alternative (untraceable AI-authored code) is unshippable in regulated domains.
+
+The loop's *cost* is now in tooling, not labor. Skipping a step skips the corresponding evidence; assessor confidence is the metric, not throughput.
+
+## Anti-patterns
+
+- Hand-writing WIT files. Spar generates them; if WIT changes, the AADL changed first.
+- Writing code before the rivet typed artifacts exist. The traceability must lead, not follow.
+- Trusting `witness` coverage percentages. Read the gap rows in the truth table. From `witness-the-truth-table-not-the-percentage` and `witness-wasm-mcdc`.
+- Skipping sigil "because internal." If the artifact ever leaves your machine — including to CI — the attestation chain is the gate that lets others trust what you built.
+- Inlining clean-room verification or oracle-gating instead of pointing at those skills. Duplication is the failure mode this whole stack is designed to avoid.
+- Calling the feature "done" before all eight steps have a green artifact.
+
+## Where this composes
+
+Sits at the top of the composition tree. Calls [`oracle-gate-a-change`] per change. Calls [`clean-room-verification`] for the verify step. Hands off to [`release-execution`] when green.

--- a/claude-tooling/plugins/pulseengine-claude/skills/release-execution/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/release-execution/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: release-execution
+description: This skill should be used when cutting, shipping, or finishing a release — including "ship it", "cut a release", "tag this", "release v0.X.Y", "take this to release", "work the PR queue to green", "finish the release tail", "publish", or any end-to-end release work that involves PRs, reviewers, merging, CI, tagging, GitHub Release, and crates.io publish. ALWAYS use this skill when the user authorizes autonomous release work or asks to "go as long as you can" on a release campaign.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# Release execution
+
+## When this fires
+
+End-to-end release machinery on a PulseEngine project (or any Rust project Ralf maintains). Triggers include: cutting a release tag, working a PR queue to green-and-merged, shipping a milestone, verifying a GitHub Release and crates.io publish landed, or fixing a release tail (post-merge cleanup, doc updates, version bumps).
+
+## Procedure
+
+Carry the whole sequence autonomously — that's the point. Stop only at the named forks below.
+
+### 1. Assemble the queue
+- Identify the set of PRs/branches that belong to this release.
+- Order them by dependency. Independent ones go in parallel; dependent ones serialize.
+- Open PRs that don't exist yet. Use branch names + PR titles per the project's convention (check the project memory for spar / synth / wohl style).
+
+### 2. Drive PRs to green
+- Dispatch reviewer subagents (multi-persona or specialized). Use `isolation: "worktree"` for parallelism without contention.
+- For each finding from a reviewer: fix in the PR, push, wait for CI, repeat. Apply [`clean-room-verification`] to non-trivial findings before claiming them resolved.
+- Watch CI status (`gh pr checks`, `gh run watch`). Re-run flaky checks; investigate genuine failures.
+- Rebase / merge main into the PR branch when needed.
+
+### 3. Merge
+- Merge each PR once green. Squash, rebase-and-merge, or merge-commit per project convention.
+- After each merge, kick the next dependent PR's CI if it needs to pick up the new main.
+
+### 4. Tag and release
+- Once the queue is empty and main is green, **PAUSE for fork**: confirm the new tag (`v0.X.Y`) and whether this is the right moment to cut, vs. holding for more. Use `AskUserQuestion` — this is a genuine decision boundary, not a routine step.
+- After confirmation: tag, push tag, watch the release workflow.
+
+### 5. Verify the release shipped
+- GitHub Release: artifacts present, notes correct.
+- crates.io: `cargo search <crate>` shows the new version.
+- Any downstream — Docker image, Bazel rules dep update, MCP server restart — kicked.
+- Apply [`clean-room-verification`] to the "release looks good" claim before reporting done.
+
+### 6. Write the falsification statement
+- Per PulseEngine methodology, every release should carry a falsifiable kill-criterion: "this release would be wrong if X is observed in the field." Add it to release notes or a follow-up issue.
+- The point is to make the claim measurable, not to draft prose. One sentence is fine.
+
+### 7. Release tail cleanup
+- Doc updates, version bumps in dependent repos, milestone close-out, follow-up issues opened for known-deferred items.
+- This is where most teams quit too early. Don't.
+
+## Forks where you stop and ask
+
+These are non-routine and consequential — `AskUserQuestion` here, don't decide silently:
+- **Cutting a new tag** (merge-all-and-tag vs. hold for more).
+- **Breaking-API or version-scheme changes** (semver bump direction, deprecations).
+- **Destructive git** (force-push to main, branch deletion of unmerged work, history rewrites).
+- **Putting RC / unproven code on a safety or signing path** (anything that affects wohl OTA verification, sigil attestation, synth-produced binaries on a cover target).
+- **Milestone scope choices** (does this PR belong in v0.X.Y or v0.X+1.0).
+
+Between these forks: keep moving. Single-letter prompts like "c" mean continue.
+
+## Anti-patterns
+
+- Waiting on green for an in-flight PR when the next work doesn't depend on it. Treat CI as async.
+- Asking for confirmation between routine steps (merge a green PR, rebase, re-run a flaky check). Don't.
+- Stopping at "tag pushed" without verifying the artifacts actually shipped.
+- Skipping the falsification statement because "the release is small." Small releases still need kill-criteria.
+- Inlining clean-room verification of findings instead of pointing at [`clean-room-verification`]. Duplicate procedure = duplicate maintenance.
+
+## Where this composes
+
+`pulseengine-feature-loop` ends here when the feature lands. `oracle-gate-a-change` is what each PR in the queue *passes through* on the way to merge.


### PR DESCRIPTION
## Summary

Publishes a Claude Code marketplace from this repository so the PulseEngine engineering methodology + procedural skills can be installed by anyone running Claude Code, with the same two-command flow as `anthropics/skills`.

```
/plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu
/plugin install pulseengine-claude@pulseengine-eu
```

### Layout

- `/.claude-plugin/marketplace.json` — manifest at repo root (must live here; that's where the Claude Code harness looks)
- `/claude-tooling/plugins/pulseengine-claude/` — plugin contents, kept under one subdirectory to isolate Claude tooling from the Zola site

### What the plugin ships

- **Reference memory** (`memory/pulseengine-philosophy.md`, `memory/pulseengine-toolchain.md`) — auto-injected at session start via the plugin's own SessionStart hook. The philosophy file captures the falsification methodology, defense-in-depth stance, MBSE-mandatory framing, variant pruning, and the three-patterns synthesis. The toolchain file is a directory of rivet/spar/witness/sigil/meld/loom/synth/smithy/wohl/kiln and what each does.

- **Four procedural skills**, conforming to the [agentskills.io spec](https://agentskills.io/specification) (kebab-case names matching parent dirs, descriptions under 1024 chars, bodies under 500 lines, metadata in the `metadata:` block):
  - `clean-room-verification` — the smithy ritual for validating findings before reporting
  - `release-execution` — end-to-end release machinery + the per-release falsification statement
  - `oracle-gate-a-change` — per-change procedure naming the *actual* PulseEngine oracle for each claim type (rivet check / spar pass / witness gap / sigil verify / Kani / Verus / fuzz / `nm` symbol check)
  - `pulseengine-feature-loop` — the full compose loop: spar (AADL) → WIT → rivet typed artifacts → oracle-gated code → witness MC/DC → sigil attestation → clean-room verify

### Why now

Memory + skills were previously copy-pasted across 11 of Ralf's per-project Claude Code memory stores. Consolidating + publishing as a plugin gives:

1. Single source of truth (this repo, versioned with the blog)
2. Bootstrap-portable across machines (`claude plugin install` instead of manual sync)
3. Onboarding path for collaborators that doesn't leak personal preferences (those live in a separate dotfiles repo)

### Impact on the website

None — zero files under `content/`, `sass/`, `templates/`, `static/`, `scripts/`, or `config.toml` touched. `zola build` and `zola check` should be unaffected.

## Test plan

- [ ] CI: `zola build` passes (no website content changed, expected to pass trivially)
- [ ] CI: any link-check / lint pass on the new markdown files (SKILL.md + READMEs)
- [ ] Manual: `jq -e . .claude-plugin/marketplace.json` returns valid (verified locally — green)
- [ ] Manual: plugin source path in marketplace.json resolves to a real directory containing `.claude-plugin/plugin.json` (verified locally — green)
- [ ] Manual: each `SKILL.md` passes agentskills.io frontmatter rules — kebab-case name matching parent dir, description 1-1024 chars, body ≤500 lines, no bare top-level `version:` field (all four verified locally — green)
- [ ] Post-merge: `/plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu` + `/plugin install pulseengine-claude@pulseengine-eu` in a real Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)