### PR TITLE
feat(plugin): cross-session memory, situational awareness, repo taxonomy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "pulseengine-claude",
-      "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus six procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, and tool-friction reporting).",
+      "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain + repo-taxonomy memory, memory-persistence hooks (situational awareness + working-context across sessions/compaction), plus seven procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, tool-friction reporting, and session-learning capture).",
       "version": "0.1.0",
       "source": "./claude-tooling/plugins/pulseengine-claude",
       "category": "development"

--- a/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
+++ b/claude-tooling/plugins/pulseengine-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pulseengine-claude",
   "version": "0.1.0",
-  "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain reference memory, plus six procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, and tool-friction reporting).",
+  "description": "PulseEngine methodology as installable Claude Code tooling — philosophy + toolchain + repo-taxonomy memory, memory-persistence hooks (situational awareness at session start, working-context checkpoints across sessions/compaction), plus seven procedural skills (clean-room verification, release execution with a V-model traceability gate, oracle-gating, the full feature loop, the standardized release-artifact pipeline, tool-friction reporting, and session-learning capture).",
   "author": {
     "name": "PulseEngine",
     "url": "https://pulseengine.eu"

--- a/claude-tooling/plugins/pulseengine-claude/README.md
+++ b/claude-tooling/plugins/pulseengine-claude/README.md
@@ -7,6 +7,11 @@ PulseEngine engineering methodology as installable Claude Code tooling.
 - **Reference memory** (`memory/`) — auto-injected at session start via the plugin's SessionStart hook:
   - `pulseengine-philosophy.md` — verification + traceability + attestation, falsification methodology, defense-in-depth, MBSE-mandatory, variant pruning, the three-patterns synthesis.
   - `pulseengine-toolchain.md` — directory of the tools (rivet, spar, witness, sigil, meld, loom, synth, smithy, wohl) and what each is for.
+  - `pulseengine-repo-taxonomy.md` — the two kinds of PulseEngine repo and which lens to use: **toolchain development** (the tool builds itself — inward; oracle-gate the tool, dogfood the chain) vs **toolchain consumer/application** (compose the full feature loop outward). Picks the right methodology per repo.
+
+- **Memory-persistence hooks** (`hooks/`) — keep work from starting cold:
+  - **SessionStart** injects the methodology memory *and* situational awareness (git branch / status / recent commits, a best-effort repo-category guess, and the working-context resumed from last time).
+  - **PreCompact + SessionEnd** save a `.claude/pulseengine/working-context.md` checkpoint (git state + an agent-maintained notes section, kept out of git via `.git/info/exclude`) so context survives compaction and carries to the next session.
 
 - **Skills** (`skills/`) — loaded on trigger only:
   - `clean-room-verification/` — the smithy ritual: findings → falsifiable claims → cold subagent → confirm/refute/cannot-verify → reconcile.
@@ -15,20 +20,30 @@ PulseEngine engineering methodology as installable Claude Code tooling.
   - `pulseengine-feature-loop/` — end-to-end compose loop: spar (AADL) → WIT → rivet typed artifacts → code (oracle-gated) → witness MC/DC → sigil attestation → clean-room verify.
   - `release-artifact-pipeline/` — the standardized release.yml: signed `SHA256SUMS.txt`, CycloneDX SBOM, SLSA attestation, cosign keyless OIDC. Canonical implementation in `pulseengine/synth/.github/workflows/release.yml`.
   - `report-tool-friction/` — standing dogfooding practice: when a tool errors, misbehaves, or forces a workaround during real work, file it as a `tool-friction` issue in the tool's own repo — automatically, as you hit it. Referenced by the feature loop and release execution.
+  - `capture-session-learnings/` — continuous learning: distill a session's resume-state into the working-context checkpoint, and promote durable patterns/decisions into memory or a new skill. The agent-authored counterpart to the memory-persistence hooks; where recurring `report-tool-friction` workarounds get promoted so they stop recurring.
 
 ## Install
 
-The marketplace manifest sits at the **repo root** of pulseengine.eu (under `.claude-plugin/marketplace.json`) so the install flow mirrors `anthropics/skills` exactly:
+The marketplace manifest lives at `.claude-plugin/marketplace.json` in the repo root of pulseengine.eu.
+
+`/plugin marketplace add` takes **one source argument** — a full git URL or the `owner/repo` shorthand. It does **not** take a separate name argument (the marketplace name, `pulseengine-eu`, is read from `marketplace.json`). Run these inside Claude Code:
 
 ```
-/plugin marketplace add pulseengine-eu github.com/pulseengine/pulseengine.eu
+# Add the marketplace — full HTTPS URL (most reliable):
+/plugin marketplace add https://github.com/pulseengine/pulseengine.eu
+#   …or SSH:        /plugin marketplace add git@github.com:pulseengine/pulseengine.eu.git
+#   …or shorthand:  /plugin marketplace add pulseengine/pulseengine.eu
+
+# Install the plugin — <plugin-name>@<marketplace-name>, both from marketplace.json:
 /plugin install pulseengine-claude@pulseengine-eu
 ```
 
-(Run the first command inside Claude Code, or `claude plugin marketplace add ...` from the shell. Adjust GitHub coordinates to wherever you actually publish the repo.)
+Equivalent from the shell: `claude plugin marketplace add https://github.com/pulseengine/pulseengine.eu`. A bare `github.com/owner/repo` (no scheme) and the old two-argument `<name> <coords>` form are **not** accepted by current Claude Code.
 
 ## Design
 
 Partition rule: **belief / disposition / vocabulary stays in memory; multi-step procedure becomes a skill**. The memory files describe always-on framing for every session. The skills load only when their trigger fires — proposing a change, cutting a release, auditing findings, doing a feature end-to-end.
 
 The skills compose: `pulseengine-feature-loop` orchestrates a feature; `oracle-gate-a-change` runs per change inside the loop; `clean-room-verification` is the verify step both feature-loop and oracle-gate point at; `release-execution` ships the result and gates the tag on V-model completeness; `report-tool-friction` runs as a standing practice across all of them, turning every workaround into a tracked issue.
+
+The hooks and `capture-session-learnings` close the loop *across* sessions: the memory-persistence hooks save/restore the mechanical checkpoint, and the skill writes the narrative half they can't — promoting recurring patterns (including friction workarounds) into durable memory or new skills. The `pulseengine-repo-taxonomy` memory ensures each session applies the right lens for the repo it's in (tool-development vs consumer/application).

--- a/claude-tooling/plugins/pulseengine-claude/hooks/hooks.json
+++ b/claude-tooling/plugins/pulseengine-claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject PulseEngine philosophy + toolchain reference memory at session start so the methodology is always in context for any PulseEngine project work.",
+  "description": "Always-on PulseEngine context: at session start inject the methodology memory + situational awareness (git state, repo category, resumed working context); persist a working-context checkpoint on session end and before compaction so work resumes instead of starting cold.",
   "hooks": {
     "SessionStart": [
       {
@@ -8,6 +8,33 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/inject-pulseengine-memory.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/inject-situational-awareness.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/save-working-context.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/save-working-context.sh",
+            "timeout": 10
           }
         ]
       }

--- a/claude-tooling/plugins/pulseengine-claude/hooks/inject-situational-awareness.sh
+++ b/claude-tooling/plugins/pulseengine-claude/hooks/inject-situational-awareness.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SessionStart hook (pulseengine-claude): inject cheap, mechanical situational
+# awareness so a session starts oriented instead of spending its first turns
+# re-deriving git state — branch, working-tree status, recent commits, a
+# best-effort repo-category guess (see pulseengine-repo-taxonomy memory), and
+# the working-context snapshot saved by the previous session, if any.
+#
+# Deliberately git-only (no network / no gh) so it stays fast and never blocks
+# session start. Fails open: any error yields no injected context.
+
+emit() {
+  # Wrap stdin as SessionStart additionalContext; no-op if jq is unavailable.
+  if command -v jq >/dev/null 2>&1; then
+    jq -Rs '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: .}}'
+  fi
+}
+
+# Not a git repo → nothing useful to say.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo unknown)")"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+
+# Best-effort category hint. The taxonomy memory is the source of truth; this
+# is only a nudge. Keep the tool list roughly in sync with the toolchain memory.
+tools=" rivet spar witness sigil meld loom synth kiln gale scry smithy mcp temper rules_lean rules_rocq_rust rules_verus rules_wasm_component rules_moonbit "
+consumers=" wohl relay example-kvs "
+if printf '%s' "$tools" | grep -q " $repo "; then
+  category="toolchain development (tool builds itself — inward lens; oracle-gate the tool, dogfood the chain)"
+elif printf '%s' "$consumers" | grep -q " $repo "; then
+  category="toolchain consumer / application (outward lens — compose the full feature loop)"
+else
+  category="unclassified — infer role from the repo (see pulseengine-repo-taxonomy)"
+fi
+
+dirty="$(git status --porcelain 2>/dev/null | grep -vc '^$' || echo 0)"
+upstream="$(git rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null || true)"
+
+{
+  echo "## PulseEngine situational awareness (injected at session start)"
+  echo
+  echo "- **Repo:** \`${repo}\` — ${category}"
+  echo "- **Branch:** \`${branch}\`$( [ -n "$upstream" ] && echo " (behind/ahead vs upstream: ${upstream})" )"
+  echo "- **Uncommitted files:** ${dirty}"
+  echo
+  echo "Recent commits:"
+  git log --oneline -5 2>/dev/null | sed 's/^/    /' || true
+  echo
+
+  wc_file=".claude/pulseengine/working-context.md"
+  if [ -f "$wc_file" ]; then
+    echo "### Resumed working context (from the previous session)"
+    echo
+    cat "$wc_file"
+    echo
+    echo "_(Update this as work progresses; the capture-session-learnings skill maintains it.)_"
+  fi
+} | emit

--- a/claude-tooling/plugins/pulseengine-claude/hooks/save-working-context.sh
+++ b/claude-tooling/plugins/pulseengine-claude/hooks/save-working-context.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SessionEnd + PreCompact hook (pulseengine-claude): persist a working-context
+# checkpoint to .claude/pulseengine/working-context.md so the next session (or
+# the post-compaction window) can resume instead of starting cold.
+#
+# The file has two parts:
+#   - "## State (auto)"          — regenerated mechanically on every save.
+#   - "## Session notes"         — agent-maintained narrative; PRESERVED across
+#                                  saves (the capture-session-learnings skill
+#                                  writes this; the hook never clobbers it).
+#
+# The checkpoint is session state, not source: the hook keeps it out of git via
+# .git/info/exclude (local, never committed). Fails open.
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+dir=".claude/pulseengine"
+file="${dir}/working-context.md"
+mkdir -p "$dir" 2>/dev/null || exit 0
+
+# Keep the checkpoint local-only — append to the repo's private exclude once.
+exclude=".git/info/exclude"
+if [ -f "$exclude" ] && ! grep -qxF "$dir/" "$exclude" 2>/dev/null; then
+  printf '%s/\n' "$dir" >> "$exclude" 2>/dev/null || true
+fi
+
+# Preserve any existing agent-authored notes section.
+notes=""
+if [ -f "$file" ]; then
+  notes="$(awk '/^## Session notes/{f=1} f{print}' "$file")"
+fi
+
+repo="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo unknown)")"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+stamp="$(date -u '+%Y-%m-%d %H:%M UTC' 2>/dev/null || echo unknown)"
+
+{
+  echo "# Working context — ${repo}"
+  echo
+  echo "## State (auto — regenerated each save)"
+  echo "- Saved: ${stamp}"
+  echo "- Branch: \`${branch}\`"
+  echo "- Uncommitted files: $(git status --porcelain 2>/dev/null | grep -vc '^$' || echo 0)"
+  echo "- Recent commits:"
+  git log --oneline -5 2>/dev/null | sed 's/^/    /' || true
+  echo
+  if [ -n "$notes" ]; then
+    printf '%s\n' "$notes"
+  else
+    echo "## Session notes (agent-maintained — survives auto-saves)"
+    echo
+    echo "_Not yet captured. Run the capture-session-learnings skill to record what"
+    echo "this session is doing, key decisions, and what's next._"
+  fi
+} > "$file" 2>/dev/null || true
+
+exit 0

