### PR TITLE
fix(reports): MC/DC links -> verdict-evidence/suite-index.html

### DIFF
--- a/templates/reports.html
+++ b/templates/reports.html
@@ -17,7 +17,7 @@
     {% set report_index = load_data(path="static/reports/index.json") %}
 
     {# Each project carries a `kind`: "compliance" (rivet HTML bundle, served at #}
-    {# .../compliance/) or "mcdc" (witness evidence, served at .../mcdc/suite-index.html). #}
+    {# .../compliance/) or "mcdc" (witness evidence, served at .../mcdc/verdict-evidence/suite-index.html). #}
     {# Overview shows the latest 3 minor versions; the rest are one click away.   #}
 
     {% if report_index.projects %}
@@ -57,11 +57,11 @@
               <div class="glass-card__desc">Latest: v{{ project.latest }} &middot; {{ project.versions | length }} version{{ project.versions | length | pluralize }}</div>
               <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.75rem; align-items: center;">
                 {% for version in shown %}
-                  <a href="{{ get_url(path='reports/' ~ name ~ '/' ~ version ~ '/mcdc/suite-index.html') }}"
+                  <a href="{{ get_url(path='reports/' ~ name ~ '/' ~ version ~ '/mcdc/verdict-evidence/suite-index.html') }}"
                      class="badge {% if version == project.latest %}badge--accent{% else %}badge--cyan{% endif %}" style="text-decoration: none;">v{{ version }}</a>
                 {% endfor %}
                 {% if project.versions | length > shown | length %}
-                  <a href="{{ get_url(path='reports/' ~ name ~ '/latest/mcdc/suite-index.html') }}" style="font-size: 0.8rem; color: #8b90a0;">all {{ project.versions | length }} versions</a>
+                  <a href="{{ get_url(path='reports/' ~ name ~ '/latest/mcdc/verdict-evidence/suite-index.html') }}" style="font-size: 0.8rem; color: #8b90a0;">all {{ project.versions | length }} versions</a>
                 {% endif %}
               </div>
             </div>

--- a/tools/fetch-reports/src/main.rs
+++ b/tools/fetch-reports/src/main.rs
@@ -34,7 +34,8 @@ fn default_kind() -> String {
 /// Map a report kind to its (extract subdirectory, entry-point HTML filename).
 fn kind_layout(kind: &str) -> (&'static str, &'static str) {
     match kind {
-        "mcdc" => ("mcdc", "suite-index.html"),
+        // The witness evidence bundle nests its viewer under verdict-evidence/.
+        "mcdc" => ("mcdc", "verdict-evidence/suite-index.html"),
         _ => ("compliance", "index.html"),
     }
 }


### PR DESCRIPTION
Verified against the real witness-v0.30.0 evidence bundle: viewer is at ./verdict-evidence/suite-index.html, not the root. Corrects the mcdc entry path in fetch-reports + reports page (follow-up to #71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)