### PR TITLE
fix(ux): a11y — contrast, reduced-motion, ARIA toggle, 44px hit-target

### DIFF
--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -54,7 +54,7 @@
   --border-subtle:  #d9d1bd;
   --text:           #1a2235;        // deep navy — high AA on cream
   --text-dim:       #44516a;
-  --text-faint:     #6b7280;
+  --text-faint:     #586273;        // AA 4.5:1 on cream (was #6b7280, 4.4:1) — sunlight-legibility fix
   --accent:         #3a5fce;        // darkened accent for AA on cream
   --accent-hover:   #2747ad;
   --accent-glow:    rgba(58, 95, 206, 0.10);

--- a/static/cube.js
+++ b/static/cube.js
@@ -155,6 +155,15 @@
       });
     }
 
+    if (reduceMotion) {
+      // Honor prefers-reduced-motion: snap to target rotation, no zoom/rotate animations.
+      cube.style.transition = 'none';
+      scene.style.transition = 'none';
+      apply();
+      if (detailPanel) detailPanel.classList.add('cube-detail--open');
+      return;
+    }
+
     // Animate: rotate the cube
     cube.style.transition = 'transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94)';
     apply();
@@ -177,12 +186,24 @@
     // Hide detail
     if (detailPanel) detailPanel.classList.remove('cube-detail--open');
 
-    // Zoom back in
-    scene.style.transform = 'scale(1)';
-
     // Return to isometric
     rotX = -30;
     rotY = 35;
+
+    if (reduceMotion) {
+      // Honor prefers-reduced-motion: snap back, no zoom/rotate animations.
+      cube.style.transition = 'none';
+      scene.style.transition = 'none';
+      scene.style.transform = 'scale(1)';
+      apply();
+      autoSpin = true;
+      snaps.forEach(function (b) { b.classList.remove('face-btn--active'); });
+      return;
+    }
+
+    // Zoom back in
+    scene.style.transform = 'scale(1)';
+
     cube.style.transition = 'transform 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94)';
     apply();
 

--- a/static/theme-toggle.js
+++ b/static/theme-toggle.js
@@ -27,9 +27,24 @@
     return 'dark';
   }
 
+  // Sync ARIA state to the rendered theme. aria-pressed="true" when light
+  // is active (the non-default state); aria-label describes what the click
+  // would *do*, which is what screen readers announce.
+  function syncAria() {
+    var theme = currentTheme();
+    btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false');
+    btn.setAttribute(
+      'aria-label',
+      theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'
+    );
+  }
+
+  syncAria();
+
   btn.addEventListener('click', function () {
     var next = currentTheme() === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', next);
     try { localStorage.setItem(STORAGE_KEY, next); } catch (e) { /* private mode */ }
+    syncAria();
   });
 })();

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -538,6 +538,8 @@
     .cube__face--bottom { transform: rotateX(-90deg) translateZ(135px); }
     .cube-wrap { padding: 2.5rem 0 2rem; }
     .face-component__name { font-size: 1.1rem; }
+    /* Hit-target fix — iOS guideline is 44×44 minimum for touchable controls. */
+    .face-btn { min-height: 44px; padding: 0.6rem 0.9rem; font-size: 0.875rem; }
   }
 
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Ports the **accessibility fixes** from the stale #44 onto current `main`:
- light-mode `--text-faint` → `#586273` (clears AA 4.5:1 on cream)
- `cube.js` honors `prefers-reduced-motion` (snap, no zoom/rotate) on open + close
- theme-toggle syncs `aria-pressed` + `aria-label` to the rendered theme
- 44×44 min hit-target for `.face-btn` on mobile

**Supersedes #44.** #44's `projects.html` content edits are intentionally dropped — they removed witness from the Verify face and reworded to "three proof paths," which contradicts #61 (added scry, kept witness) and the in-flight witness MC/DC work. Only the a11y improvements are carried forward. JS syntax-checked; `zola build` green; witness + scry confirmed intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)