### PR TITLE
fix(ci): install gh CLI in blog-autopublish on self-hosted runner

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -73,6 +73,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # The smithy self-hosted runners (migrated in #51) don't ship the gh
+      # CLI — only GitHub-hosted images do — so every gh call below failed
+      # with "command not found" (exit 127), breaking this cron daily.
+      # Drop a pinned gh binary into a user-writable dir, the same no-sudo
+      # pattern used for Zola via taiki-e/install-action. The durable fix is
+      # baking gh into the runner image; this is the repo-level remedy.
+      - name: Install gh CLI
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            echo "gh already on PATH: $(gh --version | head -1)"
+            exit 0
+          fi
+          GH_VERSION=2.62.0
+          cd "$RUNNER_TEMP"
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o gh.tar.gz
+          tar -xzf gh.tar.gz
+          echo "${RUNNER_TEMP}/gh_${GH_VERSION}_linux_amd64/bin" >> "$GITHUB_PATH"
+          "${RUNNER_TEMP}/gh_${GH_VERSION}_linux_amd64/bin/gh" --version
+
       - name: Ensure labels exist
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}


### PR DESCRIPTION
## Problem
The daily **Blog auto-publish** cron has failed every run since #51 migrated it to the smithy self-hosted runners — those images don't ship the `gh` CLI, so the first `gh` call (`gh label create`) died with `command not found` (exit 127) and every downstream `gh` step cascaded. The "open failure issue" step *also* uses `gh`, so the job couldn't even file its own failure alerts — which is why this rotted unnoticed for ~10 days.

## Fix
Add a no-sudo `gh` install step (pinned binary into `$RUNNER_TEMP`, added to `$GITHUB_PATH`) before the first `gh` use — the same user-writable pattern #51 uses for Zola via `taiki-e/install-action`. Idempotent: skips the download if `gh` is ever baked into the runner image (the durable fix).

## Verification
- Workflow YAML validates.
- gh 2.62.0 linux_amd64 asset URL resolves.
- Uses only static values (no untrusted `github.event.*` input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)