--- a/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-repo-taxonomy.md
+++ b/claude-tooling/plugins/pulseengine-claude/memory/pulseengine-repo-taxonomy.md
@@ -1,0 +1,64 @@
+# PulseEngine repo taxonomy — which kind of work am I in?
+
+PulseEngine work splits into two categories, and the methodology applies
+differently to each. **Identify which one the current repo is before
+choosing how to work** (the situational-awareness hook prints a best-effort
+guess at session start; confirm it from the repo itself).
+
+## 1. Toolchain development — building the tools
+
+Repos whose product *is* a verification/build tool. The methodology turns
+*inward*: the tool must prove its own correctness.
+
+Examples: `rivet`, `spar`, `witness`, `sigil`, `meld`, `loom`, `synth`,
+`kiln`, `gale`, `scry`, the Bazel rule sets (`rules_lean`,
+`rules_rocq_rust`, `rules_verus`, `rules_wasm_component`, `rules_moonbit`),
+plus infrastructure (`smithy` runners, `mcp` framework, `temper`).
+
+Focus here:
+- **Oracle-gate the tool's own behavior** — the mechanical oracle is the
+  tool's own check/pass/proof (e.g. synth's transcode-equivalence, witness's
+  truth-table, loom's optimization-preserves-semantics).
+- **The release-artifact pipeline** is part of the product — signed
+  `SHA256SUMS`, SBOM, SLSA, cosign (see [`release-artifact-pipeline`]).
+- The tool **dogfoods** the chain on itself: rivet emits its own compliance
+  report; witness runs MC/DC on its own Wasm; sigil signs its own releases.
+- `pulseengine-feature-loop` applies to the *tool's* features, but the
+  "architecture" step is often the tool's own design, not an AADL model.
+
+## 2. Toolchain consumers — building verified products
+
+Repos that *use* the toolchain to build a real, verified application. The
+methodology turns *outward*: compose the tools end-to-end.
+
+Examples: `wohl` (home supervision), `relay` (flight software),
+`example-kvs`, and other applications (this list grows — classify by role,
+not by memorising names).
+
+Focus here:
+- **`pulseengine-feature-loop` is the primary mode**: spar (AADL) → WIT →
+  rivet typed traceability → oracle-gated code → witness MC/DC → sigil
+  attestation → clean-room verify. The architecture step is a real model.
+- The value is *composition* — proving the application correct *through*
+  the tools, with traceability from requirement to shipped Wasm.
+- The release gate is the V-model completeness check (see
+  [`release-execution`]): every approved/implemented artifact traced + tested.
+
+## Dual-role and edge cases
+
+Some repos are both: `scry` is a tool **and** dogfoods witness MC/DC;
+`rivet` is a tool **and** produces a consumer-style compliance report. When
+a repo is dual, apply the inward lens to its own code and the outward lens
+to what it produces. Repos like `automator`, `glsp-mcp`, `studio-mcp`,
+`bazel-file-ops-component` are tooling/support — treat as category 1.
+
+If a repo is **not** a PulseEngine repo at all (a fork, an upstream
+dependency, a scratch repo), the methodology framing still informs *how* to
+work, but don't force the toolchain onto it.
+
+## Why this matters
+
+Reaching for `pulseengine-feature-loop` in a tool-development repo (where
+there's no AADL model to start from) wastes effort; skipping it in a
+consumer repo (where composition *is* the point) drops the evidence chain.
+Pick the lens that matches the repo's role.

--- a/claude-tooling/plugins/pulseengine-claude/skills/capture-session-learnings/SKILL.md
+++ b/claude-tooling/plugins/pulseengine-claude/skills/capture-session-learnings/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: capture-session-learnings
+description: This skill should be used to distill durable knowledge out of a working session before it is lost — at the end of substantive work, before a likely compaction, when the user says "remember this" / "capture what we learned" / "update the working context", or whenever a pattern, decision, or gotcha recurs often enough to be worth keeping. It turns ephemeral session work into (1) an updated working-context checkpoint for resuming next time and (2) durable memory or a new/updated skill when the learning generalizes. The continuous-learning counterpart to the memory-persistence hooks shipped with this plugin.
+metadata:
+  author: pulseengine.eu
+  version: "0.1.0"
+---
+
+# Capture session learnings
+
+Sessions accumulate three things worth keeping that otherwise evaporate at
+compaction or session end: **where the work stands** (resume state), **what
+was decided and why** (rationale), and **patterns that will recur** (durable
+knowledge). The plugin's hooks persist a *mechanical* checkpoint (git state);
+this skill captures the *narrative* and promotes the generalizable parts.
+
+## When this fires
+
+- Wrapping up a substantive chunk of work, or before a likely compaction.
+- The user says "remember this", "capture what we learned", "update the
+  working context", or similar.
+- A pattern, workaround, or decision has recurred enough to be worth keeping.
+
+## Three tiers — route each learning to the right place
+
+### 1. Working context (resume state) — almost always
+Update the **`## Session notes`** section of
+`.claude/pulseengine/working-context.md` (the hooks own the `## State` section
+above it — leave that alone). Keep it tight:
+- What this session is doing (one or two sentences).
+- Key decisions made and *why* (so the next session doesn't relitigate them).
+- What's in flight / next step / open question.
+- Any landmark commits, PRs, branches.
+
+This is per-repo, local-only (git-excluded), and is re-injected at the next
+session start. It is for *this thread of work*, not permanent knowledge.
+
+### 2. Durable memory — when it outlives this work
+If the learning is true beyond this session — a project constraint, a
+non-obvious fact about the codebase, a confirmed preference, an external
+reference — write it to the **file-based memory store**, one fact per file with
+frontmatter, and add the one-line pointer to `MEMORY.md`. Prefer updating an
+existing memory over creating a duplicate. Don't save what the repo already
+records (code structure, git history, things in CLAUDE.md).
+
+### 3. A skill — when it's a repeatable procedure
+If the learning is a *multi-step procedure* others will reuse, it belongs in a
+skill, not memory (belief/vocabulary → memory; procedure → skill). Propose a
+new skill under this plugin's `skills/`, or extend an existing one, following
+the existing SKILL.md shape (frontmatter trigger + ordered steps + anti-patterns
++ cross-links). Don't inline a procedure into memory.
+
+## How to decide the tier
+
+> Is it just "where we are"? → working context.
+> Will it be true next month regardless of this task? → memory.
+> Is it a procedure someone will follow again? → skill.
+
+A single session can produce all three. Capture the working context every
+time; promote to memory/skill only when the learning genuinely generalizes —
+over-capturing durable artifacts is as harmful as losing them (noise drowns
+signal).
+
+## Anti-patterns
+
+- **Letting a session end without updating the working context** when work is
+  unfinished — the next session starts cold and re-derives everything.
+- **Dumping raw transcript into memory.** Memory is distilled facts, not logs.
+- **Promoting one-off task state to durable memory** — it becomes stale noise.
+  If it only matters to this thread, it stays in working context.
+- **Writing a procedure as a memory file** instead of a skill (or vice-versa).
+- Capturing the *mechanical* git state by hand — the hooks already do that;
+  spend the effort on rationale and patterns a script can't infer.
+
+## Where this composes
+
+- The plugin's **memory-persistence hooks** save/restore the mechanical
+  checkpoint; this skill writes the narrative half they can't.
+- [`report-tool-friction`] captures friction *as it happens*; this skill is
+  where a recurring friction or its workaround gets promoted into durable
+  memory or a skill so it stops recurring.
+- [`pulseengine-feature-loop`] / [`release-execution`] — capture the decisions
+  and gotchas these produce so the next pass through the loop is faster.


### PR DESCRIPTION
Ports the genuinely useful patterns from [affaan-m/ECC](https://github.com/affaan-m/ECC) into `pulseengine-claude` — adapted to our file-based memory + methodology, not copied.

## Memory persistence (hooks)
- **SessionStart** now also injects **situational awareness**: git branch/status, recent commits, a best-effort repo-category guess, and the **working-context resumed from the previous session**. (No network/gh — fast, fails open.)
- **PreCompact + SessionEnd** save `.claude/pulseengine/working-context.md` (mechanical git state + an agent-maintained `## Session notes` section), kept out of git via `.git/info/exclude`, so work survives compaction and carries across sessions.

## Continuous learning
- New **`capture-session-learnings`** skill — the agent-authored counterpart to the hooks: writes the working-context narrative and promotes durable patterns/decisions/recurring friction into memory or a new skill (three-tier routing). Composes with `report-tool-friction`.

## Rethink — repo taxonomy
- New **`pulseengine-repo-taxonomy`** memory: **toolchain-development** repos (rivet, spar, witness, synth, rules_*, … — inward lens) vs **consumer/application** repos (wohl, relay, … — outward lens, compose the full feature loop). The situational-awareness hook hints the category so each session uses the right methodology.

## README fix
Corrects the install instructions — `/plugin marketplace add` takes a **single** source arg (full URL or `owner/repo`), not the old two-argument `<name> <coords>` form that current Claude Code rejects.

Verified: hook scripts syntax-checked + run (valid SessionStart JSON; working-context save preserves agent notes and stays git-excluded); all JSON manifests valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)