### PR TITLE
feat(skills): V-model traceability gate + tool-friction reporting

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pulseengine-claude",
-      "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus five procedural skills (clean-room verification, release execution, oracle-gating, the full feature loop, and the standardized release-artifact pipeline).",
+      "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus six procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, and tool-friction reporting).",
       "version": "0.1.0",
       "source": "./claude-tooling/plugins/pulseengine-claude",
       "category": "development"

--- a/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
+++ b/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseengine-claude",
   "version": "0.1.0",
-  "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus five procedural skills (clean-room verification, release execution, oracle-gating, the full feature loop, and the standardized release-artifact pipeline).",
+  "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus six procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, and tool-friction reporting).",
   "author": {
     "name": "PulseEngine",
     "url": "https://pulseengine.eu"

--- a/claude-tooling/plugins/pulseengine-claude/README.md
+++ b/claude-tooling/plugins/pulseengine-claude/README.md
@@ -10,10 +10,11 @@ PulseEngine engineering methodology as installable Claude Code tooling.
 
 - **Skills** (`skills/`) — loaded on trigger only:
   - `clean-room-verification/` — the smithy ritual: findings → falsifiable claims → cold subagent → confirm/refute/cannot-verify → reconcile.
-  - `release-execution/` — end-to-end release machinery: PRs → reviewers → fixes → merge → CI → tag → GitHub Release + crates.io verify. Includes the per-release falsification statement.
+  - `release-execution/` — end-to-end release machinery: PRs → reviewers → fixes → merge → CI → **V-model traceability completeness gate** → tag → GitHub Release + crates.io verify. The gate blocks the tag until every `approved`/`implemented` artifact has a closed V (req → arch → impl) and green right-side evidence (tests, witness MC/DC, attestation). Includes the per-release falsification statement.
   - `oracle-gate-a-change/` — per-change procedure: name the mechanical oracle (rivet check / spar pass / witness gap / sigil verify / Kani / Verus / fuzz / nm symbol check), write it first if it doesn't exist, only the diff that flips it counts.
   - `pulseengine-feature-loop/` — end-to-end compose loop: spar (AADL) → WIT → rivet typed artifacts → code (oracle-gated) → witness MC/DC → sigil attestation → clean-room verify.
   - `release-artifact-pipeline/` — the standardized release.yml: signed `SHA256SUMS.txt`, CycloneDX SBOM, SLSA attestation, cosign keyless OIDC. Canonical implementation in `pulseengine/synth/.github/workflows/release.yml`.
+  - `report-tool-friction/` — standing dogfooding practice: when a tool errors, misbehaves, or forces a workaround during real work, file it as a `tool-friction` issue in the tool's own repo — automatically, as you hit it. Referenced by the feature loop and release execution.
 
 ## Install
 
@@ -30,4 +31,4 @@ The marketplace manifest sits at the **repo root** of pulseengine.eu (under `.cl
 
 Partition rule: **belief / disposition / vocabulary stays in memory; multi-step procedure becomes a skill**. The memory files describe always-on framing for every session. The skills load only when their trigger fires — proposing a change, cutting a release, auditing findings, doing a feature end-to-end.
 
-The four skills compose: `pulseengine-feature-loop` orchestrates a feature; `oracle-gate-a-change` runs per change inside the loop; `clean-room-verification` is the verify step both feature-loop and oracle-gate point at; `release-execution` ships the result.
+The skills compose: `pulseengine-feature-loop` orchestrates a feature; `oracle-gate-a-change` runs per change inside the loop; `clean-room-verification` is the verify step both feature-loop and oracle-gate point at; `release-execution` ships the result and gates the tag on V-model completeness; `report-tool-friction` runs as a standing practice across all of them, turning every workaround into a tracked issue.

--- a/claude-tooling/plugins/pulseengine-claude/skills/pulseengine-feature-loop/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/pulseengine-feature-loop/SKILL.md
@@ -14,6 +14,10 @@ End-to-end feature work on a PulseEngine project where the methodology actually 
 
 Use this when the feature touches more than one layer of the stack. Single-file refactors don't need the full loop; reach for [`oracle-gate-a-change`] alone.
 
+## Standing practice across every step
+
+Friction is data. At any step below, if a tool errors, produces wrong output, lacks a capability you needed, or forces a workaround, file it via [`report-tool-friction`] in that tool's repo *as you hit it* — then continue. A workaround you don't report is friction the next feature re-hits. This is woven through the whole loop, not a phase of it.
+
 ## The compose loop (ordered steps, each producing a concrete artifact)
 
 ### 1. Start in spar — model the architecture
@@ -77,7 +81,7 @@ Per [`clean-room-verification`]:
 
 ### 8. Land via release-execution
 
-When the feature is green end-to-end, ship it via [`release-execution`]. Include the falsification statement for the new behavior in the release notes.
+When the feature is green end-to-end, ship it via [`release-execution`]. Its **traceability completeness gate** is where this loop gets audited at release time: every `approved`/`implemented` artifact must have the full V closed — requirement → architecture → implementation, and up the right side (tests via `verifies`, witness MC/DC with zero gap rows, sigil attestation). If a step here was skipped, that gate is where it surfaces as a blocker. Include the falsification statement for the new behavior in the release notes.
 
 ## What "MBSE is mandatory infrastructure" means here
 
@@ -92,8 +96,9 @@ The loop's *cost* is now in tooling, not labor. Skipping a step skips the corres
 - Trusting `witness` coverage percentages. Read the gap rows in the truth table. From `witness-the-truth-table-not-the-percentage` and `witness-wasm-mcdc`.
 - Skipping sigil "because internal." If the artifact ever leaves your machine — including to CI — the attestation chain is the gate that lets others trust what you built.
 - Inlining clean-room verification or oracle-gating instead of pointing at those skills. Duplication is the failure mode this whole stack is designed to avoid.
+- Working around a tool silently. If you hand-edit generated WIT, `|| true` a failing check, or do a step outside the tool "for now," that's friction — file it via [`report-tool-friction`]. Unreported workarounds are how the tools stop improving.
 - Calling the feature "done" before all eight steps have a green artifact.
 
 ## Where this composes
 
-Sits at the top of the composition tree. Calls [`oracle-gate-a-change`] per change. Calls [`clean-room-verification`] for the verify step. Hands off to [`release-execution`] when green.
+Sits at the top of the composition tree. Calls [`oracle-gate-a-change`] per change. Calls [`clean-room-verification`] for the verify step. [`report-tool-friction`] runs as a standing practice across every step. Hands off to [`release-execution`] when green — whose traceability completeness gate audits the artifacts this loop produced.

--- a/claude-tooling/plugins/pulseengine-claude/skills/release-execution/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/release-execution/SKILL.md
@@ -31,21 +31,34 @@ Carry the whole sequence autonomously — that's the point. Stop only at the nam
 - Merge each PR once green. Squash, rebase-and-merge, or merge-commit per project convention.
 - After each merge, kick the next dependent PR's CI if it needs to pick up the new main.
 
-### 4. Tag and release
-- Once the queue is empty and main is green, **PAUSE for fork**: confirm the new tag (`v0.X.Y`) and whether this is the right moment to cut, vs. holding for more. Use `AskUserQuestion` — this is a genuine decision boundary, not a routine step.
+### 4. Traceability completeness gate (blocking — before tag)
+The release does not get tagged until the V-model is closed for everything it claims to ship. This is the "what did we approve, what did we implement, is it all there and tested" check, made mechanical.
+
+- Run rivet over the project: `rivet validate`, `rivet check`, and `rivet coverage`. All green is the entry condition.
+- For **every artifact whose status is `approved` or `implemented`**, confirm the full chain exists and is traced — left side down, right side up:
+  - feature → requirement → architecture (spar/AADL) → design decision → implementation, and
+  - implementation → verification evidence → up the right side of the V: test(s) linked via `verifies`, witness MC/DC truth-table with zero unresolved gap rows for any new decision, sigil attestation for any new build artifact.
+- The gate is **mechanical, not narrative**: an `approved`/`implemented` artifact with no `verifies` link, an untested branch (witness gap row), a requirement with no architecture above it, or an implementation with no requirement tracing to it is a **release blocker** — not a follow-up. Fix the trace or the test, or explicitly demote the artifact's status, before tagging.
+- The rivet **compliance report** (the signed bundle the release-artifact pipeline produces, surfaced on pulseengine.eu) is the human-readable view of this gate. The report passing is necessary; the per-artifact check above is what makes it sufficient.
+- If a *tool* can't express or verify part of the chain, that's friction → [`report-tool-friction`], then carry on with the gate.
+
+This composes [`pulseengine-feature-loop`] (which produces the artifacts this gate audits) and [`clean-room-verification`] (verify the "the V is closed" claim cold, don't infer it from a green dashboard).
+
+### 5. Tag and release
+- Once the queue is empty, main is green, **and the traceability gate (step 4) passes**, **PAUSE for fork**: confirm the new tag (`v0.X.Y`) and whether this is the right moment to cut, vs. holding for more. Use `AskUserQuestion` — this is a genuine decision boundary, not a routine step.
 - After confirmation: tag, push tag, watch the release workflow.
 
-### 5. Verify the release shipped
+### 6. Verify the release shipped
 - GitHub Release: artifacts present, notes correct.
 - crates.io: `cargo search <crate>` shows the new version.
 - Any downstream — Docker image, Bazel rules dep update, MCP server restart — kicked.
 - Apply [`clean-room-verification`] to the "release looks good" claim before reporting done.
 
-### 6. Write the falsification statement
+### 7. Write the falsification statement
 - Per PulseEngine methodology, every release should carry a falsifiable kill-criterion: "this release would be wrong if X is observed in the field." Add it to release notes or a follow-up issue.
 - The point is to make the claim measurable, not to draft prose. One sentence is fine.
 
-### 7. Release tail cleanup
+### 8. Release tail cleanup
 - Doc updates, version bumps in dependent repos, milestone close-out, follow-up issues opened for known-deferred items.
 - This is where most teams quit too early. Don't.
 
@@ -57,6 +70,7 @@ These are non-routine and consequential — `AskUserQuestion` here, don't decide
 - **Destructive git** (force-push to main, branch deletion of unmerged work, history rewrites).
 - **Putting RC / unproven code on a safety or signing path** (anything that affects wohl OTA verification, sigil attestation, synth-produced binaries on a cover target).
 - **Milestone scope choices** (does this PR belong in v0.X.Y or v0.X+1.0).
+- **Demoting an artifact's status to pass the traceability gate** (step 4). Marking an `approved`/`implemented` artifact down so the gate goes green is a scope decision, not a mechanical fix — confirm it, don't do it silently.
 
 Between these forks: keep moving. Single-letter prompts like "c" mean continue.
 
@@ -66,8 +80,10 @@ Between these forks: keep moving. Single-letter prompts like "c" mean continue.
 - Asking for confirmation between routine steps (merge a green PR, rebase, re-run a flaky check). Don't.
 - Stopping at "tag pushed" without verifying the artifacts actually shipped.
 - Skipping the falsification statement because "the release is small." Small releases still need kill-criteria.
+- **Tagging with an open traceability gap recorded as a "follow-up."** The gate (step 4) is blocking by design — an untested `implemented` artifact or a missing `verifies` link is a reason not to tag, not a TODO to ship around.
+- **Carrying tool friction in your head through the release tail.** When a tool fails or forces a workaround during the release, file it via [`report-tool-friction`] as you hit it.
 - Inlining clean-room verification of findings instead of pointing at [`clean-room-verification`]. Duplicate procedure = duplicate maintenance.
 
 ## Where this composes
 
-`pulseengine-feature-loop` ends here when the feature lands. `oracle-gate-a-change` is what each PR in the queue *passes through* on the way to merge.
+`pulseengine-feature-loop` ends here when the feature lands. `oracle-gate-a-change` is what each PR in the queue *passes through* on the way to merge. The traceability completeness gate (step 4) audits the artifacts the feature loop produced and leans on [`clean-room-verification`]. [`report-tool-friction`] fires throughout — any tool that fails or forces a workaround during the release becomes a tracked issue.

--- a/claude-tooling/plugins/pulseengine-claude/skills/report-tool-friction/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/report-tool-friction/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: report-tool-friction
+description: This skill should be used whenever a PulseEngine tool (rivet, spar, witness, sigil, smithy, wohl, kiln, synth, loom, meld, thrum, temper) produces friction during real work — it errors, crashes, produces wrong or surprising output, is missing a capability you needed, has confusing/undocumented behavior, or forced you into a workaround. ALWAYS use this skill the moment you notice yourself working *around* a tool instead of *with* it, or saying "this should just work but doesn't." The friction is the signal; capturing it as an issue in the tool's own repo is the action. Fires inside [`pulseengine-feature-loop`] and [`release-execution`] and any standalone tool use.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# Report tool friction
+
+## When this fires
+
+You are using a PulseEngine tool to *get real work done* — not testing the tool, just using it — and it gets in your way. Concretely, any of:
+
+- It errors, panics, or crashes on input that should be valid.
+- It produces wrong, surprising, or unexplained output.
+- It's missing a capability the task needed, so you reached for something else.
+- Its behavior was confusing or undocumented enough that you had to guess.
+- You wrote a workaround — a manual step, a shim, a `|| true`, a hand-edit of generated output, a "do it outside the tool for now."
+
+The moment you notice the workaround is the trigger. **A workaround you don't report is friction the next person re-hits.** Dogfooding only improves the tools if the friction becomes a tracked, fixable artifact.
+
+This is a standing practice woven through all tool use, not a phase. It fires *as you work*, not at a checkpoint.
+
+## Procedure
+
+### 1. Identify the right repo
+File in the **tool's own repo** (`pulseengine/<tool>`), not in the consuming project. If rivet misbehaves while you're shipping spar, the issue goes to `pulseengine/rivet`. If you can't tell which tool owns the friction, file in the one you invoked and cross-link.
+
+### 2. Search for a duplicate first
+`gh issue list --repo pulseengine/<tool> --search "<key phrase>" --state all`. If an open issue already covers it, add a comment with your fresh repro instead of opening a new one. Label-search for the friction label too.
+
+### 3. File it automatically, then mention it
+Open the issue without pausing the work, then note it in your response to the user (link + one line). Don't batch, don't wait for permission — friction is cheap to capture and expensive to forget. The body, kept short:
+
+```
+**What I was trying to do:** <the real task, one or two sentences>
+**Tool + version:** <tool> <version / commit / "source @ <sha>">
+**What happened:** <the error / wrong output / missing capability>
+**Repro:** <the exact command(s) or input, minimal>
+**Workaround used (if any):** <what I did instead, so the next person isn't blocked>
+**Impact:** <blocked / slowed / cosmetic — be honest>
+```
+
+Use a consistent label so these are filterable and reviewable as a batch later:
+
+```sh
+gh issue create --repo pulseengine/<tool> \
+  --title "friction: <short description>" \
+  --label tool-friction \
+  --body-file <body>
+# create the label once per repo if missing:
+gh label create tool-friction --color fbbf24 --description "Friction hit while using the tool for real work (dogfooding signal)" --force
+```
+
+### 4. Keep moving
+Filing the issue is not a stop point. Note the workaround in the issue, apply it, and continue the task. The issue is the durable record; the work doesn't wait on the fix.
+
+## What makes a good friction issue
+
+- **The real task is in it.** "rivet check failed" is noise; "rivet check rejected a valid `verifies` link between a test and a sec-constraint while shipping spar v0.9" is signal — it tells the maintainer what use-case broke.
+- **Minimal repro.** The smallest command/input that reproduces. If you can't minimize quickly, paste what you have and say so.
+- **Honest impact.** Cosmetic friction and blocking friction need different triage. Don't inflate; don't omit.
+- **The workaround is recorded.** Even a bad workaround is information — it shows what the tool failed to make easy.
+
+## Anti-patterns
+
+- **Silent workarounds.** The single failure mode this skill exists to kill. If you worked around a tool and didn't file, the friction is now invisible.
+- **Batching everything to the end of the session.** You forget the specifics; repros decay. File when you hit it.
+- **Filing in the consuming repo instead of the tool repo.** The fix lives where the tool lives.
+- **Filing without searching for a dupe.** Noise erodes the signal of the `tool-friction` label.
+- **Turning every preference into friction.** Friction is "the tool failed at what it's for," not "I'd have designed it differently." Disagreements about design are a different conversation.
+- **Pausing the real work to perfect the issue.** Capture, link, continue. A terse-but-real issue beats a polished one you never filed.
+
+## Where this composes
+
+- [`pulseengine-feature-loop`] — friction surfaces at every step (spar passes, rivet validate, witness gaps, sigil verify); report it inline as you go.
+- [`release-execution`] — the release-tail is where deferred friction tends to accumulate; the traceability completeness gate often surfaces tool gaps. File them rather than carrying them in your head.
+- [`oracle-gate-a-change`] — when the oracle itself is the tool that's broken (the check won't run, or runs wrong), that's friction in the verifier — report it; a broken oracle is worse than a missing one.


### PR DESCRIPTION
Adds a blocking **V-model traceability completeness gate** to `release-execution` (rivet coverage/check must show every approved/implemented artifact has a closed V — req→arch→impl — with green right-side evidence: tests, witness MC/DC, attestation — before tagging) and a new **`report-tool-friction`** micro-skill (file tool friction as a `tool-friction` issue in the tool's repo, as you hit it). Cross-linked into the feature loop. Registers the sixth skill in plugin.json/marketplace.json/README.

Part of splitting the old docs-site branch into focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)