### PR TITLE
fix(blog): safe-by-default publishing + unpublish cerisier post

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,23 +43,36 @@ title = "Post Title"
 description = "One-line summary — shown on listing cards and in <meta> tags."
 date = 2026-03-05
 draft = true
+ready = true   # opt in to auto-publishing on `date`; omit to keep it a pure draft
 [taxonomies]
 tags = ["deep-dive", "meld"]
 +++
 ```
 
-- `date` controls sort order on the blog listing
+- `date` controls sort order on the blog listing, and (for `ready` posts) the day the cron publishes
 - `description` is required — it appears on the blog index cards
 - `tags` render as accent badges and generate tag pages at `/tags/<name>/`
-- `draft = true` excludes the post from production builds — remove it when ready to publish
+- `draft = true` excludes the post from production builds
+- `ready = true` is the **explicit opt-in** that lets the daily cron auto-publish the post once `date` arrives
 
-### Draft workflow
+### Publishing model — three states (safe by default)
 
-Posts start as drafts and get published when ready:
+A post is in exactly one of these states. The key property: **a draft never auto-publishes unless you explicitly opt in** with `ready = true`. Forgetting the flag can't ship a post early.
 
-1. Write with `draft = true` in frontmatter
-2. Preview locally: `zola serve --drafts`
-3. Publish: remove `draft = true`, commit, push — deploy is automatic
+| State | Frontmatter | What the cron does |
+|---|---|---|
+| **Draft** | `draft = true` (no `ready`, or `ready = false`) | Nothing — stays unpublished indefinitely. Preview with `zola serve --drafts`. |
+| **Ready / scheduled** | `draft = true` + `ready = true` + `date` | On/after `date`, flips `draft = false`, commits, deploys. Before `date` it shows as *scheduled*. |
+| **Published** | `draft = false` | Live on the site. |
+
+`hold = true` is still honored as a hard belt-and-suspenders override (forces *held* even if `ready = true`), but it's no longer needed — absence of `ready` is the safe default.
+
+**To publish a post:**
+
+1. Write it with `draft = true` (and no `ready`) — it's a private draft.
+2. Preview locally: `zola serve --drafts`.
+3. When you genuinely want it to go live, add `ready = true` and set `date` to the intended publish day. The daily cron publishes it on/after that date.
+4. To publish immediately by hand instead, just set `draft = false`, commit, push — deploy is automatic.
 
 ### What you get automatically
 

--- a/content/blog/2026-05-11-attestation-chains-trustmee-to-cerisier.md
+++ b/content/blog/2026-05-11-attestation-chains-trustmee-to-cerisier.md
@@ -2,7 +2,7 @@
 title = "Reasoning about attestation chains: from TrustMee to Cerisier"
 description = "Two academic papers — TrustMee verifies single attestations in Wasm, Cerisier reasons about their composition in a capability machine — and what is still missing to close sigil's PQ-migration trust story. An internal milestone, not a finished result."
 date = 2026-05-11
-draft = false
+draft = true
 [taxonomies]
 tags = ["verification", "attestation", "sigil", "deep-dive"]
 authors = ["Ralf Anton Beier"]

--- a/scripts/blog-autopublish.py
+++ b/scripts/blog-autopublish.py
@@ -5,9 +5,14 @@ Three modes:
 
   --mode scan
       Print a JSON inventory to stdout: {today, ready, scheduled, held}.
-      A draft is "ready" when date <= today and hold is not true.
-      A draft is "scheduled" when date > today (and hold is not true).
-      A draft is "held" when hold = true (regardless of date).
+      Safe-by-default: a draft auto-publishes ONLY when it explicitly opts
+      in with `ready = true` AND its `date` has arrived. Concretely:
+      A draft is "ready"     when ready = true, hold is not true, date <= today.
+      A draft is "scheduled" when ready = true, hold is not true, date > today.
+      A draft is "held"      otherwise — no ready flag, ready = false, an
+                             explicit hold = true, or ready but missing a date.
+      The absence of `ready` is the default, so forgetting it can never
+      publish a post early; you have to opt in.
 
   --mode flip --file PATH
       Atomically replace the first `draft = true` line in PATH with
@@ -18,9 +23,9 @@ Three modes:
       bot marker) suitable for posting on the pinned status issue.
 
 The frontmatter parser is intentionally regex-based, not full-TOML — it
-only reads the four fields that drive the cron (date, draft, hold, title)
-and does not need to interpret arrays or tables. This avoids a dependency
-on `tomllib` and keeps the script readable.
+only reads the five fields that drive the cron (date, draft, ready, hold,
+title) and does not need to interpret arrays or tables. This avoids a
+dependency on `tomllib` and keeps the script readable.
 """
 
 import argparse
@@ -35,6 +40,7 @@ BLOG_DIR = pathlib.Path("content/blog")
 FRONTMATTER_RE = re.compile(r"\A\+\+\+\n(.*?)\n\+\+\+", re.S)
 DATE_RE = re.compile(r"^date\s*=\s*(\d{4}-\d{2}-\d{2})\s*$", re.M)
 DRAFT_RE = re.compile(r"^draft\s*=\s*(true|false)\s*$", re.M)
+READY_RE = re.compile(r"^ready\s*=\s*(true|false)\s*$", re.M)
 HOLD_RE = re.compile(r"^hold\s*=\s*(true|false)\s*$", re.M)
 TITLE_RE = re.compile(r'^title\s*=\s*"([^"]*)"\s*$', re.M)
 DRAFT_TRUE_LINE = re.compile(r"^draft\s*=\s*true\s*$", re.M)
@@ -49,6 +55,7 @@ def parse_post(path: pathlib.Path) -> dict | None:
     fm = fm_match.group(1)
     date_m = DATE_RE.search(fm)
     draft_m = DRAFT_RE.search(fm)
+    ready_m = READY_RE.search(fm)
     hold_m = HOLD_RE.search(fm)
     title_m = TITLE_RE.search(fm)
     return {
@@ -57,6 +64,7 @@ def parse_post(path: pathlib.Path) -> dict | None:
         "title": title_m.group(1) if title_m else path.stem,
         "date": date_m.group(1) if date_m else None,
         "draft": bool(draft_m and draft_m.group(1) == "true"),
+        "ready": bool(ready_m and ready_m.group(1) == "true"),
         "hold": bool(hold_m and hold_m.group(1) == "true"),
     }
 
@@ -71,10 +79,16 @@ def scan(today: str) -> dict:
             continue
         if record["draft"]:
             drafts.append(record)
-    held = [p for p in drafts if p["hold"]]
-    active = [p for p in drafts if not p["hold"]]
-    ready = [p for p in active if p["date"] and p["date"] <= today]
-    scheduled = [p for p in active if p["date"] and p["date"] > today]
+    # Safe-by-default partition. A draft auto-publishes ONLY if it explicitly
+    # opts in with `ready = true`, is not explicitly held, and has a date.
+    # Everything else stays held — so a missing `ready` flag can never ship a
+    # post early. Each draft lands in exactly one bucket.
+    ready, scheduled, held = [], [], []
+    for p in drafts:
+        if p["ready"] and not p["hold"] and p["date"]:
+            (ready if p["date"] <= today else scheduled).append(p)
+        else:
+            held.append(p)
     return {
         "today": today,
         "ready": ready,


### PR DESCRIPTION
## Problem
The cron auto-published any draft once its `date` passed unless you remembered `hold = true`. "Ready" was the implicit default, so a post could ship before it was meant to — which is exactly what happened to the 2026-05-11 attestation-chains post.

## Fix — invert the default
A draft now auto-publishes **only** when it carries an explicit `ready = true` **and** its `date` has arrived. Forgetting the flag can never publish early.

| State | Frontmatter | Cron |
|---|---|---|
| Draft | `draft = true`, no `ready` | never publishes |
| Ready | `draft = true` + `ready = true` + `date` | flips to published on/after `date` |
| Published | `draft = false` | live |

`hold = true` is still honored as a hard override.

## Changes
- `blog-autopublish.py`: add `ready` field, repartition `scan()` (safe-by-default).
- `CONTRIBUTING.md`: document the three-state model.
- **Unpublish** `2026-05-11-attestation-chains-trustmee-to-cerisier` → `draft = true` (it was published before intended; now a held draft).

## Verification
- `scan`: a `ready=true` past-dated draft lands in `ready`; cerisier + everything without `ready` lands in `held` (nothing auto-publishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)